### PR TITLE
Move production Azure stack to canonical names

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -14,8 +14,8 @@ permissions:
   id-token: write
 
 env:
-  AZURE_RESOURCE_GROUP: "nl-prod-hov-rg-san"
-  AZURE_FUNCTIONAPP_NAME: "nl-prod-hov-func-san"
+  AZURE_RESOURCE_GROUP: "nl-prod-hov-rg"
+  AZURE_FUNCTIONAPP_NAME: "nl-prod-hov-func"
   PYTHON_VERSION: "3.11"
 
 jobs:

--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -29,7 +29,7 @@ permissions:
   id-token: write
 
 env:
-  AZURE_RESOURCE_GROUP: "nl-prod-hov-rg-san"
+  AZURE_RESOURCE_GROUP: "nl-prod-hov-rg"
   AZURE_ENV: "prod"
 
 jobs:
@@ -122,12 +122,12 @@ jobs:
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3
         with:
-          app-name: ${{ vars.WEBAPP_NAME || 'nl-prod-hov-app-san' }}
+          app-name: ${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}
           package: deploy.zip
 
       - name: Verify Web App Health
         run: |
-          APP_URL="https://${{ vars.WEBAPP_NAME || 'nl-prod-hov-app-san' }}.azurewebsites.net"
+          APP_URL="https://${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}.azurewebsites.net"
           healthy=false
           for i in {1..10}; do
             HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$APP_URL" || echo "000")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ permissions:
 
 env:
   WORKING_DIR: "./terraform/environments/production"
-  AZURE_RESOURCE_GROUP: "nl-prod-hov-rg-san"
+  AZURE_RESOURCE_GROUP: "nl-prod-hov-rg"
   AZURE_ENV: "prod"
 
 jobs:
@@ -252,7 +252,7 @@ jobs:
             -backend-config="resource_group_name=${{ secrets.TF_STATE_RESOURCE_GROUP }}" \
             -backend-config="storage_account_name=${{ secrets.TF_STATE_STORAGE_ACCOUNT }}" \
             -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER }}" \
-            -backend-config="key=${{ secrets.TF_STATE_KEY || 'production.terraform.tfstate' }}"
+            -backend-config="key=${{ secrets.TF_STATE_KEY || 'production-canonical.terraform.tfstate' }}"
 
       - name: Terraform Plan
         working-directory: ${{ env.WORKING_DIR }}
@@ -320,12 +320,12 @@ jobs:
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3
         with:
-          app-name: ${{ vars.WEBAPP_NAME || 'nl-prod-hov-app-san' }}
+          app-name: ${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}
           package: deploy.zip
 
       - name: Verify Web App Health
         run: |
-          APP_URL="https://${{ vars.WEBAPP_NAME || 'nl-prod-hov-app-san' }}.azurewebsites.net"
+          APP_URL="https://${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}.azurewebsites.net"
           healthy=false
           for i in {1..10}; do
             HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$APP_URL" || echo "000")
@@ -350,6 +350,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [deploy-infrastructure]
+    if: ${{ vars.ENABLE_OPERATIONAL_SERVICES == 'true' }}
     environment: ${{ inputs.environment || 'production' }}
 
     steps:
@@ -409,6 +410,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [deploy-infrastructure]
+    if: ${{ vars.ENABLE_OPERATIONAL_SERVICES == 'true' }}
     environment: ${{ inputs.environment || 'production' }}
 
     steps:
@@ -468,7 +470,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [deploy-baserow]
-    if: ${{ inputs.seed_data }}
+    if: ${{ inputs.seed_data && vars.ENABLE_OPERATIONAL_SERVICES == 'true' }}
     environment: ${{ inputs.environment || 'production' }}
 
     steps:

--- a/.github/workflows/deployment-checklist.yml
+++ b/.github/workflows/deployment-checklist.yml
@@ -19,7 +19,7 @@ permissions:
   issues: write
 
 env:
