### PR TITLE
fix(build): bundle @swc/helpers in standalone output for Azure runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
+    "@swc/helpers": "0.5.15",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.1.6
         version: 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@swc/helpers':
+        specifier: 0.5.15
+        version: 0.5.15
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.24(postcss@8.5.12)


### PR DESCRIPTION
## Problem
The production Web App (`nl-prod-hov-app-san`) crashed on boot with:
```
Error: Cannot find module '@swc/helpers/_/_interop_require_default'
```
`@swc/helpers` is a transitive dependency of Next.js' SWC-compiled output. pnpm's symlinked `node_modules` hides it from Next's file tracer (`@vercel/nft`), so it was omitted from `.next/standalone/node_modules` and the container exited with code 1 (HTTP 503).

## Fix
Declare `@swc/helpers` as a direct dependency, pinned to the version Next already resolves (`0.5.15`). This gives it a top-level `node_modules` entry the tracer includes in the standalone bundle.

## Validation
Built locally with `CI=true` (standalone) and booted `.next/standalone/server.js` — `/` and `/login` both return HTTP 200. No other missing deps surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)