### PR TITLE
feat(auth): env-gated OIDC auto-provisioning of verified users

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -1,6 +1,6 @@
 import NextAuth from "next-auth"
 import authConfig from "./auth.config"
-import { findUserByEmailAsync } from "@/lib/users"
+import { findUserByEmailAsync, findOrCreateOidcUserAsync } from "@/lib/users"
 import { logger } from "@/lib/logger"
 
 /**
@@ -33,10 +33,23 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         logger.warn("OIDC sign-in rejected: no email claim")
         return false
       }
-      const local = await findUserByEmailAsync(email)
+      let local = await findUserByEmailAsync(email)
       if (!local) {
-        logger.warn("OIDC sign-in rejected: email not in local user store", { email })
-        return false
+        // When auto-provisioning is enabled, admit any IdP-verified user and
+        // create a minimal record on first sign-in (profile completed during
+        // onboarding). Otherwise fail closed to pre-provisioned users only.
+        if (process.env.OIDC_AUTO_PROVISION !== "true") {
+          logger.warn("OIDC sign-in rejected: email not in local user store", { email })
+          return false
+        }
+        const displayName =
+          typeof claims.name === "string"
+            ? claims.name
+            : typeof claims.given_name === "string"
+              ? claims.given_name
+              : null
+        local = await findOrCreateOidcUserAsync(email, displayName)
+        logger.info("OIDC sign-in auto-provisioned new user", { email, userId: local.id })
       }
       const enriched = user as {
         userId?: string

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -166,6 +166,51 @@ export async function findUserByEmailAsync(email: string): Promise<User | undefi
   return rows[0] ? rowToUser(rows[0]) : undefined
 }
 
+/**
+ * Find a user by email, or create a minimal record for a newly-seen,
+ * IdP-verified user. Used by the OIDC signIn callback (gated on
+ * OIDC_AUTO_PROVISION) so users can sign in without being pre-provisioned;
+ * they complete their profile (name/phone) during onboarding. New users get
+ * the least-privileged "resident" role.
+ *
+ * In static (no-Postgres) mode the new user is held in-memory only and does
+ * not survive a restart — acceptable for demo onboarding, not durable accounts.
+ */
+export async function findOrCreateOidcUserAsync(
+  email: string,
+  name?: string | null
+): Promise<User> {
+  const existing = await findUserByEmailAsync(email)
+  if (existing) return existing
+
+  const normalizedEmail = email.toLowerCase()
+  const id = `oidc-${normalizedEmail.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")}`
+  const user: User = {
+    id,
+    name: name?.trim() || normalizedEmail.split("@")[0],
+    email: normalizedEmail,
+    phone: "",
+    role: "resident",
+    description: "Self-provisioned via Mystira sign-in",
+    color: "gray",
+    icon: "👤",
+    specialty: [],
+  }
+
+  if (isPostgresConfigured()) {
+    await ensureUsersSchemaOnce()
+    await query(
+      `INSERT INTO users (id, name, email, phone, password_hash, role, description, color, icon, specialty)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       ON CONFLICT (id) DO NOTHING`,
+      [user.id, user.name, user.email, user.phone, "", user.role, user.description, user.color, user.icon, user.specialty]
+    )
+  } else {
+    USERS[user.id] = user
+  }
+  return user
+}
+
 export async function getAllUsersAsync(): Promise<User[]> {
   if (!isPostgresConfigured()) {
     return Object.values(USERS)


### PR DESCRIPTION
## What
Adds `findOrCreateOidcUserAsync()` and wires the `signIn` callback so that, when `OIDC_AUTO_PROVISION=true`, any IdP-verified user is admitted and gets a minimal record created on first sign-in (least-privileged `resident` role; name/phone completed during onboarding). With the flag unset, behavior is unchanged (fail-closed to pre-provisioned users).

## Why
For the demo, this removes the dependency on pre-knowing charl/irma/lucky's exact Mystira emails — they can sign in and self-provision.

## Notes
- In static (no-Postgres) mode the new user is in-memory only (fine for demo onboarding, not durable accounts).
- Enabled per-environment via the `OIDC_AUTO_PROVISION` app setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)