### PR TITLE
ci: skip Infrastructure Verification for Dependabot PRs

### DIFF
--- a/.github/workflows/deployment-checklist.yml
+++ b/.github/workflows/deployment-checklist.yml
@@ -29,6 +29,9 @@ jobs:
   # ============================================
   deployment-checklist:
     name: "Infrastructure Verification"
+    # Dependabot PRs run without repo secrets, so fromJSON(secrets.AZURE_CREDENTIALS)
+    # fails at template-parse time. Skip the infra job for them — Build/Test/E2E still run.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:


### PR DESCRIPTION
## Summary
- Adds \`if: github.actor != 'dependabot[bot]'\` to the Infrastructure Verification job.
- Dependabot can't read repo secrets, so \`fromJSON(secrets.AZURE_CREDENTIALS)\` was erroring at template-parse time (lines 61, 68).
- Unblocks PR #55 and any future Dependabot PRs.

## Test plan
- [x] PR #55 should re-run cleanly after this merges — Build/Test/E2E will still gate the merge.