### PR TITLE
docs: add Charl sale incentive agreement

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pdf binary

--- a/Charl-Chapman-Sale-Incentive-Agreement.pdf
+++ b/Charl-Chapman-Sale-Incentive-Agreement.pdf
@@ -1,0 +1,967 @@
+%PDF-1.3
+%ºß¬à
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.2799999999999727 841.8899999999999864]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 6100
+>>
+stream
+0.200025 w
+0 G
+BT
+/F2 15 Tf
+17.25 TL
+0 g
+56. 785.8899999999999864 Td
+(SALE INCENTIVE AGREEMENT) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0.431 g
+56. 763.8899999999999864 Td
+(Date: 7 June 2026) Tj
+ET
+0.71 G
+0.6 w
+56. 745.8899999999999864 m
+539.2799999999999727 745.8899999999999864 l
+S
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 725.8899999999999864 Td
+(1. Parties) Tj
+ET
+BT
+/F2 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 709.8899999999999864 Td
+(The Seller / Estate:) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 694.8899999999999864 Td
+(The Estate of the Late Izak Petrus Albertus Smit \(ID 410911 5045 082\), Estate No. 2859/2014, Master) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 679.8899999999999864 Td
+(of the High Court, Pretoria \("the Estate"\), herein represented by:) Tj
+ET
+BT
+/F2 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 664.8899999999999864 Td
+(Hans Jurgens Smit N.O. \(ID 810107 5268 084\),) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 649.8899999999999864 Td
+(in his capacity as the duly appointed Executor per Letters of Executorship dated 4 March 2014 \("the) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 634.8899999999999864 Td
+(Executor"\).) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 619.8899999999999864 Td
+(Email: smit.jurie@gmail.com    Tel: +27 69 238 1255) Tj
+ET
+BT
+/F2 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 596.8899999999999864 Td
+(The Employee:) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 581.8899999999999864 Td
+(Charl Chapman \("the Employee"\).) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 566.8899999999999864 Td
+(ID No: __________________________) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 551.8899999999999864 Td
+(Email: charl@houseofv.com    Tel: +27 71 148 8390) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 530.8899999999999864 Td
+(2. Background) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 514.8899999999999864 Td
+(The Estate is the owner of the residential property described below. The Employee has carried out repair) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 499.8899999999999864 Td
+(and renovation work on the Property, which work is nearing completion. In recognition of that work, the) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 484.8899999999999864 Td
+(Estate agrees to pay the Employee the incentive set out below upon the successful sale and transfer of) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 469.8899999999999864 Td
+(the Property.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 448.8899999999999864 Td
+(3. The Property) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 432.8899999999999864 Td
+(The residential house situated at:) Tj
+ET
+BT
+/F2 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 417.8899999999999864 Td
+(32 Singlehurst, Casseldale, Springs,) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 402.8899999999999864 Td
+(being an asset of the Estate \("the Property"\).) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 381.8899999999999864 Td
+(4. Incentive) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 365.8899999999999864 Td
+(On registration of transfer of the Property, the Estate shall pay the Employee an incentive equal to 10%) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 350.8899999999999864 Td
+(\(ten percent\) of the Net Proceeds in excess of R800,000.) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 333.8899999999999864 Td
+("Net Proceeds" means the final sale price of the Property, less any estate agents' commission paid by) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 318.8899999999999864 Td
+(the Estate on the sale.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 297.8899999999999864 Td
+(5. Worked Examples) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 281.8899999999999864 Td
+(The following show how the incentive is calculated at different sale outcomes:) Tj
+ET
+0.92 g
+56. 274.8899999999999864 483.2799999999999727 -20. re
+f
+0.78 G
+0.5 w
+56. 274.8899999999999864 483.2799999999999727 -20. re
+S
+BT
+/F2 10 Tf
+11.5 TL
+0. g
+64. 260.8899999999999864 Td
+(Net Proceeds) Tj
+ET
+220.3152000000000044 274.8899999999999864 m
+220.3152000000000044 254.8899999999999864 l
+S
+BT
+/F2 10 Tf
+11.5 TL
+0. g
+228.3152000000000044 260.8899999999999864 Td
+(Excess over R800,000) Tj
+ET
+394.2959999999999923 274.8899999999999864 m
+394.2959999999999923 254.8899999999999864 l
+S
+BT
+/F2 10 Tf
+11.5 TL
+0. g
+402.2959999999999923 260.8899999999999864 Td
+(Incentive \(10%\)) Tj
+ET
+0.78 G
+0.5 w
+56. 254.8899999999999864 483.2799999999999727 -20. re
+S
+BT
+/F1 10 Tf
+11.5 TL
+0. g
+64. 240.8899999999999864 Td
+(R900 000) Tj
+ET
+220.3152000000000044 254.8899999999999864 m
+220.3152000000000044 234.8899999999999864 l
+S
+BT
+/F1 10 Tf
+11.5 TL
+0. g
+228.3152000000000044 240.8899999999999864 Td
+(R100 000) Tj
+ET
+394.2959999999999923 254.8899999999999864 m
+394.2959999999999923 234.8899999999999864 l
+S
+BT
+/F1 10 Tf
+11.5 TL
+0. g
+402.2959999999999923 240.8899999999999864 Td
+(R10 000) Tj
+ET
+0.78 G
+0.5 w
+56. 234.8899999999999864 483.2799999999999727 -20. re
+S
+BT
+/F1 10 Tf
+11.5 TL
+0. g
+64. 220.8899999999999864 Td
+(R1 000 000) Tj
+ET
+220.3152000000000044 234.8899999999999864 m
+220.3152000000000044 214.8899999999999864 l
+S
+BT
+/F1 10 Tf
+11.5 TL
+0. g
+228.3152000000000044 220.8899999999999864 Td
+(R200 000) Tj
+ET
+394.2959999999999923 234.8899999999999864 m
+394.2959999999999923 214.8899999999999864 l
+S
+BT
+/F1 10 Tf
+11.5 TL
+0. g
+402.2959999999999923 220.8899999999999864 Td
+(R20 000) Tj
+ET
+0.78 G
+0.5 w
+56. 214.8899999999999864 483.2799999999999727 -20. re
+S
+BT
+/F1 10 Tf
+11.5 TL
+0. g
+64. 200.8899999999999864 Td
+(R1 200 000) Tj
+ET
+220.3152000000000044 214.8899999999999864 m
+220.3152000000000044 194.8899999999999864 l
+S
+BT
+/F1 10 Tf
+11.5 TL
+0. g
+228.3152000000000044 200.8899999999999864 Td
+(R400 000) Tj
+ET
+394.2959999999999923 214.8899999999999864 m
+394.2959999999999923 194.8899999999999864 l
+S
+BT
+/F1 10 Tf
+11.5 TL
+0. g
+402.2959999999999923 200.8899999999999864 Td
+(R40 000) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 168.8899999999999864 Td
+(6. Market Context \(for reference\)) Tj
+ET
+endstream
+endobj
+5 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.2799999999999727 841.8899999999999864]
+/Contents 6 0 R
+>>
+endobj
+6 0 obj
+<<
+/Length 5761
+>>
+stream
+0.5 w
+0.78 G
+0.96 g
+0.82 G
+0.6 w
+56. 797.8899999999999864 483.2799999999999727 -142. re
+B
+BT
+/F2 9.5 Tf
+10.9249999999999989 TL
+0. g
+66. 781.8899999999999864 Td
+(Comparable 3-bedroom houses in Casseldale, Springs:) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+66. 767.8899999999999864 Td
+(• Typical asking range: approx. R900,000 – R1,250,000) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+66. 753.8899999999999864 Td
+(• Most listings cluster around R950,000 – R1,050,000) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+66. 725.8899999999999864 Td
+(The R800,000 floor therefore sits below typical market value for the area,) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+66. 711.8899999999999864 Td
+(meaning a sale at prevailing prices is expected to trigger an incentive.) Tj
+ET
+BT
+/F1 8.5 Tf
+9.7749999999999986 TL
+0.431 g
+66. 683.8899999999999864 Td
+(Source: Property24 listings for Casseldale, Springs \(retrieved 7 June 2026\).) Tj
+ET
+BT
+/F1 8.5 Tf
+9.7749999999999986 TL
+0.431 g
+66. 672.8899999999999864 Td
+(Asking prices, not guaranteed sale values; for guidance only.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 637.8899999999999864 Td
+(7. Threshold) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 621.8899999999999864 Td
+(If the Net Proceeds are R800,000 or less, no incentive is payable.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 600.8899999999999864 Td
+(8. Sale Period) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 584.8899999999999864 Td
+(This incentive applies to a sale and transfer of the Property registered within 24 \(twenty-four\) months of) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 569.8899999999999864 Td
+(the date of signature of this agreement. This period may be extended by written agreement between the) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 554.8899999999999864 Td
+(parties. Subject to clause 9, if no sale is registered within this period, the incentive lapses.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 533.8899999999999864 Td
+(9. Election to Let Instead of Sell) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 517.8899999999999864 Td
+(Should the Estate elect to let or rent the Property rather than sell it, this incentive shall not lapse but) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 502.8899999999999864 Td
+(shall remain attached to the Property and become payable on the first subsequent sale and transfer of) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 487.8899999999999864 Td
+(the Property, whenever that occurs. The 24-month period in clause 8 is suspended for any period during) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 472.8899999999999864 Td
+(which the Property is let.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 451.8899999999999864 Td
+(10. Departure Before Sale) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 435.8899999999999864 Td
+(If the Employee's engagement ends before the date of sale of the Property, this agreement and the) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 420.8899999999999864 Td
+(incentive remain valid and payable, provided that the Employee's departure was requested or initiated by) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 405.8899999999999864 Td
+(the Estate or the Executor.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 384.8899999999999864 Td
+(11. Death, Incapacity and Succession) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 368.8899999999999864 Td
+(Should the Employee die or become permanently incapacitated before payment, the incentive shall be) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 353.8899999999999864 Td
+(paid to his estate or nominated beneficiary. This agreement binds the heirs, executors, administrators) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 338.8899999999999864 Td
+(and successors-in-title of the Estate and of the Executor, and remains enforceable against the Estate) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 323.8899999999999864 Td
+(and any replacement executor appointed by the Master of the High Court.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 302.8899999999999864 Td
+(12. Tax and Deductions) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 286.8899999999999864 Td
+(The incentive is a gross amount and is subject to any tax or statutory deductions required by law to be) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 271.8899999999999864 Td
+(withheld.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 250.8899999999999864 Td
+(13. No Obligation to Sell) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 234.8899999999999864 Td
+(Nothing in this agreement obliges the Estate to sell the Property, to sell at any particular price, or by any) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 219.8899999999999864 Td
+(particular date. No incentive is payable unless and until a sale is registered.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 198.8899999999999864 Td
+(14. Governing Law) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 182.8899999999999864 Td
+(This agreement is governed by the laws of the Republic of South Africa, and the administration of the) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 167.8899999999999864 Td
+(Estate remains subject to the Administration of Estates Act 66 of 1965.) Tj
+ET
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 146.8899999999999864 Td
+(15. Whole Agreement) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 130.8899999999999864 Td
+(This document constitutes the entire agreement between the parties. No variation is of any force unless) Tj
+ET
+BT
+/F1 10.5 Tf
+12.0749999999999993 TL
+0. g
+56. 115.8899999999999864 Td
+(reduced to writing and signed by both parties.) Tj
+ET
+endstream
+endobj
+7 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 595.2799999999999727 841.8899999999999864]
+/Contents 8 0 R
+>>
+endobj
+8 0 obj
+<<
+/Length 1217
+>>
+stream
+0.6 w
+0.82 G
+0.71 G
+0.6 w
+56. 767.8899999999999864 m
+539.2799999999999727 767.8899999999999864 l
+S
+BT
+/F2 11 Tf
+12.6499999999999986 TL
+0. g
+56. 747.8899999999999864 Td
+(Signatures) Tj
+ET
+0.24 G
+0.8 w
+56. 697.8899999999999864 m
+277.6399999999999864 697.8899999999999864 l
+S
+317.6399999999999864 697.8899999999999864 m
+539.2799999999999727 697.8899999999999864 l
+S
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+56. 683.8899999999999864 Td
+(Hans Jurgens Smit N.O. \(Executor\)) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+56. 669.8899999999999864 Td
+(for Estate Late I.P.A. Smit, No. 2859/2014) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+56. 653.8899999999999864 Td
+(Date: __________  Place: __________) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+317.6399999999999864 683.8899999999999864 Td
+(Charl Chapman \(Employee\)) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+317.6399999999999864 669.8899999999999864 Td
+(Date: __________  Place: __________) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+56. 625.8899999999999864 Td
+(Witness 1: ____________________________) Tj
+ET
+BT
+/F1 9.5 Tf
+10.9249999999999989 TL
+0. g
+317.6399999999999864 625.8899999999999864 Td
+(Witness 2: ____________________________) Tj
+ET
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R 5 0 R 7 0 R ]
+/Count 3
+>>
+endobj
+9 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+10 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+11 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+12 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+13 0 obj
+<<
+/Type /Font
+/BaseFont /Courier
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+14 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+15 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+16 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+17 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+18 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+19 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+20 0 obj
+<<
+/Type /Font
+/BaseFont /Times-BoldItalic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+21 0 obj
+<<
+/Type /Font
+/BaseFont /ZapfDingbats
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+22 0 obj
+<<
+/Type /Font
+/BaseFont /Symbol
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 9 0 R
+/F2 10 0 R
+/F3 11 0 R
+/F4 12 0 R
+/F5 13 0 R
+/F6 14 0 R
+/F7 15 0 R
+/F8 16 0 R
+/F9 17 0 R
+/F10 18 0 R
+/F11 19 0 R
+/F12 20 0 R
+/F13 21 0 R
+/F14 22 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+23 0 obj
+<<
+/Producer (jsPDF 4.2.1)
+/CreationDate (D:20260607004518+02'00')
+>>
+endobj
+24 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 25
+0000000000 65535 f 
+0000013660 00000 n 
+0000015493 00000 n 
+0000000015 00000 n 
+0000000152 00000 n 
+0000006304 00000 n 
+0000006441 00000 n 
+0000012254 00000 n 
+0000012391 00000 n 
+0000013729 00000 n 
+0000013854 00000 n 
+0000013985 00000 n 
+0000014119 00000 n 
+0000014257 00000 n 
+0000014381 00000 n 
+0000014510 00000 n 
+0000014642 00000 n 
+0000014778 00000 n 
+0000014906 00000 n 
+0000015033 00000 n 
+0000015162 00000 n 
+0000015295 00000 n 
+0000015397 00000 n 
+0000015745 00000 n 
+0000015831 00000 n 
+trailer
+<<
+/Size 25
+/Root 24 0 R
+/Info 23 0 R
+/ID [ <BC11585B2F9B8FE20155AEEC832AB118> <BC11585B2F9B8FE20155AEEC832AB118> ]
+>>
+startxref
+15935
+%%EOF


### PR DESCRIPTION
## Summary
- add Charl Chapman sale incentive agreement PDF
- mark PDFs as binary in .gitattributes to avoid line-ending conversion

## Verification
- git check-attr confirms the PDF has binary set and text unset
- staged diff shows the PDF as a binary blob
