### PR TITLE
docs(auth): document Mystira OIDC env vars in tracked .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,64 @@
+# House of Veritas - Environment Template
+# Copy to .env.local and fill in values
+
+# =============================================================================
+# Auth (Auth.js v5 + Mystira OIDC)
+# =============================================================================
+# Session/JWT encryption secret for Auth.js v5. Generate with: npx auth secret
+# AUTH_SECRET=
+
+# Mystira Identity OIDC relying-party config (client: neuralliquid-hov-web).
+# DEV-ONLY for now: staging/prod issuer + client secret will be provisioned
+# via Azure Key Vault once HOV hosting/domain is decided. Do not put real
+# secrets in this file.
+# Dev issuer: https://mys-dev-id-webapi.azurewebsites.net
+# MYSTIRA_OIDC_ISSUER=https://mys-dev-id-webapi.azurewebsites.net
+# MYSTIRA_OIDC_CLIENT_ID=neuralliquid-hov-web
+# MYSTIRA_OIDC_CLIENT_SECRET=
+
+# Invite links still use their own JWT secret (lib/invite.ts);
+# INVITE_JWT_SECRET takes precedence, JWT_SECRET is the fallback.
+# INVITE_JWT_SECRET=
+# JWT_SECRET=
+
+# =============================================================================
+# Workflow / Inngest
+# =============================================================================
+# When "true", expense and kiosk approvals use Inngest workflows instead of
+# realtime event store. Tasks and maintenance always use Inngest.
+# USE_INNGEST_APPROVALS=false
+
+# Optional: User ID for confidential incident (victim support) routing.
+# When incident has victimSupportPath=true, notifications go here instead of hans.
+# VICTIM_SUPPORT_CONTACT=hans
+
+# =============================================================================
+# Baserow (operational data)
+# =============================================================================
+# BASEROW_API_URL=https://ops.nexamesh.ai/api
+# BASEROW_API_TOKEN=
+# BASEROW_DATABASE_ID=
+# BASEROW_TABLE_EMPLOYEES=0
+# BASEROW_TABLE_ASSETS=0
+# BASEROW_TABLE_TASKS=0
+# BASEROW_TABLE_TIME_CLOCK=0
+# BASEROW_TABLE_INCIDENTS=0
+# BASEROW_TABLE_VEHICLE_LOGS=0
+# BASEROW_TABLE_EXPENSES=0
+# BASEROW_TABLE_DOCUMENT_EXPIRY=0
+# BASEROW_TABLE_LEAVE_REQUESTS=0
+# BASEROW_TABLE_LOANS=0
+# BASEROW_TABLE_PETTY_CASH=0
+# BASEROW_TABLE_ONBOARDING_CHECKLIST=0
+# BASEROW_TABLE_BUDGET=0
+# BASEROW_TABLE_PPE=0
+# BASEROW_TABLE_INSURANCE_CLAIMS=0
+
+# =============================================================================
+# Integrations
+# =============================================================================
+# DOCUSEAL_WEBHOOK_SECRET=
+# DOCUSEAL_WEBHOOK_HEADER=X-DocuSeal-Signature
+# TWILIO_ACCOUNT_SID=
+# TWILIO_AUTH_TOKEN=
+# TWILIO_PHONE_NUMBER=

--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,12 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files
+# NOTE: the un-ignore for .env.example must come AFTER the broad patterns —
+# later rules win in gitignore, so placing it first silently re-ignored it.
 .env*
-!.env.example
 *.env
 *.env.*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Scope: DEV-ONLY

Owner decision 2026-07-03: HOV ↔ Mystira Identity OIDC wiring is dev-scope for now; staging/prod configuration is deferred until HOV hosting/domain is decided (values will then come via Azure Key Vault).

## Context

The RP wiring itself already shipped in #62 (Auth.js v5, generic `mystira` OIDC provider, PKCE + state, JWT sessions, verified-email gate before account linking). This PR closes the remaining documentation gap plus a latent `.gitignore` bug:

- `.gitignore` had `!.env.example` **before** the broad `*.env` / `*.env.*` patterns — later rules win, so the template was silently ignored despite the clear intent to track it. The negation is moved after the broad patterns.
- `.env.example` is now committed, documenting the Auth.js v5 + Mystira OIDC variables from #62: `AUTH_SECRET`, `MYSTIRA_OIDC_ISSUER` (dev issuer `https://mys-dev-id-webapi.azurewebsites.net` noted in a comment), `MYSTIRA_OIDC_CLIENT_ID` (default `neuralliquid-hov-web`), `MYSTIRA_OIDC_CLIENT_SECRET` (placeholder only — no real values anywhere).
- `INVITE_JWT_SECRET` / `JWT_SECRET` remain documented: invite links (`lib/invite.ts`) still consume them; only the bcrypt-era session JWT path is dead.

## Verified against dev Identity (2026-07-03)

- `GET https://mys-dev-id-webapi.azurewebsites.net/.well-known/openid-configuration` returns a real OpenIddict discovery document (authorization/token/userinfo/endsession/revocation/introspection endpoints + JWKS).
- Client `neuralliquid-hov-web` **is seeded** in dev: `/connect/authorize` with this client_id + `http://localhost:3000/api/auth/callback/mystira` passes client and redirect_uri validation (401 auth challenge), while a bogus client_id fails with OpenIddict ID2052 and a wrong redirect_uri fails with ID2043.

## Remaining manual steps (dev round-trip)

1. Provision the real dev `MYSTIRA_OIDC_CLIENT_SECRET` into `.env.local` (ask the owner; never commit it).
2. Set `MYSTIRA_OIDC_ISSUER=https://mys-dev-id-webapi.azurewebsites.net` and `AUTH_SECRET` (`npx auth secret`) in `.env.local`.
3. Run the round-trip smoke: `pnpm dev` → visit `http://localhost:3000/login` → sign in via Mystira → confirm callback lands on `http://localhost:3000/api/auth/callback/mystira` and a session is established (the local user store must contain the signing-in email, and the Mystira account email must be verified).

No build-affecting files changed (env template + .gitignore only); CI validates the branch as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)