### PR TITLE
fix(build): hoist node_modules so Next standalone bundle is complete

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -17,6 +17,7 @@ on:
       - "next.config.mjs"
       - "package.json"
       - "pnpm-lock.yaml"
+      - ".npmrc"
       - "tsconfig.json"
       - "tailwind.config*"
       - "postcss.config*"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# Hoist all dependencies to the root of node_modules (like npm/yarn) while
+# keeping pnpm's default (isolated) node-linker. Next.js standalone output uses
+# @vercel/nft to trace runtime deps; pnpm's per-package symlinked node_modules
+# causes the tracer to miss transitive packages (e.g. @swc/helpers, @next/env),
+# which then crash the container on boot in Azure App Service (isolated wwwroot,
+# no parent node_modules to fall back on). Hoisting makes every dependency
+# resolvable from the root so the tracer includes it in the standalone bundle.
+shamefully-hoist=true


### PR DESCRIPTION
## Problem
After #68 (`@swc/helpers` direct dep), the production container got past that error but crashed on the next missing module: `Cannot find module '@next/env'`. pnpm's symlinked `node_modules` hides multiple transitive deps from Next's standalone file tracer (`@vercel/nft`), so `.next/standalone/node_modules` is incomplete and the app exits on boot in Azure App Service (isolated `wwwroot`, no parent `node_modules`).

## Fix
`.npmrc` → `shamefully-hoist=true`. This lays out every dependency at the root of `node_modules` (keeping pnpm's default isolated linker, so the lockfile and `--frozen-lockfile` are unaffected), making all runtime deps resolvable to the tracer and included in the standalone bundle. Also adds `.npmrc` to the `deploy-on-merge` trigger paths.

## Note
Local validation was blocked by a full local disk; CI has ample disk and sets `CI=true`, so the hoisted install runs cleanly there. Boot will be verified against the deployed app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)