### PR TITLE
fix(bootstrap): MSYS path-mangling + drop unneeded UAA grant

### DIFF
--- a/config/scripts/bootstrap-azure.sh
+++ b/config/scripts/bootstrap-azure.sh
@@ -3,9 +3,13 @@
 # bootstrap-azure.sh — one-shot Azure + GitHub Actions bootstrap for HoV.
 #
 # Creates:
-#   - Service principal (Contributor + User Access Administrator on the
-#     chosen subscription) — User Access Admin is needed because the
-#     Terraform Key Vault module assigns roles.
+#   - Service principal (Contributor on the chosen subscription, plus
+#     Storage Blob Data Contributor on the tfstate storage account so
+#     terraform can read/write state via Azure AD auth).
+#     The Key Vault module uses access_policy resources, not role
+#     assignments, so User Access Administrator is intentionally not
+#     granted — this avoids ABAC-condition AuthorizationFailed errors
+#     in tenants that restrict role-assignment elevation.
 #   - Terraform state backend: resource group, storage account, container.
 #
 # Sets the following GitHub Actions repo secrets via the gh CLI:
@@ -33,6 +37,13 @@
 #     assignments for the new SP).
 
 set -euo pipefail
+
+# Stop Git Bash / MSYS2 from rewriting Azure resource scopes like
+# "/subscriptions/<guid>" into Windows paths ("C:/Program Files/Git/...").
+# Without this every `az role assignment create` and `az ... --scopes` call
+# fails with MissingSubscription on Windows.
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
 
 # ── Config (override via env) ────────────────────────────────────────────────
 SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-}"
@@ -79,12 +90,6 @@ SP_JSON="$(az ad sp create-for-rbac \
   --scopes "/subscriptions/$SUBSCRIPTION_ID" \
   --json-auth)"
 SP_APPID="$(echo "$SP_JSON" | jq -r .clientId)"
-
-echo "      Granting 'User Access Administrator' (Key Vault role assignments)..."
-az role assignment create \
-  --assignee "$SP_APPID" \
-  --role "User Access Administrator" \
-  --scope "/subscriptions/$SUBSCRIPTION_ID" >/dev/null
 
 # ── 2. Terraform state backend ───────────────────────────────────────────────
 echo
@@ -162,7 +167,6 @@ cat <<EOF
        (PFX cert — or change terraform/modules/gateway to use an
         Azure-managed cert if the domain is already in your tenant)
    - DOCUSEAL_URL, BASEROW_URL                  (after first deploy)
-   - Self-hosted runner [self-hosted, azure-vnet-ghost] must be online
    - 'production' environment in the GitHub UI must approve the run
 
  DB_ADMIN_PASSWORD (saved only as a GitHub secret — copy now if you


### PR DESCRIPTION
## Two bugs the first real run surfaced

### 1. MSYS path-mangling on Windows

Git Bash / MSYS2 silently rewrites `--scopes /subscriptions/<guid>` into `C:/Program Files/Git/subscriptions/<guid>` on the way to `az`. Every Azure CLI call that takes a resource ID failed with:

```
ERROR: (MissingSubscription) The request did not have a subscription
or a valid tenant level resource provider.
```

Fix: `export MSYS_NO_PATHCONV=1` and `export MSYS2_ARG_CONV_EXCL='*'` at the top of the script. Standard Git Bash workaround for Azure CLI on Windows. Harmless on Linux/macOS.

### 2. Dropped the "User Access Administrator" grant

The script was granting UAA on the subscription on the assumption that the Terraform Key Vault module assigns roles. **It doesn't** — `terraform/modules/security/main.tf` uses `azurerm_key_vault_access_policy` (legacy access policies), not `azurerm_role_assignment`. Contributor on the subscription is sufficient.

In tenants with ABAC conditions that block Owners from creating role-elevation assignments (correct security posture), the UAA step was failing with:

```
ERROR: (AuthorizationFailed) ABAC condition that is not fulfilled to
perform action 'Microsoft.Authorization/roleAssignments/write'
```

Removed the step. Updated the script's docstring to explain the role split: SP gets **Contributor on subscription** + **Storage Blob Data Contributor on the tfstate storage account** for terraform-state RW via Azure AD auth. That's the minimum needed for the current set of terraform modules.

### Bonus

Dropped the now-stale `Self-hosted runner [self-hosted, azure-vnet-ghost] must be online` line from the post-run TODO list — PR #50 migrated all terraform workflows to `ubuntu-latest`.

## Confirmed working

Ran the fixed script end-to-end against subscription `bb4e3882-...`:

```
Service principal : hov-shared-deploy-sp (clientId=663a7d2a-...)
TF state          : hovsharedtfstatesa / tfstate (rg=hov-shared-tfstate-rg)
Secrets set       : AZURE_CREDENTIALS, TF_STATE_*, DB_ADMIN_PASSWORD
```

If anyone re-runs this from the same workstation, it'll be a no-op patch (`az ad sp create-for-rbac` finds the existing app and patches it; `az group create` is idempotent; storage account create errors out idempotently when reusing a name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)