### PR TITLE
fix(ui): optimize custom cursor, fix post-login redirect, harden PWA/scroll

### DIFF
--- a/components/custom-cursor.tsx
+++ b/components/custom-cursor.tsx
@@ -1,12 +1,25 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { motion } from "framer-motion"
+import { motion, useMotionValue, useSpring } from "framer-motion"
+
+// Base diameter of the dot in px (matches the h-3 w-3 Tailwind classes below).
+const DOT_SIZE = 12
 
 export function CustomCursor() {
-  const [mousePos, setMousePos] = useState({ x: 0, y: 0 })
   const [isHovering, setIsHovering] = useState(false)
   const [enabled, setEnabled] = useState(false)
+
+  // Motion values write straight to the DOM transform on each rAF frame, so
+  // pointer movement never triggers a React re-render (the old version called
+  // setState on every mousemove, re-rendering dozens of times per second).
+  // Start off-screen so the dot doesn't flash in the top-left corner on mount.
+  const x = useMotionValue(-100)
+  const y = useMotionValue(-100)
+  // Snappy spring: enough follow-through to feel smooth, without a laggy trail.
+  const springConfig = { damping: 30, stiffness: 800, mass: 0.25 }
+  const springX = useSpring(x, springConfig)
+  const springY = useSpring(y, springConfig)
 
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -14,45 +27,43 @@ export function CustomCursor() {
     const isCoarsePointer = window.matchMedia("(pointer: coarse)").matches
     const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
     if (isCoarsePointer || prefersReducedMotion) return
+    // One-time client-only enable after the pointer-type check (can't run during
+    // SSR without a hydration mismatch). Fires once on mount, not per frame.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setEnabled(true)
 
     const handleMouseMove = (e: MouseEvent) => {
-      setMousePos({ x: e.clientX, y: e.clientY })
+      x.set(e.clientX - DOT_SIZE / 2)
+      y.set(e.clientY - DOT_SIZE / 2)
     }
 
     const handleMouseOver = (e: MouseEvent) => {
       const target = e.target as HTMLElement
-      const interactive =
-        target.tagName === "BUTTON" ||
-        target.tagName === "A" ||
-        target.closest("button") ||
-        target.closest("a") ||
-        target.classList.contains("cursor-pointer")
-      setIsHovering(Boolean(interactive))
+      // One selector match instead of several tag/class checks.
+      const interactive = target.closest("button, a, [role='button'], .cursor-pointer") !== null
+      setIsHovering(interactive)
     }
 
-    window.addEventListener("mousemove", handleMouseMove)
-    window.addEventListener("mouseover", handleMouseOver)
+    window.addEventListener("mousemove", handleMouseMove, { passive: true })
+    window.addEventListener("mouseover", handleMouseOver, { passive: true })
 
     return () => {
       window.removeEventListener("mousemove", handleMouseMove)
       window.removeEventListener("mouseover", handleMouseOver)
     }
-  }, [])
+  }, [x, y])
 
   if (!enabled) return null
 
   return (
     <motion.div
-      className="custom-cursor pointer-events-none fixed top-0 left-0 z-[60] h-5 w-5 rounded-full mix-blend-difference"
-      style={{ backgroundColor: "#D4AF37" }}
+      className="custom-cursor pointer-events-none fixed top-0 left-0 z-[60] h-3 w-3 rounded-full mix-blend-difference"
+      style={{ x: springX, y: springY, backgroundColor: "#D4AF37" }}
       animate={{
-        x: mousePos.x - 10,
-        y: mousePos.y - 10,
-        scale: isHovering ? 2.5 : 1,
+        scale: isHovering ? 1.8 : 1,
         opacity: isHovering ? 0.6 : 1,
       }}
-      transition={{ type: "spring", damping: 25, stiffness: 250, mass: 0.5 }}
+      transition={{ type: "spring", damping: 25, stiffness: 300 }}
       aria-hidden="true"
     />
   )

--- a/components/smooth-scroll.tsx
+++ b/components/smooth-scroll.tsx
@@ -7,18 +7,27 @@ import Lenis from "lenis"
 
 export function SmoothScroll({ children }: { children: React.ReactNode }) {
   useEffect(() => {
+    // Respect reduced-motion: skip the smooth-scroll hijack and use native scroll.
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return
+    }
+
     const lenis = new Lenis({
       duration: 1.2,
       easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
       smoothWheel: true,
     })
 
+    let rafId = 0
     function raf(time: number) {
       lenis.raf(time)
-      requestAnimationFrame(raf)
+      rafId = requestAnimationFrame(raf)
     }
 
-    requestAnimationFrame(raf)
+    rafId = requestAnimationFrame(raf)
 
     const handleAnchorClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement
@@ -38,6 +47,7 @@ export function SmoothScroll({ children }: { children: React.ReactNode }) {
 
     return () => {
       document.removeEventListener("click", handleAnchorClick, true)
+      cancelAnimationFrame(rafId)
       lenis.destroy()
     }
   }, [])

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -67,6 +67,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (isLoading) return
 
     const isAuthPage = pathname === "/login"
+    // The public landing page has no authenticated view (the navbar always shows
+    // "Login"), and OIDC sign-in lands here via callbackUrl "/". Forward a logged-in
+    // user to their dashboard so a successful login doesn't look like a no-op.
+    const isHomePage = pathname === "/"
     const isDashboardPage = pathname?.startsWith("/dashboard")
     const isOnboardingPage = pathname === "/onboarding"
 
@@ -76,7 +80,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setRequiresAuth(false)
     }
 
