### PR TITLE
fix: point nexamesh dns at shared zone group

### DIFF
--- a/docs/02-architecture/03-infrastructure.md
+++ b/docs/02-architecture/03-infrastructure.md
@@ -115,9 +115,9 @@ network ─────────────┬──────────
 
 | Record             | Type | Target                 | Zone                      |
 | ------------------ | ---- | ---------------------- | ------------------------- |
-| `docs.nexamesh.ai` | A    | Application Gateway IP | `nl-prod-nexamesh-rg-san` |
-| `ops.nexamesh.ai`  | A    | Application Gateway IP | `nl-prod-nexamesh-rg-san` |
-| `nexamesh.ai`      | A    | Application Gateway IP | `nl-prod-nexamesh-rg-san` |
+| `docs.nexamesh.ai` | A    | Application Gateway IP | `mys-global-shared-rg` |
+| `ops.nexamesh.ai`  | A    | Application Gateway IP | `mys-global-shared-rg` |
+| `nexamesh.ai`      | A    | Application Gateway IP | `mys-global-shared-rg` |
 
 ## Traffic Flow
 

--- a/docs/03-deployment/01-deployment-guide.md
+++ b/docs/03-deployment/01-deployment-guide.md
@@ -277,7 +277,7 @@ Resolve-DnsName ops.nexamesh.ai
 
 ### Azure DNS Zone
 
-The DNS zone `nexamesh.ai` is in resource group `nl-prod-nexamesh-rg-san`. Ensure the domain registrar's nameservers point to:
+The DNS zone `nexamesh.ai` is in resource group `mys-global-shared-rg`. Ensure the domain registrar's nameservers point to:
 
 - `ns1-09.azure-dns.com`
 - `ns2-09.azure-dns.net`
@@ -311,7 +311,7 @@ For DNS validation, add a TXT record via Azure DNS (or update `acme_challenge_va
 
 ```powershell
 az network dns record-set txt add-record `
-  --resource-group nl-prod-nexamesh-rg-san `
+  --resource-group mys-global-shared-rg `
   --zone-name nexamesh.ai `
   --record-set-name _acme-challenge `
   --value "<acme-challenge-value>"
@@ -660,7 +660,7 @@ az cognitiveservices account show `
 | `ssl_certificate_data`         | `""`                      | tfvars (sensitive, optional) |
 | `ssl_certificate_password`     | `""`                      | tfvars (sensitive, optional) |
 | `dns_zone_name`                | `nexamesh.ai`             | default                      |
-| `dns_zone_resource_group`      | `nl-prod-nexamesh-rg-san` | default                      |
+| `dns_zone_resource_group`      | `mys-global-shared-rg`    | default                      |
 | `document_intelligence_name`   | `nl-prod-hov-di-san`      | default                      |
 | `storage_account_name`         | `nlprodhovstsan`          | default                      |
 | `key_vault_name`               | `nl-prod-hov-kv-san`      | default                      |
@@ -717,7 +717,7 @@ az storage blob lease break `
 ```powershell
 # Verify Azure DNS records
 az network dns record-set a list `
-  --resource-group nl-prod-nexamesh-rg-san `
+  --resource-group mys-global-shared-rg `
   --zone-name nexamesh.ai `
   --output table
 

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -371,7 +371,7 @@ variable "dns_zone_name" {
 variable "dns_zone_resource_group" {
   description = "Resource group containing the DNS zone"
   type        = string
-  default     = "nl-prod-nexamesh-rg-san"
+  default     = "mys-global-shared-rg"
 }
 
 # SSL Certificate variables


### PR DESCRIPTION
## Summary
- update production Terraform default for nexamesh.ai DNS zone resource group to the actual Azure DNS resource group: mys-global-shared-rg
- update deployment and architecture docs that still referenced nl-prod-nexamesh-rg-san

## Validation
- terraform fmt -check -recursive
- terraform validate in terraform/environments/production
- git diff --check
- targeted operational-data plan regenerated successfully with DNS records reading nexamesh.ai from mys-global-shared-rg

## Remaining blocker for HTTPS-first op data deploy
- SSL_CERTIFICATE_DATA and SSL_CERTIFICATE_PASSWORD GitHub secrets are not configured
- Key Vault certificate list is blocked for this identity, so no existing PFX could be discovered
- Targeted plan remains HTTP-only until SSL certificate material is supplied