### PR TITLE
feat(kitchen): add meal quality feedback escalation

### DIFF
--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -47,6 +47,7 @@ import { taskHandoverAbsence } from "@/lib/workflows/task-handover-absence"
 import { taskAssignmentRotate } from "@/lib/workflows/task-assignment-rotate"
 import { taskFailurePropagate } from "@/lib/workflows/task-failure-propagate"
 import { kitchenCrossContamination } from "@/lib/workflows/kitchen-cross-contamination"
+import { kitchenMealFeedback } from "@/lib/workflows/kitchen-meal-feedback"
 import { kitchenLockerAudit } from "@/lib/workflows/kitchen-locker-audit"
 import { kitchenForcedDeepClean } from "@/lib/workflows/kitchen-forced-deep-clean"
 import { assetMiniAudit } from "@/lib/workflows/asset-mini-audit"
@@ -114,6 +115,7 @@ export const { GET, POST, PUT } = serve({
     taskAssignmentRotate,
     taskFailurePropagate,
     kitchenCrossContamination,
+    kitchenMealFeedback,
     kitchenLockerAudit,
     kitchenForcedDeepClean,
     assetMiniAudit,

--- a/app/api/kitchen/route.ts
+++ b/app/api/kitchen/route.ts
@@ -14,7 +14,7 @@ export const POST = withRole(
 )(async (request) => {
   try {
     const body = await request.json()
-    const { type, description, location } = body
+    const { type, description, location, mealName, servedBy, severity } = body
 
     if (!type || !description) {
       return NextResponse.json({ error: "Type and description are required" }, { status: 400 })
@@ -42,6 +42,45 @@ export const POST = withRole(
       }
 
       return withDataSource({ task, type: "cross_contamination" })
+    }
+
+    if (type === "meal_feedback") {
+      const safeSeverity =
+        severity === "low" || severity === "medium" || severity === "high" ? severity : "medium"
+      const titleMeal = mealName ? `: ${mealName}` : ""
+      const detailLines = [
+        `Meal feedback${titleMeal}`,
+        servedBy ? `Served by: ${servedBy}` : undefined,
+        location ? `Location: ${location}` : undefined,
+        `Severity: ${safeSeverity}`,
+        "",
+        description,
+      ].filter(Boolean)
+
+      const task = await createTask({
+        title: `Meal Quality Review${titleMeal}`,
+        description: detailLines.join("\n"),
+        priority: safeSeverity === "high" ? "High" : safeSeverity === "low" ? "Low" : "Medium",
+        status: "Not Started",
+        dueDate: toISODateString(),
+        project: "Kitchen",
+      })
+
+      if (task) {
+        await routeToInngest({
+          name: "house-of-veritas/kitchen.meal.feedback",
+          data: {
+            taskId: task.id,
+            description,
+            mealName,
+            servedBy,
+            location: location || "Kitchen",
+            severity: safeSeverity,
+          },
+        })
+      }
+
+      return withDataSource({ task, type: "meal_feedback" })
     }
 
     return NextResponse.json({ error: "Unknown report type" }, { status: 400 })

--- a/docs/02-architecture/n8n-business-rules.md
+++ b/docs/02-architecture/n8n-business-rules.md
@@ -79,16 +79,17 @@ See [10-workflow-specifications.md](10-workflow-specifications.md) for full work
 
 Events emitted by Inngest/Next.js that n8n can consume:
 
-| Event                                              | Payload                                        | Use Case                                |
-| -------------------------------------------------- | ---------------------------------------------- | --------------------------------------- |
-| `house-of-veritas/leave.request.submitted`         | id, employeeId, startDate, endDate, type, days | Leave 48h escalation                    |
-| `house-of-veritas/loan.request.submitted`          | id, employeeId, amount, purpose                | Loan approval flow                      |
-| `house-of-veritas/petty.cash.request.submitted`    | id, requesterId, amount, purpose               | Petty cash approval                     |
-| `house-of-veritas/petty.cash.policy.violation`     | requesterId, amount, reason                    | Policy violation alert                  |
-| `house-of-veritas/kitchen.cross.contamination`     | taskId, description, location                  | Cross-contamination escalation          |
-| `house-of-veritas/employee.created`                | employeeId, name, email                        | Welcome email, checklist, ID doc upload |
-| `house-of-veritas/onboarding.checklist.progressed` | checklistId, employeeId                        | IT provisioning trigger                 |
-| `house-of-veritas/succession.live.test`            | successorId, duration                          | Live succession test                    |
+| Event                                              | Payload                                                     | Use Case                                |
+| -------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------- |
+| `house-of-veritas/leave.request.submitted`         | id, employeeId, startDate, endDate, type, days              | Leave 48h escalation                    |
+| `house-of-veritas/loan.request.submitted`          | id, employeeId, amount, purpose                             | Loan approval flow                      |
+| `house-of-veritas/petty.cash.request.submitted`    | id, requesterId, amount, purpose                            | Petty cash approval                     |
+| `house-of-veritas/petty.cash.policy.violation`     | requesterId, amount, reason                                 | Policy violation alert                  |
+| `house-of-veritas/kitchen.cross.contamination`     | taskId, description, location                               | Cross-contamination escalation          |
+| `house-of-veritas/kitchen.meal.feedback`           | taskId, description, mealName, servedBy, location, severity | Meal quality review escalation          |
+| `house-of-veritas/employee.created`                | employeeId, name, email                                     | Welcome email, checklist, ID doc upload |
+| `house-of-veritas/onboarding.checklist.progressed` | checklistId, employeeId                                     | IT provisioning trigger                 |
+| `house-of-veritas/succession.live.test`            | successorId, duration                                       | Live succession test                    |
 
 ## Webhook Integration
 

--- a/lib/workflows/kitchen-meal-feedback.ts
+++ b/lib/workflows/kitchen-meal-feedback.ts
@@ -1,0 +1,34 @@
+import { inngest } from "@/lib/inngest/client"
+import { sendNotification } from "@/lib/services/notification-service"
+import { getAdminNotificationRecipient } from "@/lib/workflows/notification-recipients"
+
+export const kitchenMealFeedback = inngest.createFunction(
+  { id: "kitchen-meal-feedback", retries: 2 },
+  { event: "house-of-veritas/kitchen.meal.feedback" },
+  async ({ event, step }) => {
+    const data = event.data as {
+      taskId?: number
+      description?: string
+      mealName?: string
+      servedBy?: string
+      location?: string
+      severity?: "low" | "medium" | "high"
+    }
+
+    await step.run("send-notification", async () => {
+      const mealLabel = data.mealName ? `: ${data.mealName}` : ""
+      const servedBy = data.servedBy ? ` Served by ${data.servedBy}.` : ""
+      await sendNotification({
+        type: "system_alert",
+        userId: getAdminNotificationRecipient(),
+        title: `Meal Quality Feedback${mealLabel}`,
+        message: `${data.location || "Kitchen"} received ${data.severity || "medium"} severity meal feedback.${servedBy} ${data.description || "Review required"}`,
+        channels: ["in_app"],
+        data: { taskId: data.taskId },
+        priority: data.severity === "high" ? "urgent" : "medium",
+      })
+    })
+
+    return { notified: true }
+  }
+)

--- a/lib/workflows/schema.ts
+++ b/lib/workflows/schema.ts
@@ -8,6 +8,7 @@ export type WorkflowEventName =
   | "house-of-veritas/employee.created"
   | "house-of-veritas/onboarding.checklist.progressed"
   | "house-of-veritas/kitchen.cross.contamination"
+  | "house-of-veritas/kitchen.meal.feedback"
   | "house-of-veritas/succession.live.test"
   | "house-of-veritas/document.expiry.check"
   | "house-of-veritas/recurring.tasks.create"
@@ -59,6 +60,15 @@ export interface KitchenCrossContaminationPayload {
   taskId: number
   description: string
   location: string
+}
+
+export interface KitchenMealFeedbackPayload {
+  taskId: number
+  description: string
+  mealName?: string
+  servedBy?: string
+  location: string
+  severity: "low" | "medium" | "high"
 }
 
 export interface IncidentPayload {
@@ -167,6 +177,7 @@ export type WorkflowEvent =
       data: { checklistId?: number; employeeId?: number }
     }
   | { name: "house-of-veritas/kitchen.cross.contamination"; data: KitchenCrossContaminationPayload }
+  | { name: "house-of-veritas/kitchen.meal.feedback"; data: KitchenMealFeedbackPayload }
   | { name: "house-of-veritas/document.expiry.check"; data?: Record<string, unknown> }
   | { name: "house-of-veritas/recurring.tasks.create"; data?: Record<string, unknown> }
   | { name: "house-of-veritas/overtime.calculate"; data?: Record<string, unknown> }

--- a/tests/api/kitchen.test.ts
+++ b/tests/api/kitchen.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { POST } from "@/app/api/kitchen/route"
+import { routeToInngest } from "@/lib/workflows"
+
+vi.mock("@/lib/workflows", () => ({ routeToInngest: vi.fn().mockResolvedValue(undefined) }))
+
+const authHeaders = {
+  "x-user-id": "irma",
+  "x-user-role": "employee",
+  "x-user-email": "irma@houseofv.com",
+}
+
+describe("POST /api/kitchen", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("returns 400 when type is missing", async () => {
+    const request = new Request("http://localhost/api/kitchen", {
+      method: "POST",
+      headers: { ...authHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ description: "No type" }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+  })
+
+  it("creates a meal quality review task and routes meal feedback", async () => {
+    const request = new Request("http://localhost/api/kitchen", {
+      method: "POST",
+      headers: { ...authHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "meal_feedback",
+        mealName: "Rice, tuna, and polony",
+        servedBy: "Irma",
+        location: "Main Kitchen",
+        severity: "high",
+        description: "Meal was unplanned and below household standards.",
+      }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.type).toBe("meal_feedback")
+    expect(data.task).toMatchObject({
+      title: "Meal Quality Review: Rice, tuna, and polony",
+      priority: "High",
+      status: "Not Started",
+      project: "Kitchen",
+    })
+    expect(data.task.description).toContain("Served by: Irma")
+    expect(routeToInngest).toHaveBeenCalledWith({
+      name: "house-of-veritas/kitchen.meal.feedback",
+      data: expect.objectContaining({
+        taskId: data.task.id,
+        mealName: "Rice, tuna, and polony",
+        servedBy: "Irma",
+        location: "Main Kitchen",
+        severity: "high",
+      }),
+    })
+  })
+
+  it("defaults invalid meal feedback severity to medium", async () => {
+    const request = new Request("http://localhost/api/kitchen", {
+      method: "POST",
+      headers: { ...authHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "meal_feedback",
+        description: "Meal needs review.",
+        severity: "critical",
+      }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.task.priority).toBe("Medium")
+    expect(routeToInngest).toHaveBeenCalledWith({
+      name: "house-of-veritas/kitchen.meal.feedback",
+      data: expect.objectContaining({
+        location: "Kitchen",
+        severity: "medium",
+      }),
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add meal_feedback handling to /api/kitchen that creates a Kitchen review task
- route meal feedback through a new Inngest kitchen.meal.feedback workflow
- document the new workflow event and cover the API behavior with tests

## Verification
- pnpm exec vitest run tests/api/kitchen.test.ts tests/lib/workflows.test.ts
- pnpm build