-    if (user && isAuthPage) {
+    if (user && (isAuthPage || isHomePage)) {
       router.push(getDashboardPath(user.id, user.role))
     } else if (user && isOnboardingPage && user.onboardingStatus === "completed") {
       router.push(getDashboardPath(user.id, user.role))

--- a/lib/hooks/use-pwa.tsx
+++ b/lib/hooks/use-pwa.tsx
@@ -16,19 +16,32 @@ export function usePWA() {
   const [swRegistration, setSwRegistration] = useState<ServiceWorkerRegistration | null>(null)
 
   useEffect(() => {
-    // Register service worker
+    // Register the service worker in production only. In development the SW caches
+    // hashed build chunks that Turbopack regenerates on every rebuild, which causes
+    // ChunkLoadError and stale-content bugs. In dev we instead unregister any SW a
+    // previous prod-like session left behind and clear its caches, so the browser
+    // self-heals rather than serving stale assets.
     if ("serviceWorker" in navigator) {
-      navigator.serviceWorker
-        .register("/sw.js")
-        .then((registration) => {
-          logger.info("[PWA] Service Worker registered", { scope: registration.scope })
-          setSwRegistration(registration)
-        })
-        .catch((error) => {
-          logger.error("[PWA] Service Worker registration failed", {
-            error: error instanceof Error ? error.message : String(error),
+      if (process.env.NODE_ENV === "production") {
+        navigator.serviceWorker
+          .register("/sw.js")
+          .then((registration) => {
+            logger.info("[PWA] Service Worker registered", { scope: registration.scope })
+            setSwRegistration(registration)
           })
-        })
+          .catch((error) => {
+            logger.error("[PWA] Service Worker registration failed", {
+              error: error instanceof Error ? error.message : String(error),
+            })
+          })
+      } else {
+        navigator.serviceWorker
+          .getRegistrations()
+          .then((regs) => regs.forEach((reg) => reg.unregister()))
+        if (typeof caches !== "undefined") {
+          caches.keys().then((keys) => keys.forEach((key) => caches.delete(key)))
+        }
+      }
     }
 
     // Handle install prompt


### PR DESCRIPTION
## Summary

Four targeted fixes from a debugging session, most importantly a **post-login redirect bug** that made OIDC sign-in look like it failed.

### 🔑 Post-login redirect (`lib/auth-context.tsx`)
OIDC sign-in returns to `/` (via `callbackUrl`), but the landing page has **no authenticated view** (`navbar` never reads auth state) and nothing forwarded a logged-in user onward — so a *successful* login dumped the user back on the marketing homepage, indistinguishable from failure. Now authenticated users landing on `/` are redirected to their dashboard (mirrors the existing `/login` behavior). Verified live: session was valid all along (`/api/auth/me` → 200), this was purely a redirect gap.

### 🖱️ Custom cursor perf (`components/custom-cursor.tsx`)
Was calling `setState` on every `mousemove` → a React re-render per pointer move. Rewritten with framer-motion `useMotionValue`/`useSpring` (zero re-renders on move). Dot shrunk 20→12px, spring stiffened, starts off-screen. Correctly hidden on touch/reduced-motion.

### 📦 Service worker in dev (`lib/hooks/use-pwa.tsx`)
SW was registered unconditionally → cached hashed Turbopack chunks that regenerate each rebuild, causing `ChunkLoadError` and stale-content bugs in dev. Now **production-only**; in dev it unregisters stale SWs and clears caches so browsers self-heal.

### ♿ Smooth scroll (`components/smooth-scroll.tsx`)
Respects `prefers-reduced-motion` (skips Lenis) and adds `cancelAnimationFrame` on cleanup (rAF leak).

## Testing
- ✅ `npm test` — **187 tests pass** (31 files)
- ✅ `tsc --noEmit` clean
- ✅ `eslint` clean (0 errors)

## Deploy note
⚠️ Merging triggers `deploy-on-merge` (production deploy). The login fix is relevant to onboarding real users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
