### PR TITLE
chore: update repo refs after neuralliquid transfer

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,5 @@
-# actionlint config - allow custom self-hosted runner labels
-# Used by: terraform-apply, terraform-destroy, terraform-plan, deploy (deploy-infrastructure)
+# actionlint config
+# Self-hosted runner labels removed 2026-05-14: all workflows use ubuntu-latest
+# after transfer to neuralliquid (see docs/03-deployment/07-self-hosted-runner-setup.md).
 self-hosted-runner:
-  labels:
-    - self-hosted
-    - azure-vnet-ghost
+  labels: []

--- a/config/scripts/bootstrap-azure.sh
+++ b/config/scripts/bootstrap-azure.sh
@@ -53,7 +53,7 @@ TF_STORAGE="${TF_STORAGE:-hovsharedtfstatesa}"
 TF_CONTAINER="${TF_CONTAINER:-tfstate}"
 TF_LOCATION="${TF_LOCATION:-southafricanorth}"
 TF_STATE_KEY="${TF_STATE_KEY:-production.terraform.tfstate}"
-REPO="${REPO:-JustAGhosT/house-of-veritas}"
+REPO="${REPO:-neuralliquid/house-of-veritas}"
 
 # ── Sanity checks ────────────────────────────────────────────────────────────
 need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }; }

--- a/docs/03-deployment/07-self-hosted-runner-setup.md
+++ b/docs/03-deployment/07-self-hosted-runner-setup.md
@@ -1,6 +1,12 @@
-# Self-Hosted Runner Setup (JustAGhosT Repos)
+# Self-Hosted Runner Setup (Historical)
 
-HouseOfVeritas runs on the **JustAGhosT** account but uses a self-hosted runner hosted in **phoenixvc** Azure infrastructure. This avoids Key Vault and Storage 403 errors that occur when using GitHub-hosted runners (`ubuntu-latest`).
+> **Status: Historical — no longer in use as of 2026-05-14.**
+> After the transfer to `neuralliquid/house-of-veritas`, all workflows run on `ubuntu-latest`.
+> The `azure-vnet-ghost` runner was deregistered and the runner subnet allowlisting on
+> Key Vault / Storage is being kept for now (re-evaluate when next touched).
+> This page is retained for archaeology only.
+
+This describes the previous architecture: the repo lived under the **JustAGhosT** account but used a self-hosted runner hosted in **phoenixvc** Azure infrastructure. This avoided Key Vault and Storage 403 errors that can occur when using GitHub-hosted runners (`ubuntu-latest`).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@
 | [03-ci-cd-workflows.md](03-deployment/03-ci-cd-workflows.md)                                       | GitHub Actions workflows: plan, apply, deploy, destroy, checklist                |
 | [04-rollback-procedure.md](03-deployment/04-rollback-procedure.md)                                 | Rollback procedure for Next.js, Functions, Terraform, containers                 |
 | [05-terraform-firewall-troubleshooting.md](03-deployment/05-terraform-firewall-troubleshooting.md) | Key Vault/Storage 403, container IP type, consumption budget, self-hosted runner |
-| [07-self-hosted-runner-setup.md](03-deployment/07-self-hosted-runner-setup.md)                     | Self-hosted runner setup for JustAGhosT repos (cross-account with phoenixvc)     |
+| [07-self-hosted-runner-setup.md](03-deployment/07-self-hosted-runner-setup.md)                     | _Historical:_ self-hosted runner setup (no longer in use — workflows use `ubuntu-latest`) |
 
 _Note: 06 reserved for future deployment documentation._
 


### PR DESCRIPTION
## Summary
- `config/scripts/bootstrap-azure.sh`: default `REPO` now points at `neuralliquid/house-of-veritas`
- `docs/README.md`: marks self-hosted runner doc as historical
- `docs/03-deployment/07-self-hosted-runner-setup.md`: deprecation banner — workflows use `ubuntu-latest`; `azure-vnet-ghost` runner no longer registered
- `.github/actionlint.yaml`: drops dead `self-hosted` / `azure-vnet-ghost` label allowlist

## Why this is a PR (not a direct push to unprotected main)
This is the first workflow run against the new owner — the PR is the verification mechanism per the transfer plan (`org-meta/docs/handoffs/2026-05-14-hov-neuralliquid-transfer-plan.md`).

## Context
- Repo transferred from `JustAGhosT/house-of-veritas` to `neuralliquid/house-of-veritas` earlier today
- Pre-transfer audit found that **all 7 workflows already use `runs-on: ubuntu-latest`**; the self-hosted runner (`azure-vnet-ghost`) had been sitting offline and unreferenced
- Auth is SP+secret (`AZURE_CREDENTIALS`) — no OIDC federated credential update needed
- Runner record did not carry over with the transfer; `gh api repos/.../actions/runners` returns 0 — no deregistration step needed

## Test plan
- [ ] Deployment-checklist workflow runs green on this PR (or fails only on Dependabot-skip path)
- [ ] No actionlint complaints after label-list removal
- [ ] After merge: redirect `JustAGhosT/house-of-veritas` -> `neuralliquid/house-of-veritas` still resolves

## Follow-ups (separate PRs / org-meta work)
- Drop dead `RUNNER_RESOURCE_GROUP_NAME` / `RUNNER_SSH_PUBLIC_KEY` / `RUNNER_SUBNET_ID` secrets + `RUNNER_*` variable
- Clean up `serene-gentleness / production` orphan environment
- Address 8 Dependabot alerts surfaced post-transfer (4 high, 4 moderate)
- Rotate `AZURE_CREDENTIALS` SP secret (plaintext copy exists in untracked `azure-credentials.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)