### PR TITLE
ci(terraform): gate terraform-apply on workflow_dispatch + APPLY confirm

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,13 +1,20 @@
 name: "Terraform Apply"
 
+# Gated on manual dispatch only. Auto-apply on push was removed because the
+# config currently defines ~43 resources that have never been built (database,
+# compute, gateway, functions, webapp, dns, monitoring modules) — an
+# accidental push to terraform/** would build a real production stack. Plan
+# visibility for PRs is provided by terraform-plan.yml. See
+# org-meta/docs/handoffs/2026-05-14-hov-state-drift-inventory.md for context.
+# Until the overhang is resolved, prefer local `terraform apply -target=...`
+# for surgical changes.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "terraform/**"
-      - ".github/workflows/terraform-apply.yml"
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type APPLY to confirm. Any other value aborts.'
+        required: true
+        default: ''
 
 permissions:
   contents: write
@@ -21,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: production
+    if: inputs.confirm == 'APPLY'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

The Terraform Apply workflow was triggering on push to `terraform/**` with `apply -auto-approve`. The current config defines ~43 resources across 7 modules (database, compute, gateway, functions, webapp, dns, monitoring) that have **never been deployed** in any subscription. An accidental push would build a real production stack and likely fail at the DNS step.

After this change:
- Apply requires manual `workflow_dispatch` trigger
- The `confirm` input must equal `APPLY`
- Plan visibility for PRs continues via `terraform-plan.yml`, unchanged

Mirrors the existing pattern in `terraform-destroy.yml` (manual dispatch + `DESTROY` confirm).

## Why this is the right call right now

Per the inventory in [phoenixvc/org-meta#23](https://github.com/phoenixvc/org-meta/pull/23), the 43-add overhang is config-vs-built drift, not state-vs-live drift. Auto-apply on push is a footgun until either:

- The 7 unbuilt modules are removed from config, OR
- They are intentionally built out, OR
- A `-target` parameterization is added to this workflow

Until then, surgical changes should run locally via `terraform apply -target=...`.

## What this unblocks

- The pending `chore/drop-runner-subnet` branch (commit `edcfe98`, currently local-only) can be opened as a PR after this lands. Plan will still show the 43-add overhang in its diff, but the PR review can confirm only the 2-change/3-destroy is new from the patch.

## Test plan

- [ ] Confirm `terraform-plan.yml` still runs on PRs (no changes there)
- [ ] After merge, confirm push to `terraform/**` does NOT trigger an apply run
- [ ] Manually trigger Terraform Apply from the Actions tab, leave `confirm` blank → job should not run
- [ ] Manually trigger with `confirm=APPLY` → job runs as before (will still need `-target` on the actual `apply` step until the overhang is resolved, but that's a separate change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)