### PR TITLE
chore(naming): align tfstate backend + deploy SP with org convention

### DIFF
--- a/config/scripts/bootstrap-azure.sh
+++ b/config/scripts/bootstrap-azure.sh
@@ -36,9 +36,9 @@ set -euo pipefail
 
 # ── Config (override via env) ────────────────────────────────────────────────
 SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-}"
-SP_NAME="${SP_NAME:-hov-deploy-sp}"
-TF_RG="${TF_RG:-rg-houseofveritas-tfstate}"
-TF_STORAGE="${TF_STORAGE:-sthoveritastfstate}"
+SP_NAME="${SP_NAME:-hov-shared-deploy-sp}"
+TF_RG="${TF_RG:-hov-shared-tfstate-rg}"
+TF_STORAGE="${TF_STORAGE:-hovsharedtfstatesa}"
 TF_CONTAINER="${TF_CONTAINER:-tfstate}"
 TF_LOCATION="${TF_LOCATION:-southafricanorth}"
 TF_STATE_KEY="${TF_STATE_KEY:-production.terraform.tfstate}"

--- a/docs/02-architecture/03-infrastructure.md
+++ b/docs/02-architecture/03-infrastructure.md
@@ -7,8 +7,8 @@ Subscription: 22f9eb18-6553-4b7d-9451-47d0195085fe
 Region: South Africa North
 
 Resource Groups
-├── rg-houseofveritas-tfstate        (Terraform state backend)
-│   └── sthoveritastfstate           Storage Account (LRS)
+├── hov-shared-tfstate-rg           (Terraform state backend)
+│   └── hovsharedtfstatesa           Storage Account (LRS)
 │       └── tfstate                  Blob Container
 │
 └── nl-prod-hov-rg-san               (Production workload)

--- a/docs/03-deployment/01-deployment-guide.md
+++ b/docs/03-deployment/01-deployment-guide.md
@@ -92,8 +92,8 @@ See `.env.local` for the full list of environment variables and secrets.
 Create the storage account for remote Terraform state.
 
 ```powershell
-$RESOURCE_GROUP = "rg-houseofveritas-tfstate"
-$STORAGE_ACCOUNT = "sthoveritastfstate"
+$RESOURCE_GROUP = "hov-shared-tfstate-rg"
+$STORAGE_ACCOUNT = "hovsharedtfstatesa"
 $CONTAINER = "tfstate"
 $LOCATION = "southafricanorth"
 
@@ -134,8 +134,8 @@ az storage account blob-service-properties update `
 File: `terraform/environments/production/backend.hcl`
 
 ```hcl
-resource_group_name  = "rg-houseofveritas-tfstate"
-storage_account_name = "sthoveritastfstate"
+resource_group_name  = "hov-shared-tfstate-rg"
+storage_account_name = "hovsharedtfstatesa"
 container_name       = "tfstate"
 key                  = "production.terraform.tfstate"
 ```
@@ -707,7 +707,7 @@ az container restart --resource-group nl-prod-hov-rg-san --name prod-baserow
 
 ```powershell
 az storage blob lease break `
-  --account-name sthoveritastfstate `
+  --account-name hovsharedtfstatesa `
   --container-name tfstate `
   --blob-name production.terraform.tfstate
 ```

