### PR TITLE
chore(auth): OIDC migration follow-ups — logout, E2E, schema, fixtures

### DIFF
--- a/app/api/auth/federated-logout/route.ts
+++ b/app/api/auth/federated-logout/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { getToken } from "next-auth/jwt"
+import { logger } from "@/lib/logger"
+import { buildEndSessionUrl, resolveEndSessionEndpoint } from "@/lib/auth/federated-logout"
+
+const issuer = process.env.MYSTIRA_OIDC_ISSUER ?? "http://localhost:5262"
+
+/**
+ * Returns the Mystira RP-initiated-logout URL for the current session so the
+ * client can end the IdP's SSO session (front-channel) after clearing the local
+ * Auth.js cookie. Without this, sign-out only drops the local cookie and the
+ * next "Continue with Mystira" click silently re-authenticates against the
+ * still-live IdP session.
+ *
+ * Returns `{ url: null }` when there is no `id_token` to hint with (e.g. a
+ * session minted without one, or in dev before the first real handshake) — the
+ * client then falls back to a local-only sign-out. Any error also yields
+ * `{ url: null }`: logout must never be blocked by this best-effort step.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // Auth.js names the session cookie `__Secure-authjs.session-token` over
+    // https and `authjs.session-token` otherwise; getToken must be told which so
+    // it reads the right cookie. Detect from which one the request actually carries.
+    const secureCookie = request.cookies.has("__Secure-authjs.session-token")
+    const token = await getToken({
+      req: request,
+      secret: process.env.AUTH_SECRET,
+      secureCookie,
+    })
+
+    const idToken = typeof token?.id_token === "string" ? token.id_token : null
+    if (!idToken) {
+      return NextResponse.json({ url: null })
+    }
+
+    const base = process.env.AUTH_URL ?? new URL(request.url).origin
+    const postLogoutRedirectUri =
+      process.env.MYSTIRA_OIDC_POST_LOGOUT_REDIRECT_URI ?? new URL(base).origin
+
+    const endSessionEndpoint = await resolveEndSessionEndpoint(issuer)
+    const url = buildEndSessionUrl({ endSessionEndpoint, idToken, postLogoutRedirectUri })
+    return NextResponse.json({ url })
+  } catch (err) {
+    logger.error("Failed to build federated-logout URL", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return NextResponse.json({ url: null })
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,11 +7,32 @@ import { ArrowRight, Shield } from "lucide-react"
 import { useSearchParams } from "next/navigation"
 import { Suspense, useState } from "react"
 
+// Auth.js redirects a failed sign-in back to the configured sign-in page as
+// `/login?error=<code>`. Map the codes we can meaningfully act on to friendly
+// copy; anything else falls back to a generic message. `AccessDenied` is the
+// one users hit most here — it's what our `signIn` callback returns when the
+// Mystira identity is unverified or not present in the estate registry.
+const AUTH_ERROR_MESSAGES: Record<string, string> = {
+  AccessDenied:
+    "Your Mystira account isn't recognized by the estate registry. Contact an administrator to be granted access.",
+  Configuration: "Sign-in is temporarily unavailable. Please try again in a moment.",
+  Verification: "That sign-in link has expired. Please try signing in again.",
+  OAuthAccountNotLinked: "This email is already linked to a different sign-in method.",
+}
+const DEFAULT_AUTH_ERROR = "Sign-in failed. Please try again."
+
+function messageForErrorCode(code: string | null): string {
+  if (!code) return ""
+  return AUTH_ERROR_MESSAGES[code] ?? DEFAULT_AUTH_ERROR
+}
+
 function LoginPageContent() {
   const { isLoading: authLoading } = useAuth()
   const searchParams = useSearchParams()
   const [isSigningIn, setIsSigningIn] = useState(false)
-  const [error, setError] = useState("")
+  // Seed the error from the `?error=` code Auth.js appends on a failed sign-in
+  // redirect, so a rejected user sees why instead of a silent bounce to /login.
+  const [error, setError] = useState(() => messageForErrorCode(searchParams.get("error")))
 
   const callbackUrl = searchParams.get("redirect") ?? "/"
 

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -95,6 +95,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = useCallback(async () => {
     setUser(null)
     setRequiresAuth(true)
+    // Fetch the IdP RP-initiated-logout URL (built from the current session's
+    // id_token) BEFORE clearing the local cookie — signOut destroys the cookie
+    // the id_token lives in. With a URL, clear locally then hand off to Mystira
+    // so its SSO session ends too; otherwise fall back to a local-only sign-out.
+    let endSessionUrl: string | null = null
+    try {
+      const res = await fetch("/api/auth/federated-logout")
+      if (res.ok) {
+        const data = (await res.json()) as { url?: string | null }
+        endSessionUrl = data.url ?? null
+      }
+    } catch {
+      // Network hiccup — fall through to the local-only sign-out below.
+    }
+    if (endSessionUrl) {
+      await nextAuthSignOut({ redirect: false })
+      window.location.href = endSessionUrl
+      return
+    }
     await nextAuthSignOut({ callbackUrl: "/login" })
   }, [])
 

--- a/lib/auth/federated-logout.ts
+++ b/lib/auth/federated-logout.ts
@@ -1,0 +1,63 @@
+import { logger } from "@/lib/logger"
+
+// Discovery of the RP-initiated-logout endpoint is cached per issuer for the
+// life of the server process: it effectively never changes, and re-fetching on
+// every sign-out would add latency to a user-facing action.
+const endSessionEndpointCache = new Map<string, string>()
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "")
+}
+
+/**
+ * Resolve the IdP's RP-initiated-logout endpoint. Prefers the value advertised
+ * by OIDC discovery (`end_session_endpoint`); falls back to OpenIddict's
+ * conventional `/connect/endsession` path when discovery is unreachable or
+ * omits it (Mystira runs OpenIddict). Never throws — sign-out must degrade
+ * gracefully rather than fail on a discovery hiccup.
+ */
+export async function resolveEndSessionEndpoint(issuer: string): Promise<string> {
+  const cached = endSessionEndpointCache.get(issuer)
+  if (cached) return cached
+
+  const fallback = `${trimTrailingSlash(issuer)}/connect/endsession`
+  try {
+    const res = await fetch(`${trimTrailingSlash(issuer)}/.well-known/openid-configuration`, {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (res.ok) {
+      const doc = (await res.json()) as { end_session_endpoint?: unknown }
+      const endpoint =
+        typeof doc.end_session_endpoint === "string" ? doc.end_session_endpoint : fallback
+      endSessionEndpointCache.set(issuer, endpoint)
+      return endpoint
+    }
+    logger.warn("OIDC discovery for end_session_endpoint returned non-OK; using fallback", {
+      issuer,
+      status: res.status,
+    })
+  } catch (err) {
+    logger.warn("OIDC discovery for end_session_endpoint failed; using fallback", {
+      issuer,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+  return fallback
+}
+
+/**
+ * Build an RP-initiated-logout URL per the OIDC session-management spec:
+ * `end_session_endpoint?id_token_hint=…&post_logout_redirect_uri=…`. The
+ * `id_token_hint` lets the IdP identify and end the correct session; the
+ * `post_logout_redirect_uri` must be pre-registered at the IdP or it is ignored.
+ */
+export function buildEndSessionUrl(params: {
+  endSessionEndpoint: string
+  idToken: string
+  postLogoutRedirectUri: string
+}): string {
+  const url = new URL(params.endSessionEndpoint)
+  url.searchParams.set("id_token_hint", params.idToken)
+  url.searchParams.set("post_logout_redirect_uri", params.postLogoutRedirectUri)
+  return url.toString()
+}

--- a/lib/db/postgres.ts
+++ b/lib/db/postgres.ts
@@ -79,7 +79,6 @@ export async function ensureSchema(): Promise<void> {
           name TEXT NOT NULL,
           email TEXT NOT NULL UNIQUE,
           phone TEXT NOT NULL,
-          password_hash TEXT NOT NULL,
           role TEXT NOT NULL,
           description TEXT DEFAULT '',
           color TEXT DEFAULT 'gray',
@@ -91,6 +90,13 @@ export async function ensureSchema(): Promise<void> {
         CREATE INDEX IF NOT EXISTS idx_users_email ON users(LOWER(email));
         CREATE INDEX IF NOT EXISTS idx_users_phone ON users(phone);
       `)
+
+      // Legacy column drop: pre-OIDC databases created `users` with a NOT NULL
+      // `password_hash` column. The bcrypt+JWT auth it backed was fully removed
+      // in the Auth.js/Mystira OIDC migration, so the column is now dead weight
+      // (and its NOT NULL constraint blocks inserts that omit it). Idempotent —
+      // a no-op on fresh databases where the column was never created.
+      await client.query(`ALTER TABLE users DROP COLUMN IF EXISTS password_hash;`)
 
       await client.query(`
         CREATE TABLE IF NOT EXISTS file_uploads (

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -202,10 +202,10 @@ export async function findOrCreateOidcUserAsync(
   if (isPostgresConfigured()) {
     await ensureUsersSchemaOnce()
     await query(
-      `INSERT INTO users (id, name, email, phone, password_hash, role, description, color, icon, specialty)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      `INSERT INTO users (id, name, email, phone, role, description, color, icon, specialty)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
        ON CONFLICT (email) DO NOTHING`,
-      [user.id, user.name, user.email, user.phone, "", user.role, user.description, user.color, user.icon, user.specialty]
+      [user.id, user.name, user.email, user.phone, user.role, user.description, user.color, user.icon, user.specialty]
     )
     // Return the canonical persisted row so a concurrent create that won the
     // race (same email) yields the same account rather than a divergent object.
@@ -248,20 +248,17 @@ export async function seedUsersIfEmpty(): Promise<void> {
   const { rowCount } = await query("SELECT 1 FROM users LIMIT 1")
   if (rowCount > 0) return
 
-  // password_hash column still exists in legacy schema but is unused after
-  // the OIDC migration; seed with empty string until the column is dropped.
   await withClient(async (client) => {
     for (const user of Object.values(USERS)) {
       await client.query(
-        `INSERT INTO users (id, name, email, phone, password_hash, role, description, color, icon, specialty)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        `INSERT INTO users (id, name, email, phone, role, description, color, icon, specialty)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
          ON CONFLICT (id) DO NOTHING`,
         [
           user.id,
           user.name,
           user.email,
           user.phone,
-          "",
           user.role,
           user.description,
           user.color,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,18 @@
 import { defineConfig, devices } from "@playwright/test"
+import { loadEnvConfig } from "@next/env"
 
 process.env.E2E_TEST = "1"
+
+// Resolve AUTH_SECRET the same way the dev server (booted below) will — Next
+// loads .env.local via @next/env — so the session cookie the auth helper mints
+// (tests/e2e/helpers/auth.ts) decrypts with the identical key. Loading it here
+// pins the value into the inherited env before the server starts, guaranteeing
+// both sides agree whether or not a .env.local is present (e.g. CI has none, so
+// the fallback below applies on both sides). Keep the fallback in sync with the
+// helper.
+loadEnvConfig(process.cwd())
+process.env.AUTH_SECRET =
+  process.env.AUTH_SECRET ?? "e2e-insecure-test-secret-do-not-use-in-production"
 
 export default defineConfig({
   testDir: "./tests/e2e",

--- a/tests/api/audit.test.ts
+++ b/tests/api/audit.test.ts
@@ -4,7 +4,7 @@ import { GET, POST } from "@/app/api/audit/route"
 const adminHeaders = {
   "x-user-id": "hans",
   "x-user-role": "admin",
-  "x-user-email": "hans@houseofv.com",
+  "x-user-email": "smit.jurie@gmail.com",
 }
 
 const operatorHeaders = {

--- a/tests/api/auth-users.test.ts
+++ b/tests/api/auth-users.test.ts
@@ -25,7 +25,7 @@ describe("GET /api/auth/users", () => {
       headers: {
         "x-user-id": "hans",
         "x-user-role": "admin",
-        "x-user-email": "hans@houseofv.com",
+        "x-user-email": "smit.jurie@gmail.com",
       },
     })
     const response = await GET(request, {})

--- a/tests/api/budget.test.ts
+++ b/tests/api/budget.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/lib/services/baserow", () => ({
 const adminHeaders = {
   "x-user-id": "hans",
   "x-user-role": "admin",
-  "x-user-email": "hans@houseofv.com",
+  "x-user-email": "smit.jurie@gmail.com",
 }
 
 const operatorHeaders = {

--- a/tests/api/expenses.test.ts
+++ b/tests/api/expenses.test.ts
@@ -66,7 +66,7 @@ vi.mock("@/lib/services/baserow", () => {
 const adminHeaders = {
   "x-user-id": "hans",
   "x-user-role": "admin",
-  "x-user-email": "hans@houseofv.com",
+  "x-user-email": "smit.jurie@gmail.com",
 }
 
 describe("GET /api/expenses", () => {

--- a/tests/api/kiosk-requests.test.ts
+++ b/tests/api/kiosk-requests.test.ts
@@ -81,7 +81,7 @@ vi.mock("@/lib/db/kiosk-store", async (importOriginal) => {
 const adminHeaders = {
   "x-user-id": "hans",
   "x-user-role": "admin",
-  "x-user-email": "hans@houseofv.com",
+  "x-user-email": "smit.jurie@gmail.com",
 }
 
 describe("GET /api/kiosk/requests", () => {

--- a/tests/api/payroll.test.ts
+++ b/tests/api/payroll.test.ts
@@ -4,7 +4,7 @@ import { GET } from "@/app/api/payroll/route"
 const adminHeaders = {
   "x-user-id": "hans",
   "x-user-role": "admin",
-  "x-user-email": "hans@houseofv.com",
+  "x-user-email": "smit.jurie@gmail.com",
 }
 
 const operatorHeaders = {

--- a/tests/api/reports.test.ts
+++ b/tests/api/reports.test.ts
@@ -45,7 +45,7 @@ vi.mock("@/lib/services/baserow", () => {
 const adminHeaders = {
   "x-user-id": "hans",
   "x-user-role": "admin",
-  "x-user-email": "hans@houseofv.com",
+  "x-user-email": "smit.jurie@gmail.com",
 }
 
 const operatorHeaders = {

--- a/tests/api/stats.test.ts
+++ b/tests/api/stats.test.ts
@@ -13,7 +13,7 @@ describe("GET /api/stats", () => {
       headers: {
         "x-user-id": "hans",
         "x-user-role": "admin",
-        "x-user-email": "hans@houseofv.com",
+        "x-user-email": "smit.jurie@gmail.com",
       },
     })
     const response = await GET(request, {})

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/lib/workflows", () => ({ routeToInngest: vi.fn().mockResolvedValue(un
 const authHeaders = {
   "x-user-id": "hans",
   "x-user-role": "admin",
-  "x-user-email": "hans@houseofv.com",
+  "x-user-email": "smit.jurie@gmail.com",
 }
 
 describe("GET /api/tasks", () => {

--- a/tests/e2e/00-auth.spec.ts
+++ b/tests/e2e/00-auth.spec.ts
@@ -1,15 +1,19 @@
 import { test, expect } from "@playwright/test"
 import type { Page } from "@playwright/test"
+import { seedSession } from "./helpers/auth"
 
 const LOGIN_RENDER_TIMEOUT = 15000
 
 // The Auth.js v5 + Mystira OIDC migration (PR #62) removed the local
 // bcrypt/JWT password form. /login is now a single "Continue with Mystira"
-// button that redirects to the Mystira OIDC provider. Only the cases that
-// don't require completing a sign-in can run in CI; the credential round-trip
-// cases need a live (or mocked) Mystira IdP and are test.fixme()'d below —
-// tracked under baton 7ad9342d (browser sign-in flow) + /team-testing for
-// mocked-IdP OIDC E2E coverage.
+// button that redirects to the Mystira OIDC provider.
+//
+// The real OIDC handshake (browser -> IdP -> callback) needs a live/mocked
+// Mystira and stays out of CI. Everything downstream of the handshake — session
+// consumption, dashboard routing, sign-out, and the failed-sign-in error
+// surface — is covered here by seeding a valid Auth.js session cookie
+// (helpers/auth.ts) instead of driving the IdP. Full mocked-IdP handshake
+// coverage is tracked under baton 7ad9342d.
 async function waitForLoginButton(page: Page) {
   await expect(page.getByTestId("login-card")).toBeVisible({ timeout: LOGIN_RENDER_TIMEOUT })
   await expect(page.getByTestId("login-submit")).toBeVisible({ timeout: LOGIN_RENDER_TIMEOUT })
@@ -31,12 +35,44 @@ test.describe("Authentication", () => {
     await waitForLoginButton(page)
   })
 
-  // Round-trip auth requires a live/mocked Mystira OIDC provider — the local
-  // password flow these used to cover no longer exists. See baton 7ad9342d
-  // (next-action: browser sign-in against the live IdP) and /team-testing for
-  // OIDC E2E coverage with a mocked IdP (sign-in success per persona, sign-out,
-  // and the ?error= callback surface on the login page).
-  test.fixme("signs in via Mystira and lands on the matching dashboard", async () => {})
-  test.fixme("signs out and returns to the login page", async () => {})
-  test.fixme("surfaces OIDC auth errors on the login page", async () => {})
+  test("an authenticated session lands on the matching dashboard", async ({ context, page }) => {
+    await seedSession(context, { id: "hans", role: "admin", email: "smit.jurie@gmail.com" })
+    // From the public landing page, a recognized session is forwarded to its
+    // own dashboard rather than left on a page with no authenticated view.
+    await page.goto("/")
+    await page.waitForURL("**/dashboard/hans**", { timeout: LOGIN_RENDER_TIMEOUT })
+    // The authenticated shell renders the profile menu (two instances exist for
+    // the responsive desktop/mobile chrome — asserting one is present is enough).
+    await expect(page.getByTestId("user-profile-trigger").first()).toBeVisible({
+      timeout: LOGIN_RENDER_TIMEOUT,
+    })
+  })
+
+  test("signs out and returns to the login page", async ({ context, page }) => {
+    await seedSession(context, { id: "hans", role: "admin", email: "smit.jurie@gmail.com" })
+    await page.goto("/dashboard/hans")
+    await page.waitForURL("**/dashboard/hans**", { timeout: LOGIN_RENDER_TIMEOUT })
+
+    // Open the profile menu and sign out. The seeded session carries no
+    // id_token, so logout takes the local-only path (no IdP redirect).
+    await page.getByTestId("user-profile-trigger").first().click()
+    await page.getByTestId("header-logout").first().click()
+
+    await page.waitForURL("**/login**", { timeout: LOGIN_RENDER_TIMEOUT })
+    await waitForLoginButton(page)
+
+    // Session is gone: navigating back to a protected route bounces to /login.
+    await page.goto("/dashboard/hans")
+    await page.waitForURL("**/login**", { timeout: LOGIN_RENDER_TIMEOUT })
+  })
+
+  test("surfaces a rejected sign-in on the login page", async ({ page }) => {
+    // Auth.js redirects a failed sign-in to /login?error=<code>; AccessDenied is
+    // what our signIn callback returns for an unrecognized/unverified identity.
+    await page.goto("/login?error=AccessDenied")
+    await waitForLoginButton(page)
+    const errorBox = page.getByTestId("login-error")
+    await expect(errorBox).toBeVisible({ timeout: LOGIN_RENDER_TIMEOUT })
+    await expect(errorBox).toContainText("estate registry")
+  })
 })

--- a/tests/e2e/02-kiosk-approval.spec.ts
+++ b/tests/e2e/02-kiosk-approval.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test"
 const hansHeaders = {
   "x-user-id": "hans",
   "x-user-role": "admin",
-  "x-user-email": "hans@houseofv.com",
+  "x-user-email": "smit.jurie@gmail.com",
 }
 
 async function postKioskRequest(request: import("@playwright/test").APIRequestContext) {

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,0 +1,52 @@
+import { encode } from "next-auth/jwt"
+import type { BrowserContext } from "@playwright/test"
+
+// Shared with the dev server the E2E webServer boots — playwright.config.ts
+// pins AUTH_SECRET into process.env before spawning it, so the cookie we mint
+// here decrypts with the same key Auth.js uses to read it. Keep the fallback in
+// sync with playwright.config.ts.
+const AUTH_SECRET = process.env.AUTH_SECRET ?? "e2e-insecure-test-secret-do-not-use-in-production"
+
+// Non-secure cookie name (E2E runs over http://localhost). Auth.js uses the
+// cookie name as the JWE salt, so this must match on both encode and decode.
+const SESSION_COOKIE = "authjs.session-token"
+
+export type SeedUser = {
+  id: string
+  role: "admin" | "operator" | "resident" | "employee"
+  email: string
+  name?: string
+}
+
+/**
+ * Inject a valid Auth.js JWT-strategy session cookie for `user`, standing in for
+ * a completed Mystira OIDC round-trip. This exercises everything downstream of
+ * the handshake — session consumption in `proxy.ts`, dashboard routing, and
+ * sign-out — without needing a live or mocked IdP (the handshake itself belongs
+ * to a separate mocked-IdP integration test). The minted token carries no
+ * `id_token`, so sign-out takes the local-only path rather than an IdP redirect.
+ */
+export async function seedSession(context: BrowserContext, user: SeedUser): Promise<void> {
+  const value = await encode({
+    salt: SESSION_COOKIE,
+    secret: AUTH_SECRET,
+    token: {
+      sub: user.id,
+      userId: user.id,
+      role: user.role,
+      email: user.email,
+      name: user.name ?? user.id,
+    },
+  })
+
+  await context.addCookies([
+    {
+      name: SESSION_COOKIE,
+      value,
+      domain: "localhost",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+  ])
+}

--- a/tests/lib/federated-logout.test.ts
+++ b/tests/lib/federated-logout.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { buildEndSessionUrl, resolveEndSessionEndpoint } from "@/lib/auth/federated-logout"
+
+describe("buildEndSessionUrl", () => {
+  it("appends id_token_hint and post_logout_redirect_uri", () => {
+    const url = buildEndSessionUrl({
+      endSessionEndpoint: "https://idp.example.com/connect/endsession",
+      idToken: "the-id-token",
+      postLogoutRedirectUri: "https://app.example.com",
+    })
+    const parsed = new URL(url)
+    expect(parsed.origin + parsed.pathname).toBe("https://idp.example.com/connect/endsession")
+    expect(parsed.searchParams.get("id_token_hint")).toBe("the-id-token")
+    expect(parsed.searchParams.get("post_logout_redirect_uri")).toBe("https://app.example.com")
+  })
+
+  it("url-encodes the redirect uri", () => {
+    const url = buildEndSessionUrl({
+      endSessionEndpoint: "https://idp.example.com/connect/endsession",
+      idToken: "t",
+      postLogoutRedirectUri: "https://app.example.com/login?next=/dashboard",
+    })
+    // The raw query string must not contain an unencoded nested "?".
+    expect(url).toContain("post_logout_redirect_uri=https%3A%2F%2Fapp.example.com%2Flogin")
+    // ...but it round-trips back to the original value when parsed.
+    expect(new URL(url).searchParams.get("post_logout_redirect_uri")).toBe(
+      "https://app.example.com/login?next=/dashboard"
+    )
+  })
+
+  it("preserves an existing query string on the endpoint", () => {
+    const url = buildEndSessionUrl({
+      endSessionEndpoint: "https://idp.example.com/connect/endsession?foo=bar",
+      idToken: "t",
+      postLogoutRedirectUri: "https://app.example.com",
+    })
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get("foo")).toBe("bar")
+    expect(parsed.searchParams.get("id_token_hint")).toBe("t")
+  })
+})
+
+describe("resolveEndSessionEndpoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("uses the discovered end_session_endpoint when discovery succeeds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          end_session_endpoint: "https://idp.example.com/custom/logout",
+        }),
+      }))
+    )
+    // Unique issuer per test to avoid the module-level cache leaking across tests.
+    const endpoint = await resolveEndSessionEndpoint("https://discover-success.example.com")
+    expect(endpoint).toBe("https://idp.example.com/custom/logout")
+  })
+
+  it("falls back to /connect/endsession when discovery omits the field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({}) }))
+    )
+    const endpoint = await resolveEndSessionEndpoint("https://discover-nofield.example.com")
+    expect(endpoint).toBe("https://discover-nofield.example.com/connect/endsession")
+  })
+
+  it("falls back to /connect/endsession when discovery is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down")
+      })
+    )
+    const endpoint = await resolveEndSessionEndpoint("https://discover-fail.example.com")
+    expect(endpoint).toBe("https://discover-fail.example.com/connect/endsession")
+  })
+
+  it("trims a trailing slash from the issuer in the fallback path", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) }))
+    )
+    const endpoint = await resolveEndSessionEndpoint("https://discover-trailing.example.com/")
+    expect(endpoint).toBe("https://discover-trailing.example.com/connect/endsession")
+  })
+})

--- a/tests/lib/rbac.test.ts
+++ b/tests/lib/rbac.test.ts
@@ -24,13 +24,13 @@ describe("RBAC", () => {
       const req = makeRequest({
         "x-user-id": "hans",
         "x-user-role": "admin",
-        "x-user-email": "hans@houseofv.com",
+        "x-user-email": "smit.jurie@gmail.com",
       })
       const ctx = getAuthContext(req)
       expect(ctx).toMatchObject({
         userId: "hans",
         role: "admin",
-        email: "hans@houseofv.com",
+        email: "smit.jurie@gmail.com",
       })
       expect(Array.isArray(ctx?.responsibilities)).toBe(true)
     })
@@ -88,7 +88,7 @@ describe("RBAC", () => {
         makeRequest({
           "x-user-id": "hans",
           "x-user-role": "admin",
-          "x-user-email": "hans@houseofv.com",
+          "x-user-email": "smit.jurie@gmail.com",
         })
       )
       expect(res.status).toBe(200)
@@ -121,7 +121,7 @@ describe("RBAC", () => {
         makeRequest({
           "x-user-id": "hans",
           "x-user-role": "admin",
-          "x-user-email": "hans@houseofv.com",
+          "x-user-email": "smit.jurie@gmail.com",
         })
       )
       expect(res.status).toBe(200)


### PR DESCRIPTION
Cleans up the remaining follow-ups from the Auth.js v5 + Mystira OIDC migration (#62, #70, #71). Four self-contained changes, one commit each.

## 1. `feat(auth)` — RP-initiated logout
Sign-out only cleared the local Auth.js cookie, leaving the Mystira SSO session live (next "Continue with Mystira" click silently re-authenticated). Logout now performs OIDC RP-initiated logout: fetch the end-session URL (built from the session `id_token`) **before** `signOut` destroys the cookie, clear locally, then hand off to Mystira's `/connect/endsession`. Endpoint resolved via OIDC discovery with an OpenIddict fallback. Falls back to local-only sign-out on any error — logout never blocks.

## 2. `feat(auth)` — surface failed sign-in + OIDC E2E coverage
- Login page now maps Auth.js `?error=<code>` (e.g. `AccessDenied` from a rejected/unverified Mystira identity) to friendly copy, instead of a silent bounce.
- The three previously-`fixme`'d auth E2E cases are now implemented and passing, by seeding a valid Auth.js JWT session cookie to stand in for a completed OIDC round-trip (no live IdP needed). Full mocked-IdP handshake coverage stays tracked under baton `7ad9342d`.

## 3. `refactor(db)` — drop legacy `password_hash`
The bcrypt column has been dead weight since #62 and its `NOT NULL` constraint forced throwaway empty strings on every insert. Removed from `CREATE TABLE` + both inserts, with an idempotent `ALTER … DROP COLUMN IF EXISTS` for existing databases.

## 4. `test` — align `hans` fixtures with the OIDC seed
Active suite still fabricated `hans@houseofv.com`; the seed email is `smit.jurie@gmail.com`. Aligned the 11 Vitest/Playwright files. Left untouched: Baserow demo mock, Python backend password-login tests (separate migration), historical report artifacts, docs.

## Verification
- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors (2 pre-existing warnings in untouched files)
- Unit: **194/194 pass** (incl. 7 new federated-logout tests)
- Auth E2E: **5/5 pass**
- `next build` not run to green locally — blocked by a Windows-only `EBUSY` lock on `.next/standalone` at the pre-compile cleanup step (unrelated to these changes); CI's Linux runner is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)