-  AZURE_RESOURCE_GROUP: "nl-prod-hov-rg-san"
+  AZURE_RESOURCE_GROUP: "nl-prod-hov-rg"
   AZURE_LOCATION: "southafricanorth"
   AZURE_ENV: "prod"
 

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -70,7 +70,7 @@ jobs:
             -backend-config="resource_group_name=${{ secrets.TF_STATE_RESOURCE_GROUP }}" \
             -backend-config="storage_account_name=${{ secrets.TF_STATE_STORAGE_ACCOUNT }}" \
             -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER }}" \
-            -backend-config="key=${{ secrets.TF_STATE_KEY || 'production.terraform.tfstate' }}"
+            -backend-config="key=${{ secrets.TF_STATE_KEY || 'production-canonical.terraform.tfstate' }}"
 
       - name: Terraform Plan
         working-directory: ${{ env.WORKING_DIR }}

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -63,7 +63,7 @@ jobs:
             -backend-config="resource_group_name=${{ secrets.TF_STATE_RESOURCE_GROUP }}" \
             -backend-config="storage_account_name=${{ secrets.TF_STATE_STORAGE_ACCOUNT }}" \
             -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER }}" \
-            -backend-config="key=${{ secrets.TF_STATE_KEY || 'production.terraform.tfstate' }}"
+            -backend-config="key=${{ secrets.TF_STATE_KEY || 'production-canonical.terraform.tfstate' }}"
 
       - name: Terraform Destroy
         working-directory: ${{ env.WORKING_DIR }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Terraform Init
         working-directory: ${{ env.WORKING_DIR }}
         env:
-          TF_STATE_KEY: ${{ secrets.TF_STATE_KEY || 'production.terraform.tfstate' }}
+          TF_STATE_KEY: ${{ secrets.TF_STATE_KEY || 'production-canonical.terraform.tfstate' }}
           TF_STATE_RESOURCE_GROUP: ${{ secrets.TF_STATE_RESOURCE_GROUP }}
           TF_STATE_STORAGE_ACCOUNT: ${{ secrets.TF_STATE_STORAGE_ACCOUNT }}
           TF_STATE_CONTAINER: ${{ secrets.TF_STATE_CONTAINER }}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { isBaserowConfigured } from "@/lib/services/baserow"
+import { isDocuSealConfigured } from "@/lib/services/docuseal"
 
 async function checkService(
   name: string,
@@ -28,12 +29,16 @@ export async function GET() {
   const checks = await Promise.all([
     checkService(
       "baserow",
-      serviceBaseUrl(process.env.BASEROW_API_URL || process.env.NEXT_PUBLIC_BASEROW_URL),
+      isBaserowConfigured()
+        ? serviceBaseUrl(process.env.BASEROW_API_URL || process.env.NEXT_PUBLIC_BASEROW_URL)
+        : undefined,
       "/api/_health/"
     ),
     checkService(
       "docuseal",
-      serviceBaseUrl(process.env.NEXT_PUBLIC_DOCUSEAL_URL || process.env.DOCUSEAL_API_URL),
+      isDocuSealConfigured()
+        ? serviceBaseUrl(process.env.NEXT_PUBLIC_DOCUSEAL_URL || process.env.DOCUSEAL_API_URL)
+        : undefined,
       "/health"
     ),
   ])

--- a/config/scripts/add-github-actions-ips-to-azure.sh
+++ b/config/scripts/add-github-actions-ips-to-azure.sh
@@ -9,8 +9,8 @@
 
 set -e
 
-KV_NAME="${TF_KEY_VAULT_NAME:-nl-prod-hov-kv-san}"
-SA_NAME="${TF_STORAGE_ACCOUNT_NAME:-nlprodhovstsan}"
+KV_NAME="${TF_KEY_VAULT_NAME:-nl-prod-hov-kv}"
+SA_NAME="${TF_STORAGE_ACCOUNT_NAME:-nlprodhovst}"
 DRY_RUN=false
 
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true

--- a/config/scripts/bootstrap-azure.sh
+++ b/config/scripts/bootstrap-azure.sh
@@ -17,7 +17,7 @@
 #   - TF_STATE_RESOURCE_GROUP
 #   - TF_STATE_STORAGE_ACCOUNT
 #   - TF_STATE_CONTAINER
-#   - TF_STATE_KEY             (production.terraform.tfstate)
+#   - TF_STATE_KEY             (production-canonical.terraform.tfstate)
 #   - DB_ADMIN_PASSWORD        (random 24-char value — also printed once at end)
 #
 # Run interactively from a shell where you can `az login` and `gh auth login`:
@@ -52,7 +52,7 @@ TF_RG="${TF_RG:-hov-shared-tfstate-rg}"
 TF_STORAGE="${TF_STORAGE:-hovsharedtfstatesa}"
 TF_CONTAINER="${TF_CONTAINER:-tfstate}"
 TF_LOCATION="${TF_LOCATION:-southafricanorth}"
-TF_STATE_KEY="${TF_STATE_KEY:-production.terraform.tfstate}"
+TF_STATE_KEY="${TF_STATE_KEY:-production-canonical.terraform.tfstate}"
 REPO="${REPO:-neuralliquid/house-of-veritas}"
 
 # ── Sanity checks ────────────────────────────────────────────────────────────

--- a/config/scripts/deployment-checklist.py
+++ b/config/scripts/deployment-checklist.py
@@ -83,21 +83,22 @@ class DeploymentChecker:
         
         # Configuration
         self.subscription_id = os.environ.get("AZURE_SUBSCRIPTION_ID", "")
-        self.resource_group = os.environ.get("AZURE_RESOURCE_GROUP", "nl-prod-hov-rg-san")
+        self.resource_group = os.environ.get("AZURE_RESOURCE_GROUP", "nl-prod-hov-rg")
         self.location = os.environ.get("AZURE_LOCATION", "southafricanorth")
         self.env = os.environ.get("AZURE_ENV", "prod")
-        
-        # Naming convention: nl-{env}-hov-{resourcetype}-san
-        # Expected resources with new naming convention
+        self.enable_operational_services = os.environ.get("ENABLE_OPERATIONAL_SERVICES", "false").lower() == "true"
+        self.enable_application_gateway = os.environ.get("ENABLE_APPLICATION_GATEWAY", "false").lower() == "true"
+
+        # Naming convention: nl-{env}-hov-{resourcetype}
         self.expected_resources = {
-            "vnet": f"nl-{self.env}-hov-vnet-san",
-            "postgres": f"nl-{self.env}-hov-pg-san",
-            "storage": f"nl{self.env}hovstsan",  # Storage accounts can't have hyphens
-            "keyvault": f"nl-{self.env}-hov-kv-san",
-            "appgateway": f"nl-{self.env}-hov-agw-san",
-            "docuseal": f"nl-{self.env}-hov-aci-docuseal-san",
-            "baserow": f"nl-{self.env}-hov-aci-baserow-san",
-            "functionapp": f"nl-{self.env}-hov-func-san",
+            "vnet": f"nl-{self.env}-hov-vnet",
+            "postgres": f"nl-{self.env}-hov-pg",
+            "storage": f"nl{self.env}hovst",  # Storage accounts can't have hyphens
+            "keyvault": f"nl-{self.env}-hov-kv",
+            "appgateway": f"nl-{self.env}-hov-agw",
+            "docuseal": f"{self.env}-docuseal",
+            "baserow": f"{self.env}-baserow",
+            "functionapp": f"nl-{self.env}-hov-func",
         }
     
     def run_command(self, command: List[str], capture_output: bool = True) -> tuple:
@@ -731,12 +732,19 @@ class DeploymentChecker:
             name="Application Services",
             description="DocuSeal and Baserow containers"
         )
-        services.checks.append(self.check_container_instance(
-            self.expected_resources["docuseal"], "DocuSeal"
-        ))
-        services.checks.append(self.check_container_instance(
-            self.expected_resources["baserow"], "Baserow"
-        ))
+        if self.enable_operational_services:
+            services.checks.append(self.check_container_instance(
+                self.expected_resources["docuseal"], "DocuSeal"
+            ))
+            services.checks.append(self.check_container_instance(
+                self.expected_resources["baserow"], "Baserow"
+            ))
+        else:
+            services.checks.append(CheckResult(
+                name="Operational Services",
+                status=Status.SKIP,
+                message="DocuSeal and Baserow containers are disabled for the low-usage canonical stack"
+            ))
         self.categories.append(services)
         
         # Category 4: Networking & Security
@@ -744,9 +752,21 @@ class DeploymentChecker:
             name="Networking & Security",
             description="Gateway, DNS, and SSL"
         )
-        networking.checks.append(self.check_app_gateway())
-        networking.checks.append(self.check_dns())
-        networking.checks.append(self.check_ssl_certificates())
+        if self.enable_application_gateway:
+            networking.checks.append(self.check_app_gateway())
+            networking.checks.append(self.check_dns())
+            networking.checks.append(self.check_ssl_certificates())
+        else:
+            networking.checks.append(CheckResult(
+                name="Application Gateway",
+                status=Status.SKIP,
+                message="Application Gateway WAF is disabled for the low-usage canonical stack"
+            ))
+            networking.checks.append(CheckResult(
+                name="DNS/SSL for Ops Services",
+                status=Status.SKIP,
+                message="docs/ops DNS and gateway SSL checks are skipped until operational services are enabled"
+            ))
         self.categories.append(networking)
 
         if not json_only:

--- a/docs/02-architecture/02-naming-convention.md
+++ b/docs/02-architecture/02-naming-convention.md
@@ -3,7 +3,7 @@
 ## Naming Pattern
 
 ```text
-nl-{env}-hov-{resourcetype}-{location}
+nl-{env}-hov-{resourcetype}
 ```
 
 ### Components
@@ -14,32 +14,32 @@ nl-{env}-hov-{resourcetype}-{location}
 | `{env}`          | Environment                | `prod`, `dev`, `staging`   |
 | `hov`            | Project Code               | House of Veritas           |
 | `{resourcetype}` | Resource type abbreviation | See below                  |
-| `{location}`     | Azure region short code    | `san` (South Africa North) |
+| `{location}`     | Azure region short code    | Deprecated for production resource names |
 
 ### Resource Type Abbreviations
 
 | Resource               | Abbreviation | Example                           |
 | ---------------------- | ------------ | --------------------------------- |
-| Resource Group         | `rg`         | `nl-prod-hov-rg-san`              |
-| Virtual Network        | `vnet`       | `nl-prod-hov-vnet-san`            |
-| Subnet                 | `snet`       | `nl-prod-hov-snet-containers-san` |
-| Network Security Group | `nsg`        | `nl-prod-hov-nsg-san`             |
-| Storage Account        | `st`         | `nlprodhovstsan` (no hyphens)     |
-| Key Vault              | `kv`         | `nl-prod-hov-kv-san`              |
-| PostgreSQL Server      | `pg`         | `nl-prod-hov-pg-san`              |
-| Container Instance     | `aci`        | `nl-prod-hov-aci-docuseal-san`    |
-| Application Gateway    | `agw`        | `nl-prod-hov-agw-san`             |
-| Function App           | `func`       | `nl-prod-hov-func-san`            |
+| Resource Group         | `rg`         | `nl-prod-hov-rg`                  |
+| Virtual Network        | `vnet`       | `nl-prod-hov-vnet`                |
+| Subnet                 | `snet`       | `nl-prod-hov-snet-containers`     |
+| Network Security Group | `nsg`        | `nl-prod-hov-nsg`                 |
+| Storage Account        | `st`         | `nlprodhovst` (no hyphens)        |
+| Key Vault              | `kv`         | `nl-prod-hov-kv`                  |
+| PostgreSQL Server      | `pg`         | `nl-prod-hov-pg`                  |
+| Container Instance     | `aci`        | `nl-prod-hov-aci-docuseal`        |
+| Application Gateway    | `agw`        | `nl-prod-hov-agw`                 |
+| Function App           | `func`       | `nl-prod-hov-func`                |
 | Container Registry     | `cr`         | `nlprodhovcr` (no hyphens)        |
-| Public IP              | `pip`        | `nl-prod-hov-pip-agw-san`         |
-| Log Analytics          | `log`        | `nl-prod-hov-log-san`             |
-| App Insights           | `appi`       | `nl-prod-hov-appi-san`            |
+| Public IP              | `pip`        | `nl-prod-hov-pip-agw`             |
+| Log Analytics          | `log`        | `nl-prod-hov-log`                 |
+| App Insights           | `appi`       | `nl-prod-hov-appi`                |
 
 ### Special Cases
 
 Some Azure resources don't allow hyphens in names:
 
-- **Storage Accounts**: `nlprodhovstsan` (concatenated)
+- **Storage Accounts**: `nlprodhovst` (concatenated)
 - **Container Registry**: `nlprodhovcr` (concatenated)
 
 ### Location Codes
@@ -52,31 +52,35 @@ Some Azure resources don't allow hyphens in names:
 | East US            | `eus`      |
 | West US            | `wus`      |
 
+Region suffixes such as `-san` are retained only for legacy resources created
+before the canonical naming migration. New production resources should omit the
+region suffix.
+
 ## Resource Inventory
 
 ### Production Environment (`prod`)
 
 | Resource           | Name                           | Purpose                  |
 | ------------------ | ------------------------------ | ------------------------ |
-| Resource Group     | `nl-prod-hov-rg-san`           | All production resources |
-| Virtual Network    | `nl-prod-hov-vnet-san`         | Network isolation        |
-| PostgreSQL         | `nl-prod-hov-pg-san`           | Database server          |
-| Storage Account    | `nlprodhovstsan`               | Document/backup storage  |
-| Key Vault          | `nl-prod-hov-kv-san`           | Secrets management       |
-| App Gateway        | `nl-prod-hov-agw-san`          | Load balancer/WAF        |
-| DocuSeal Container | `nl-prod-hov-aci-docuseal-san` | Document signing         |
-| Baserow Container  | `nl-prod-hov-aci-baserow-san`  | Operations data          |
-| Function App       | `nl-prod-hov-func-san`         | Automation functions     |
+| Resource Group     | `nl-prod-hov-rg`               | All production resources |
+| Virtual Network    | `nl-prod-hov-vnet`             | Network isolation        |
+| PostgreSQL         | `nl-prod-hov-pg`               | Database server          |
+| Storage Account    | `nlprodhovst`                  | Document/backup storage  |
+| Key Vault          | `nl-prod-hov-kv`               | Secrets management       |
+| App Gateway        | `nl-prod-hov-agw`              | Load balancer/WAF        |
+| DocuSeal Container | `nl-prod-hov-aci-docuseal`     | Document signing         |
+| Baserow Container  | `nl-prod-hov-aci-baserow`      | Operations data          |
+| Function App       | `nl-prod-hov-func`             | Automation functions     |
 
 ### Development Environment (`dev`)
 
 | Resource        | Name                  | Purpose                 |
 | --------------- | --------------------- | ----------------------- |
-| Resource Group  | `nl-dev-hov-rg-san`   | Development resources   |
-| Virtual Network | `nl-dev-hov-vnet-san` | Network isolation       |
-| PostgreSQL      | `nl-dev-hov-pg-san`   | Database server         |
-| Storage Account | `nldevhovstsan`       | Document/backup storage |
-| Key Vault       | `nl-dev-hov-kv-san`   | Secrets management      |
+| Resource Group  | `nl-dev-hov-rg`       | Development resources   |
+| Virtual Network | `nl-dev-hov-vnet`     | Network isolation       |
+| PostgreSQL      | `nl-dev-hov-pg`       | Database server         |
+| Storage Account | `nldevhovst`          | Document/backup storage |
+| Key Vault       | `nl-dev-hov-kv`       | Secrets management      |
 
 ## Tags
 
@@ -98,10 +102,10 @@ Update these in your configuration:
 
 ```bash
 # .env or GitHub Secrets
-AZURE_RESOURCE_GROUP=nl-prod-hov-rg-san
-AZURE_KEY_VAULT_NAME=nl-prod-hov-kv-san
-AZURE_STORAGE_ACCOUNT=nlprodhovstsan
-AZURE_FUNCTION_APP=nl-prod-hov-func-san
+AZURE_RESOURCE_GROUP=nl-prod-hov-rg
+AZURE_KEY_VAULT_NAME=nl-prod-hov-kv
+AZURE_STORAGE_ACCOUNT=nlprodhovst
+AZURE_FUNCTION_APP=nl-prod-hov-func
 AZURE_ENV=prod
 AZURE_LOCATION=southafricanorth
 ```
@@ -115,17 +119,17 @@ variable "environment" {
 }
 
 variable "location_short" {
-  default = "san"
+  default = ""
 }
 
 # locals.tf
 locals {
   name_prefix = "nl-${var.environment}-hov"
 
-  resource_group_name = "${local.name_prefix}-rg-${var.location_short}"
-  vnet_name           = "${local.name_prefix}-vnet-${var.location_short}"
-  keyvault_name       = "${local.name_prefix}-kv-${var.location_short}"
-  postgres_name       = "${local.name_prefix}-pg-${var.location_short}"
-  storage_name        = "nl${var.environment}hovst${var.location_short}"
+  resource_group_name = "${local.name_prefix}-rg"
+  vnet_name           = "${local.name_prefix}-vnet"
+  keyvault_name       = "${local.name_prefix}-kv"
+  postgres_name       = "${local.name_prefix}-pg"
+  storage_name        = "nl${var.environment}hovst"
 }
 ```

--- a/docs/03-deployment/07-canonical-azure-naming-migration.md
+++ b/docs/03-deployment/07-canonical-azure-naming-migration.md
@@ -1,0 +1,97 @@
+# Canonical Azure Naming Migration
+
+House of Veritas is moving away from region-suffixed Azure resource names such
+as `nl-prod-hov-rg-san`. The canonical production names remove the region code:
+
+| Resource | Current | Canonical |
+| --- | --- | --- |
+| Resource group | `nl-prod-hov-rg-san` | `nl-prod-hov-rg` |
+| Virtual network | `nl-prod-hov-vnet-san` | `nl-prod-hov-vnet` |
+| Storage account | `nlprodhovstsan` | `nlprodhovst` |
+| Key Vault | `nl-prod-hov-kv-san` | `nl-prod-hov-kv` |
+| PostgreSQL | `nl-prod-hov-pg-san` | `nl-prod-hov-pg` |
+| Cosmos DB | `nlprodhovcosmosan` | `nlprodhovcosmos` |
+| Document Intelligence | `nl-prod-hov-di-san` | `nl-prod-hov-di` |
+| Web App | `nl-prod-hov-app-san` | `nl-prod-hov-app` |
+| Function App | `nl-prod-hov-func-san` | `nl-prod-hov-func` |
+
+## Required Approach
+
+Azure cannot rename most of these resources in place. In Terraform, changing
+these names against the existing production state will plan replacements and can
+destroy or orphan live infrastructure. Use a parallel canonical stack instead:
+
+1. Keep the existing `-san` stack untouched and serving production.
+2. Create a separate canonical Terraform state key for the canonical stack.
+3. Apply the canonical stack using
+   `terraform/environments/production/canonical.tfvars.example` as the template.
+4. Deploy the app to the canonical Web App and Function App.
+5. Bring up operational data services under canonical infrastructure.
+6. Smoke-check canonical endpoints and health.
+7. Cut over DNS and GitHub Actions variables to canonical names.
+8. Retire the `-san` stack only after backups and validation are complete.
+
+## Low-Usage Cost Target
+
+Current expected use is about four users, twice per day each. The production
+stack should optimize for idle cost first.
+
+Current `-san` spend from Azure Cost Management for 2026-06-10 through
+2026-07-10 was about `$33.52`, almost entirely Cosmos DB:
+
+| Service | Cost |
+| --- | ---: |
+| Azure Cosmos DB | `$33.51` |
+| Azure App Service | `$0.01` |
+| Key Vault and Storage | `<$0.01` |
+
+The previously planned operational-data target was too expensive for this usage
+level because it included WAF_v2 Application Gateway and two always-on Azure
+Container Instances. That shape would likely idle around `$630-$700/month`.
+
+Use this cheaper target instead:
+
+| Area | Low-usage decision | Monthly target |
+| --- | --- | ---: |
+| Edge/WAF | Do not deploy Application Gateway WAF_v2 yet | save about `$380+` |
+| Baserow/DocuSeal | Prefer scale-to-zero hosting before production cutover | save most idle compute |
+| Cosmos DB | Remove if kiosk data can move to Postgres/Baserow; otherwise use free tier | save about `$33` |
+| Functions | Prefer Consumption plan or fold jobs into app until volume justifies B1 | save about `$14` |
+| Storage | Use LRS until backup/DR policy requires GRS | small saving |
+
+Practical goal for the canonical stack: keep idle/low-usage spend around
+`$50-$120/month`, not `$600+`.
+
+## Do Not Do
+
+- Do not pass canonical names to the existing `-san` state and run a broad
+  `terraform apply`.
+- Do not destroy the `-san` resource group until the canonical stack has served
+  production traffic and backups have been verified.
+- Do not enable operational data in the app before Baserow and DocuSeal have
+  real API keys and table IDs configured.
+
+## Terraform Notes
+
+The canonical tfvars template documents the low-usage profile now used by the
+production defaults. The repository deployment workflows target canonical names
+and default to the `production-canonical.terraform.tfstate` backend key.
+
+Use a distinct backend key for the canonical state, for example:
+
+```powershell
+terraform init -reconfigure `
+  -backend-config="resource_group_name=hov-shared-tfstate-rg" `
+  -backend-config="storage_account_name=hovsharedtfstatesa" `
+  -backend-config="container_name=tfstate" `
+  -backend-config="key=house-of-veritas-prod-canonical.tfstate"
+```
+
+Then plan with copied, secret-filled tfvars:
+
+```powershell
+terraform plan -no-color `
+  -var-file="canonical.tfvars" `
+  -var="ssl_certificate_data=$env:SSL_CERTIFICATE_DATA" `
+  -var="ssl_certificate_password=$env:SSL_CERTIFICATE_PASSWORD"
+```

--- a/terraform/environments/production/backend.hcl
+++ b/terraform/environments/production/backend.hcl
@@ -4,4 +4,4 @@
 resource_group_name  = "hov-shared-tfstate-rg"
 storage_account_name = "hovsharedtfstatesa"
 container_name       = "tfstate"
-key                  = "production.terraform.tfstate"
+key                  = "production-canonical.terraform.tfstate"

--- a/terraform/environments/production/canonical.tfvars.example
+++ b/terraform/environments/production/canonical.tfvars.example
@@ -1,0 +1,57 @@
+# House of Veritas - Production Canonical Naming
+#
+# Use this only for a new canonical production stack or a deliberate migration
+# plan. Do not pass this file against the existing -san Terraform state unless
+# the plan has been reviewed for replacements.
+#
+# Low-usage target: 4 household users, roughly twice per day each. Keep the
+# canonical stack cheap by avoiding WAF_v2 Application Gateway and always-on
+# operational containers unless those modules are explicitly refactored for
+# scale-to-zero hosting.
+
+domain_name = "nexamesh.ai"
+
+# Canonical names remove the Azure region suffix from resource names.
+resource_group_name = "nl-prod-hov-rg"
+vnet_name           = "nl-prod-hov-vnet"
+
+storage_account_name             = "nlprodhovst"
+storage_account_replication_type = "LRS"
+storage_network_default_action   = "Allow"
+key_vault_name                   = "nl-prod-hov-kv"
+key_vault_network_default_action = "Allow"
+db_server_name                   = "nl-prod-hov-pg"
+cosmos_account_name              = "nlprodhovcosmos"
+document_intelligence_name       = "nl-prod-hov-di"
+web_app_name                     = "nl-prod-hov-app"
+function_app_name                = "nl-prod-hov-func"
+functions_storage_account_name   = "nlprodhovfuncst"
+
+# Keep only if the kiosk workflow still needs Cosmos. Prefer migrating kiosk
+# data into Postgres/Baserow; otherwise use the subscription's Cosmos free tier.
+cosmos_enable_free_tier = true
+
+# Cost-control switches for the initial canonical stack.
+enable_cosmos_mongo          = false
+enable_database              = false
+enable_operational_services  = false
+enable_application_gateway   = false
+enable_dns_records           = false
+enable_functions             = false
+enable_monitoring            = false
+enable_document_intelligence = false
+
+# These variables are currently kept for compatibility. The compute and
+# gateway modules derive live names internally as prod-docuseal, prod-baserow,
+# and prod-appgw.
+docuseal_container_name = "nl-prod-hov-aci-docuseal"
+baserow_container_name  = "nl-prod-hov-aci-baserow"
+app_gateway_name        = "nl-prod-hov-agw"
+
+# Required secret values must be supplied by secure automation or a local
+# untracked tfvars file.
+db_admin_password = "REPLACE_WITH_DB_ADMIN_PASSWORD"
+smtp_password     = "REPLACE_WITH_SMTP_PASSWORD"
+
+# Optional deployer firewall opening for one-off local Terraform runs.
+deployer_ip = ""

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -61,13 +61,15 @@ module "network" {
 module "storage" {
   source = "../../modules/storage"
 
-  resource_group_name   = azurerm_resource_group.main.name
-  location              = azurerm_resource_group.main.location
-  storage_account_name  = var.storage_account_name
-  container_subnet_id   = module.network.container_subnet_id
-  database_subnet_id    = module.network.database_subnet_id
-  runner_subnet_id      = module.network.runner_subnet_id
-  deployer_ip_addresses = local.ci_ip_rules_storage
+  resource_group_name      = azurerm_resource_group.main.name
+  location                 = azurerm_resource_group.main.location
+  storage_account_name     = var.storage_account_name
+  account_replication_type = var.storage_account_replication_type
+  network_default_action   = var.storage_network_default_action
+  container_subnet_id      = module.network.container_subnet_id
+  database_subnet_id       = module.network.database_subnet_id
+  runner_subnet_id         = module.network.runner_subnet_id
+  deployer_ip_addresses    = local.ci_ip_rules_storage
 
   tags = local.common_tags
 }
@@ -76,16 +78,17 @@ module "storage" {
 module "security" {
   source = "../../modules/security"
 
-  resource_group_name   = azurerm_resource_group.main.name
-  location              = azurerm_resource_group.main.location
-  key_vault_name        = var.key_vault_name
-  container_subnet_id   = module.network.container_subnet_id
-  runner_subnet_id      = module.network.runner_subnet_id
-  deployer_ip_addresses = local.ci_ip_rules_keyvault
-  db_admin_password     = var.db_admin_password
-  docuseal_secret_key   = random_password.docuseal_secret.result
-  baserow_secret_key    = random_password.baserow_secret.result
-  smtp_password         = var.smtp_password
+  resource_group_name    = azurerm_resource_group.main.name
+  location               = azurerm_resource_group.main.location
+  key_vault_name         = var.key_vault_name
+  network_default_action = var.key_vault_network_default_action
+  container_subnet_id    = module.network.container_subnet_id
+  runner_subnet_id       = module.network.runner_subnet_id
+  deployer_ip_addresses  = local.ci_ip_rules_keyvault
+  db_admin_password      = var.db_admin_password
+  docuseal_secret_key    = random_password.docuseal_secret.result
+  baserow_secret_key     = random_password.baserow_secret.result
+  smtp_password          = var.smtp_password
 
   tags = local.common_tags
 }
@@ -93,6 +96,7 @@ module "security" {
 # Database Module
 module "database" {
   source = "../../modules/database"
+  count  = var.enable_database ? 1 : 0
 
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -109,6 +113,7 @@ module "database" {
 
 module "cosmos_mongo" {
   source = "../../modules/cosmosdb-mongo"
+  count  = var.enable_cosmos_mongo ? 1 : 0
 
   resource_group_name           = azurerm_resource_group.main.name
   location                      = azurerm_resource_group.main.location
@@ -127,6 +132,7 @@ module "cosmos_mongo" {
 # Compute Module (Container Instances)
 module "compute" {
   source = "../../modules/compute"
+  count  = var.enable_operational_services && var.enable_database ? 1 : 0
 
   resource_group_name   = azurerm_resource_group.main.name
   location              = azurerm_resource_group.main.location
@@ -136,9 +142,9 @@ module "compute" {
   storage_account_key   = module.storage.primary_access_key
   key_vault_id          = module.security.key_vault_id
   domain_name           = var.domain_name
-  docuseal_database_url = module.database.connection_string_docuseal
+  docuseal_database_url = module.database[0].connection_string_docuseal
   docuseal_secret_key   = random_password.docuseal_secret.result
-  baserow_database_url  = module.database.connection_string_baserow
+  baserow_database_url  = module.database[0].connection_string_baserow
   baserow_secret_key    = random_password.baserow_secret.result
   smtp_host             = var.smtp_host
   smtp_port             = var.smtp_port
@@ -153,14 +159,15 @@ module "compute" {
 # Gateway Module (Application Gateway)
 module "gateway" {
   source = "../../modules/gateway"
+  count  = var.enable_application_gateway && var.enable_operational_services ? 1 : 0
 
   resource_group_name      = azurerm_resource_group.main.name
   location                 = azurerm_resource_group.main.location
   environment              = var.environment
   gateway_subnet_id        = module.network.gateway_subnet_id
   domain_name              = var.domain_name
-  docuseal_ip_address      = module.compute.docuseal_ip_address
-  baserow_ip_address       = module.compute.baserow_ip_address
+  docuseal_ip_address      = module.compute[0].docuseal_ip_address
+  baserow_ip_address       = module.compute[0].baserow_ip_address
   ssl_certificate_data     = var.ssl_certificate_data
   ssl_certificate_password = var.ssl_certificate_password
 
@@ -172,6 +179,7 @@ module "gateway" {
 # Cognitive Services Module (Document Intelligence / OCR)
 module "cognitive" {
   source = "../../modules/cognitive"
+  count  = var.enable_document_intelligence ? 1 : 0
 
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -183,6 +191,7 @@ module "cognitive" {
 # Functions Module (Azure Function App for automation)
 module "functions" {
   source = "../../modules/functions"
+  count  = var.enable_functions ? 1 : 0
 
   resource_group_name            = azurerm_resource_group.main.name
   location                       = azurerm_resource_group.main.location
@@ -241,25 +250,26 @@ module "webapp" {
   baserow_table_contractor_contracts = var.baserow_table_contractor_contracts
   baserow_table_insurance_claims     = var.baserow_table_insurance_claims
   docuseal_api_key                   = var.docuseal_api_key
-  document_intelligence_endpoint     = module.cognitive.endpoint
-  document_intelligence_key          = module.cognitive.primary_access_key
+  document_intelligence_endpoint     = try(module.cognitive[0].endpoint, "")
+  document_intelligence_key          = try(module.cognitive[0].primary_access_key, "")
   extra_app_settings = {
-    MONGODB_URI = module.cosmos_mongo.mongo_connection_string
-    DB_NAME     = module.cosmos_mongo.mongo_database_name
+    MONGODB_URI = try(module.cosmos_mongo[0].mongo_connection_string, "")
+    DB_NAME     = try(module.cosmos_mongo[0].mongo_database_name, "")
   }
 
   tags = local.common_tags
 
-  depends_on = [module.network, module.storage, module.security, module.cognitive, module.cosmos_mongo]
+  depends_on = [module.network, module.storage, module.security]
 }
 
 # DNS Module (Azure DNS records for nexamesh.ai)
 module "dns" {
   source = "../../modules/dns"
+  count  = var.enable_dns_records && var.enable_application_gateway && var.enable_operational_services ? 1 : 0
 
   dns_zone_name           = var.dns_zone_name
   dns_zone_resource_group = var.dns_zone_resource_group
-  gateway_public_ip       = module.gateway.public_ip_address
+  gateway_public_ip       = module.gateway[0].public_ip_address
   create_root_record      = true
 
   tags = local.common_tags
@@ -272,15 +282,16 @@ module "dns" {
 # Monitoring Module (alerts, budgets, Log Analytics)
 module "monitoring" {
   source = "../../modules/monitoring"
+  count  = var.enable_monitoring && var.enable_functions ? 1 : 0
 
   resource_group_name       = azurerm_resource_group.main.name
   resource_group_id         = azurerm_resource_group.main.id
   location                  = azurerm_resource_group.main.location
   workspace_name            = "${var.project_prefix}-${var.environment}-${var.project_name}-law-${var.location_short}"
   alert_email               = "hans@nexamesh.ai"
-  database_server_id        = module.database.server_id
-  enable_database_alerts    = true
-  function_app_id           = module.functions.function_app_id
+  database_server_id        = try(module.database[0].server_id, "")
+  enable_database_alerts    = var.enable_database
+  function_app_id           = module.functions[0].function_app_id
   enable_function_alerts    = true
   web_app_id                = module.webapp.web_app_id
   enable_webapp_alerts      = true
@@ -288,7 +299,7 @@ module "monitoring" {
 
   tags = local.common_tags
 
-  depends_on = [module.database, module.functions, module.webapp]
+  depends_on = [module.webapp]
 }
 
 # Random passwords for application secrets

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -25,43 +25,43 @@ output "key_vault_uri" {
 
 output "database_server_fqdn" {
   description = "FQDN of the PostgreSQL server"
-  value       = module.database.server_fqdn
+  value       = try(module.database[0].server_fqdn, null)
 }
 
 output "cosmos_account_name" {
   description = "Cosmos DB account name"
-  value       = module.cosmos_mongo.account_name
+  value       = try(module.cosmos_mongo[0].account_name, null)
 }
 
 output "cosmos_mongo_database_name" {
   description = "Cosmos Mongo database name"
-  value       = module.cosmos_mongo.mongo_database_name
+  value       = try(module.cosmos_mongo[0].mongo_database_name, null)
 }
 
 output "cosmos_mongo_collection_name" {
   description = "Cosmos Mongo collection name"
-  value       = module.cosmos_mongo.mongo_collection_name
+  value       = try(module.cosmos_mongo[0].mongo_collection_name, null)
 }
 
 output "cosmos_mongo_connection_string" {
   description = "Cosmos Mongo connection string"
-  value       = module.cosmos_mongo.mongo_connection_string
+  value       = try(module.cosmos_mongo[0].mongo_connection_string, null)
   sensitive   = true
 }
 
 output "docuseal_container_id" {
   description = "ID of the DocuSeal container"
-  value       = module.compute.docuseal_container_id
+  value       = try(module.compute[0].docuseal_container_id, null)
 }
 
 output "baserow_container_id" {
   description = "ID of the Baserow container"
-  value       = module.compute.baserow_container_id
+  value       = try(module.compute[0].baserow_container_id, null)
 }
 
 output "application_gateway_public_ip" {
   description = "Public IP address of the Application Gateway"
-  value       = module.gateway.public_ip_address
+  value       = try(module.gateway[0].public_ip_address, null)
 }
 
 output "docuseal_url" {
@@ -77,19 +77,19 @@ output "baserow_url" {
 output "dns_records_required" {
   description = "DNS records configured"
   value = {
-    docs = module.dns.docs_fqdn
-    ops  = module.dns.ops_fqdn
+    docs = try(module.dns[0].docs_fqdn, null)
+    ops  = try(module.dns[0].ops_fqdn, null)
   }
 }
 
 output "document_intelligence_endpoint" {
   description = "Document Intelligence endpoint URL"
-  value       = module.cognitive.endpoint
+  value       = try(module.cognitive[0].endpoint, null)
 }
 
 output "document_intelligence_key" {
   description = "Document Intelligence access key"
-  value       = module.cognitive.primary_access_key
+  value       = try(module.cognitive[0].primary_access_key, null)
   sensitive   = true
 }
 
@@ -121,17 +121,17 @@ output "web_app_hostname" {
 
 output "function_app_url" {
   description = "URL of the Azure Function App"
-  value       = module.functions.function_app_url
+  value       = try(module.functions[0].function_app_url, null)
 }
 
 output "function_app_name" {
   description = "Name of the Azure Function App"
-  value       = module.functions.function_app_name
+  value       = try(module.functions[0].function_app_name, null)
 }
 
 output "function_app_hostname" {
   description = "Default hostname of the Function App"
-  value       = module.functions.function_app_default_hostname
+  value       = try(module.functions[0].function_app_default_hostname, null)
 }
 
 output "runner_subnet_id" {

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -5,30 +5,45 @@
 # specifically want to change. Most fields here are commented out so the
 # defaults flow through.
 
-# Defaults follow the org convention: nl-prod-hov-{type}-san for hyphenated
-# resources and nlprodhovXXsan for storage accounts (no hyphens permitted).
+# Defaults follow the canonical org convention: nl-prod-hov-{type} for
+# hyphenated resources and nlprodhovXX for storage accounts (no hyphens
+# permitted).
 
 # environment         = "prod"
 # location            = "South Africa North"
-# resource_group_name = "nl-prod-hov-rg-san"
+# resource_group_name = "nl-prod-hov-rg"
 
 # Storage (override only if you need a different name; storage account names
 # are globally unique, lowercase, alphanumeric, 3-24 chars, no hyphens).
-# storage_account_name = "nlprodhovstsan"
+# storage_account_name = "nlprodhovst"
+# storage_account_replication_type = "LRS"
+# storage_network_default_action = "Allow"
 
 # Key Vault - globally unique within Azure DNS.
-# key_vault_name = "nl-prod-hov-kv-san"
+# key_vault_name = "nl-prod-hov-kv"
+# key_vault_network_default_action = "Allow"
 
 # Database - PostgreSQL Flexible Server.
-# db_server_name    = "nl-prod-hov-pg-san"
+# db_server_name    = "nl-prod-hov-pg"
 # db_admin_username = "hov_admin"
 db_admin_password   = "CHANGE_ME_SECURE_PASSWORD_HERE"  # NOT optional
 
 # Cosmos DB (Mongo API) for the kiosk request queue.
-# cosmos_account_name          = "nlprodhovcosmosan"
+# enable_cosmos_mongo          = false
+# cosmos_account_name          = "nlprodhovcosmos"
 # cosmos_mongo_database_name   = "house_of_veritas"
 # cosmos_mongo_collection_name = "kiosk_requests"
 # cosmos_mongo_throughput      = 400
+
+# Low-usage defaults keep optional paid services disabled. Enable these only
+# when the household workflow actually needs them.
+# enable_operational_services  = false
+# enable_database              = false
+# enable_application_gateway   = false
+# enable_dns_records           = false
+# enable_functions             = false
+# enable_monitoring            = false
+# enable_document_intelligence = false
 
 # Domain. Update if you've migrated off nexamesh.ai.
 # domain_name = "nexamesh.ai"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -13,7 +13,7 @@ variable "location" {
 variable "location_short" {
   description = "Short location code for naming"
   type        = string
-  default     = "san"
+  default     = ""
 }
 
 variable "project_prefix" {
@@ -31,14 +31,14 @@ variable "project_name" {
 variable "resource_group_name" {
   description = "Name of the resource group"
   type        = string
-  default     = "nl-prod-hov-rg-san"
+  default     = "nl-prod-hov-rg"
 }
 
 # Network variables
 variable "vnet_name" {
   description = "Virtual network name"
   type        = string
-  default     = "nl-prod-hov-vnet-san"
+  default     = "nl-prod-hov-vnet"
 }
 
 variable "vnet_address_space" {
@@ -75,21 +75,54 @@ variable "runner_subnet_prefix" {
 variable "storage_account_name" {
   description = "Storage account name (must be globally unique, no hyphens)"
   type        = string
-  default     = "nlprodhovstsan"
+  default     = "nlprodhovst"
+}
+
+variable "storage_account_replication_type" {
+  description = "Storage account replication type"
+  type        = string
+  default     = "LRS"
+
+  validation {
+    condition     = contains(["LRS", "GRS", "RAGRS", "ZRS", "GZRS", "RAGZRS"], var.storage_account_replication_type)
+    error_message = "storage_account_replication_type must be one of LRS, GRS, RAGRS, ZRS, GZRS, or RAGZRS."
+  }
+}
+
+variable "storage_network_default_action" {
+  description = "Default network action for the storage account firewall"
+  type        = string
+  default     = "Allow"
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.storage_network_default_action)
+    error_message = "storage_network_default_action must be Allow or Deny."
+  }
 }
 
 # Security variables
 variable "key_vault_name" {
   description = "Key Vault name (must be globally unique)"
   type        = string
-  default     = "nl-prod-hov-kv-san"
+  default     = "nl-prod-hov-kv"
+}
+
+variable "key_vault_network_default_action" {
+  description = "Default network action for the Key Vault firewall"
+  type        = string
+  default     = "Allow"
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.key_vault_network_default_action)
+    error_message = "key_vault_network_default_action must be Allow or Deny."
+  }
 }
 
 # Database variables
 variable "db_server_name" {
   description = "PostgreSQL server name"
   type        = string
-  default     = "nl-prod-hov-pg-san"
+  default     = "nl-prod-hov-pg"
 }
 
 variable "db_admin_username" {
@@ -107,7 +140,7 @@ variable "db_admin_password" {
 variable "cosmos_account_name" {
   description = "Cosmos DB account name (Mongo API)"
   type        = string
-  default     = "nlprodhovcosmosan"
+  default     = "nlprodhovcosmos"
 }
 
 variable "cosmos_mongo_database_name" {
@@ -137,6 +170,54 @@ variable "cosmos_public_network_access_enabled" {
 variable "cosmos_enable_free_tier" {
   description = "Enable Cosmos DB free tier"
   type        = bool
+  default     = true
+}
+
+variable "enable_cosmos_mongo" {
+  description = "Whether to provision Cosmos DB Mongo resources"
+  type        = bool
+  default     = false
+}
+
+variable "enable_database" {
+  description = "Whether to provision PostgreSQL Flexible Server resources"
+  type        = bool
+  default     = false
+}
+
+variable "enable_operational_services" {
+  description = "Whether to provision always-on DocuSeal and Baserow container instances"
+  type        = bool
+  default     = false
+}
+
+variable "enable_application_gateway" {
+  description = "Whether to provision Application Gateway WAF and its public IP"
+  type        = bool
+  default     = false
+}
+
+variable "enable_dns_records" {
+  description = "Whether Terraform should manage docs/ops/root Azure DNS records"
+  type        = bool
+  default     = false
+}
+
+variable "enable_functions" {
+  description = "Whether to provision the Azure Function App automation stack"
+  type        = bool
+  default     = false
+}
+
+variable "enable_monitoring" {
+  description = "Whether to provision Log Analytics and metric alerts"
+  type        = bool
+  default     = false
+}
+
+variable "enable_document_intelligence" {
+  description = "Whether to provision Azure AI Document Intelligence"
+  type        = bool
   default     = false
 }
 
@@ -144,40 +225,40 @@ variable "cosmos_enable_free_tier" {
 variable "docuseal_container_name" {
   description = "DocuSeal container instance name"
   type        = string
-  default     = "nl-prod-hov-aci-docuseal-san"
+  default     = "nl-prod-hov-aci-docuseal"
 }
 
 variable "baserow_container_name" {
   description = "Baserow container instance name"
   type        = string
-  default     = "nl-prod-hov-aci-baserow-san"
+  default     = "nl-prod-hov-aci-baserow"
 }
 
 # Gateway variables
 variable "app_gateway_name" {
   description = "Application Gateway name"
   type        = string
-  default     = "nl-prod-hov-agw-san"
+  default     = "nl-prod-hov-agw"
 }
 
 # Web App variables
 variable "web_app_name" {
   description = "Azure Web App name for the Next.js frontend"
   type        = string
-  default     = "nl-prod-hov-app-san"
+  default     = "nl-prod-hov-app"
 }
 
 # Function App variables
 variable "function_app_name" {
   description = "Azure Function App name"
   type        = string
-  default     = "nl-prod-hov-func-san"
+  default     = "nl-prod-hov-func"
 }
 
 variable "functions_storage_account_name" {
   description = "Storage account for Function App code (must be globally unique, no hyphens)"
   type        = string
-  default     = "nlprodhovfuncstsan"
+  default     = "nlprodhovfuncst"
 }
 
 variable "baserow_api_token" {
@@ -358,7 +439,7 @@ variable "smtp_password" {
 variable "document_intelligence_name" {
   description = "Name of the Document Intelligence account"
   type        = string
-  default     = "nl-prod-hov-di-san"
+  default     = "nl-prod-hov-di"
 }
 
 # DNS variables

--- a/terraform/modules/security/main.tf
+++ b/terraform/modules/security/main.tf
@@ -15,7 +15,7 @@ resource "azurerm_key_vault" "main" {
 
   network_acls {
     bypass                     = "AzureServices"
-    default_action             = "Deny"
+    default_action             = var.network_default_action
     ip_rules                   = var.deployer_ip_addresses
     virtual_network_subnet_ids = [var.container_subnet_id, var.runner_subnet_id]
   }

--- a/terraform/modules/security/variables.tf
+++ b/terraform/modules/security/variables.tf
@@ -56,6 +56,17 @@ variable "deployer_ip_addresses" {
   default     = []
 }
 
+variable "network_default_action" {
+  description = "Default network action for the Key Vault firewall"
+  type        = string
+  default     = "Deny"
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.network_default_action)
+    error_message = "network_default_action must be Allow or Deny."
+  }
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_storage_account" "main" {
   resource_group_name      = var.resource_group_name
   location                 = var.location
   account_tier             = "Standard"
-  account_replication_type = "GRS" # Geo-redundant for DR
+  account_replication_type = var.account_replication_type
   account_kind             = "StorageV2"
 
   min_tls_version = "TLS1_2"
@@ -23,7 +23,7 @@ resource "azurerm_storage_account" "main" {
   }
 
   network_rules {
-    default_action             = "Deny"
+    default_action             = var.network_default_action
     bypass                     = ["AzureServices"]
     ip_rules                   = var.deployer_ip_addresses
     virtual_network_subnet_ids = [var.container_subnet_id, var.database_subnet_id, var.runner_subnet_id]

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -13,6 +13,28 @@ variable "storage_account_name" {
   type        = string
 }
 
+variable "account_replication_type" {
+  description = "Storage account replication type"
+  type        = string
+  default     = "GRS"
+
+  validation {
+    condition     = contains(["LRS", "GRS", "RAGRS", "ZRS", "GZRS", "RAGZRS"], var.account_replication_type)
+    error_message = "account_replication_type must be one of LRS, GRS, RAGRS, ZRS, GZRS, or RAGZRS."
+  }
+}
+
+variable "network_default_action" {
+  description = "Default network action for the storage account firewall"
+  type        = string
+  default     = "Deny"
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.network_default_action)
+    error_message = "network_default_action must be Allow or Deny."
+  }
+}
+
 variable "container_subnet_id" {
   description = "ID of the container subnet"
   type        = string

--- a/terraform/modules/webapp/main.tf
+++ b/terraform/modules/webapp/main.tf
@@ -35,6 +35,7 @@ resource "azurerm_linux_web_app" "main" {
 
   app_settings = merge({
     WEBSITE_NODE_DEFAULT_VERSION = "~20"
+    HOSTNAME                     = "0.0.0.0"
     NODE_ENV                     = "production"
     NEXT_PUBLIC_APP_URL          = "https://${var.domain_name}"
 
@@ -69,7 +70,8 @@ resource "azurerm_linux_web_app" "main" {
     DOCUSEAL_API_KEY         = var.docuseal_api_key
     NEXT_PUBLIC_DOCUSEAL_URL = "https://docs.${var.domain_name}"
 
-    JWT_SECRET = var.jwt_secret
+    AUTH_SECRET = var.jwt_secret
+    JWT_SECRET  = var.jwt_secret
 
     AZURE_STORAGE_CONNECTION_STRING = var.storage_connection_string
     DOCUMENT_INTELLIGENCE_ENDPOINT  = var.document_intelligence_endpoint


### PR DESCRIPTION
Summary: switch production Terraform/workflow defaults from disposable -san names to canonical Azure resource names; default production Terraform to the low-cost App Service, Storage, Key Vault, VNet stack; keep Cosmos, Postgres, WAF, Functions, monitoring, and ops services optional; update health checks so disabled Baserow and DocuSeal report unconfigured instead of degraded; document migration and cost rationale.

Production already done: applied canonical Terraform stack in nl-prod-hov-rg; deployed nl-prod-hov-app; verified https://nl-prod-hov-app.azurewebsites.net/api/health returns healthy with dataMode empty; requested deletion of old nl-prod-hov-rg-san and Azure reports provisioningState Deleting.

Validation: pnpm run lint; CI=true pnpm run build; terraform validate -no-color; python -m py_compile config/scripts/deployment-checklist.py; active stale-name sweep over .github terraform config returned no matches.