--- a/docs/03-deployment/04-rollback-procedure.md
+++ b/docs/03-deployment/04-rollback-procedure.md
@@ -94,8 +94,8 @@ Terraform state is stored in Azure Blob Storage with versioning enabled (`terraf
 ### Restore Previous State
 
 ```powershell
-$RESOURCE_GROUP = "rg-houseofveritas-tfstate"
-$STORAGE_ACCOUNT = "sthoveritastfstate"
+$RESOURCE_GROUP = "hov-shared-tfstate-rg"
+$STORAGE_ACCOUNT = "hovsharedtfstatesa"
 $CONTAINER = "tfstate"
 $BLOB = "production.terraform.tfstate"
 

--- a/docs/03-deployment/06-mvp-launch-checklist.md
+++ b/docs/03-deployment/06-mvp-launch-checklist.md
@@ -27,7 +27,7 @@ All four should succeed cleanly. Fix anything red before promoting to CI.
 - [ ] Subscription chosen, owner has Contributor + User Access Administrator.
 - [ ] Service principal created (`az ad sp create-for-rbac --sdk-auth`) — JSON output goes into `AZURE_CREDENTIALS` secret.
 - [ ] Resource group `nl-prod-hov-rg-san` exists in `southafricanorth`.
-- [ ] Terraform state backend created: storage account `sthoveritastfstate`, container `tfstate` (one-time bootstrap).
+- [ ] Terraform state backend created: resource group `hov-shared-tfstate-rg`, storage account `hovsharedtfstatesa`, container `tfstate` (one-time via `config/scripts/bootstrap-azure.sh`).
 - [ ] Custom domain in DNS: `nexamesh.ai` (or `houseofv.com`) with the App Gateway public IP.
 
 ## 4. GitHub Actions secrets
@@ -35,8 +35,8 @@ All four should succeed cleanly. Fix anything red before promoting to CI.
 | Secret | Purpose |
 | --- | --- |
 | `AZURE_CREDENTIALS` | SP JSON for `azure/login@v2` |
-| `TF_STATE_RESOURCE_GROUP` | `rg-houseofveritas-tfstate` |
-| `TF_STATE_STORAGE_ACCOUNT` | `sthoveritastfstate` |
+| `TF_STATE_RESOURCE_GROUP` | `hov-shared-tfstate-rg` |
+| `TF_STATE_STORAGE_ACCOUNT` | `hovsharedtfstatesa` |
 | `TF_STATE_CONTAINER` | `tfstate` |
 | `TF_STATE_KEY` | `production.terraform.tfstate` |
 | `DB_ADMIN_PASSWORD` | PostgreSQL admin password |

--- a/terraform/environments/production/backend.hcl
+++ b/terraform/environments/production/backend.hcl
@@ -1,7 +1,7 @@
 # Backend configuration for Terraform state
 # Use this file with: terraform init -backend-config="backend.hcl"
 
-resource_group_name  = "rg-houseofveritas-tfstate"
-storage_account_name = "sthoveritastfstate"
+resource_group_name  = "hov-shared-tfstate-rg"
+storage_account_name = "hovsharedtfstatesa"
 container_name       = "tfstate"
 key                  = "production.terraform.tfstate"


### PR DESCRIPTION
## Why

Convention across the org is `{prefix}-{env|global|shared}-{component}-{type}` (e.g. `mys-shared-acs` in `mys-global-shared-rg`, `pvc-prod-actionsrunner-rg-san`). HoV's tfstate-backend names predated this convention.

Pushing this rename **before** the bootstrap script provisions, so we don't have to migrate state across renamed accounts later.

## Renames

| Old | New |
|---|---|
| `rg-houseofveritas-tfstate` | `hov-shared-tfstate-rg` |
| `sthoveritastfstate` | `hovsharedtfstatesa` (no hyphens — Azure storage account constraint; 18 chars) |
| `hov-deploy-sp` | `hov-shared-deploy-sp` |

## Files touched

- `config/scripts/bootstrap-azure.sh` — defaults
- `terraform/environments/production/backend.hcl` — used by local `terraform init -backend-config=backend.hcl`. Workflows pass `TF_STATE_*` secrets via `-backend-config=` flags independently, so this file is consistency-only at CI time.
- `docs/02-architecture/03-infrastructure.md`
- `docs/03-deployment/01-deployment-guide.md`
- `docs/03-deployment/04-rollback-procedure.md`
- `docs/03-deployment/06-mvp-launch-checklist.md`

`docs/05-project/04-changelog.md` left alone — it's a historical record of an earlier rename and shouldn't be rewritten.

## Test plan

- [x] `grep` confirms no remaining `rg-houseofveritas-tfstate` / `sthoveritastfstate` / `hov-deploy-sp` references outside `worktrees/` and the changelog.
- [ ] After merge, run `./config/scripts/bootstrap-azure.sh` from a workstation with `az login` against subscription `bb4e3882-...`. Confirm the SP, RG, storage account, and container come up with the new names.
- [ ] Confirm the `TF_STATE_*` and `AZURE_CREDENTIALS` GitHub secrets get rewritten by the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)