### PR TITLE
Differentiate canonical production profile in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive estate and asset management platform for private households and small estates, featuring secure document signing, operational tracking, inventory management, and AI-powered automation.
 
-**Domain:** [nexamesh.ai](https://nexamesh.ai) | **Region:** South Africa North | **Status:** Deploying
+**Domain:** [nexamesh.ai](https://nexamesh.ai) | **Region:** South Africa North | **Status:** Canonical production live
 
 ---
 
@@ -26,10 +26,10 @@ A comprehensive estate and asset management platform for private households and 
 | Framework | Next.js 16 (App Router)            |
 | Language  | TypeScript 5                       |
 | Styling   | Tailwind CSS 4 + Shadcn/UI         |
-| Backend   | DocuSeal (Ruby) + Baserow (Django) |
-| Database  | Azure PostgreSQL Flexible Server   |
-| Storage   | Azure Blob Storage (GRS)           |
-| OCR       | Azure Document Intelligence        |
+| Backend   | Next.js API routes; DocuSeal and Baserow optional |
+| Database  | Empty/local mode by default; PostgreSQL optional |
+| Storage   | Azure Blob Storage (LRS baseline)  |
+| OCR       | Azure Document Intelligence optional |
 | IaC       | Terraform 1.5+                     |
 | CI/CD     | GitHub Actions                     |
 | Cloud     | Azure (South Africa North)         |
@@ -49,6 +49,11 @@ See [Local Development Guide](docs/03-deployment/02-local-development.md) for Do
 
 ### Azure Deployment
 
+Production currently uses the low-cost canonical baseline: App Service,
+Storage, Key Vault, and VNet. Optional services such as Baserow, DocuSeal,
+PostgreSQL, Cosmos DB, Functions, Document Intelligence, monitoring, and
+Application Gateway are disabled until explicitly justified.
+
 ```powershell
 cd terraform\environments\production
 terraform init -backend-config="backend.hcl"
@@ -56,7 +61,8 @@ terraform plan -var-file="terraform.tfvars" -out=tfplan
 terraform apply tfplan
 ```
 
-See [Deployment Guide](docs/03-deployment/01-deployment-guide.md) for complete instructions.
+See [Canonical Azure Production Profile](docs/03-deployment/07-canonical-azure-naming-migration.md)
+and [Deployment Guide](docs/03-deployment/01-deployment-guide.md) for complete instructions.
 
 ---
 

--- a/docs/02-architecture/02-naming-convention.md
+++ b/docs/02-architecture/02-naming-convention.md
@@ -52,25 +52,43 @@ Some Azure resources don't allow hyphens in names:
 | East US            | `eus`      |
 | West US            | `wus`      |
 
-Region suffixes such as `-san` are retained only for legacy resources created
-before the canonical naming migration. New production resources should omit the
-region suffix.
+Region suffixes such as `-san` are retained only in historical references to
+the retired demo stack. Active production resources must omit the region suffix.
 
 ## Resource Inventory
 
-### Production Environment (`prod`)
+### Production Environment (`prod`) - Live Baseline
 
 | Resource           | Name                           | Purpose                  |
 | ------------------ | ------------------------------ | ------------------------ |
 | Resource Group     | `nl-prod-hov-rg`               | All production resources |
 | Virtual Network    | `nl-prod-hov-vnet`             | Network isolation        |
-| PostgreSQL         | `nl-prod-hov-pg`               | Database server          |
 | Storage Account    | `nlprodhovst`                  | Document/backup storage  |
 | Key Vault          | `nl-prod-hov-kv`               | Secrets management       |
-| App Gateway        | `nl-prod-hov-agw`              | Load balancer/WAF        |
-| DocuSeal Container | `nl-prod-hov-aci-docuseal`     | Document signing         |
-| Baserow Container  | `nl-prod-hov-aci-baserow`      | Operations data          |
-| Function App       | `nl-prod-hov-func`             | Automation functions     |
+| Web App            | `nl-prod-hov-app`              | Next.js application      |
+
+### Production Environment (`prod`) - Optional Add-Ons
+
+These names are reserved for future production services, but the services are
+not part of the low-usage baseline. Enable them only when there is a live
+operational requirement, integration credentials are ready, and the cost impact
+has an owner decision.
+
+| Resource              | Name                       | Purpose                  |
+| --------------------- | -------------------------- | ------------------------ |
+| PostgreSQL            | `nl-prod-hov-pg`           | Optional database server |
+| Cosmos DB             | `nlprodhovcosmos`          | Optional document store  |
+| Document Intelligence | `nl-prod-hov-di`           | Optional OCR             |
+| App Gateway           | `nl-prod-hov-agw`          | Optional WAF/edge        |
+| DocuSeal Container    | `nl-prod-hov-aci-docuseal` | Optional document signing |
+| Baserow Container     | `nl-prod-hov-aci-baserow`  | Optional operations data |
+| Function App          | `nl-prod-hov-func`         | Optional automation jobs |
+
+### Retired Demo Stack
+
+Names ending in `-san` or `san`, such as `nl-prod-hov-rg-san` and
+`nlprodhovstsan`, belonged to the disposable demo stack. Do not use them for
+new production work, GitHub Actions defaults, Terraform examples, or runbooks.
 
 ### Development Environment (`dev`)
 

--- a/docs/03-deployment/07-canonical-azure-naming-migration.md
+++ b/docs/03-deployment/07-canonical-azure-naming-migration.md
@@ -1,7 +1,19 @@
-# Canonical Azure Naming Migration
+# Canonical Azure Production Profile
 
-House of Veritas is moving away from region-suffixed Azure resource names such
-as `nl-prod-hov-rg-san`. The canonical production names remove the region code:
+House of Veritas production now uses canonical Azure resource names without the
+old South Africa North `-san` suffix. The `-san` stack was a disposable demo
+environment and should not be used as the model for new production resources.
+
+## Environment Classes
+
+| Class | Purpose | Naming | Current status |
+| --- | --- | --- | --- |
+| Canonical production | Live low-usage application stack | `nl-prod-hov-*`, `nlprodhov*` | Active |
+| Optional operational services | Baserow, DocuSeal, Functions, WAF, database add-ons | Canonical names only | Disabled until justified |
+| Legacy demo | Original demo stack with region suffix | `*-san`, `*san` | Retired/deleting |
+
+The production default is intentionally small: App Service, Storage, Key Vault,
+and VNet. Optional services must be enabled deliberately and cost-reviewed first.
 
 | Resource | Current | Canonical |
 | --- | --- | --- |
@@ -15,28 +27,44 @@ as `nl-prod-hov-rg-san`. The canonical production names remove the region code:
 | Web App | `nl-prod-hov-app-san` | `nl-prod-hov-app` |
 | Function App | `nl-prod-hov-func-san` | `nl-prod-hov-func` |
 
-## Required Approach
+## Cutover Status
 
-Azure cannot rename most of these resources in place. In Terraform, changing
-these names against the existing production state will plan replacements and can
-destroy or orphan live infrastructure. Use a parallel canonical stack instead:
+The canonical stack has been created under the separate backend key
+`production-canonical.terraform.tfstate` and deployed to:
 
-1. Keep the existing `-san` stack untouched and serving production.
-2. Create a separate canonical Terraform state key for the canonical stack.
-3. Apply the canonical stack using
-   `terraform/environments/production/canonical.tfvars.example` as the template.
-4. Deploy the app to the canonical Web App and Function App.
-5. Bring up operational data services under canonical infrastructure.
-6. Smoke-check canonical endpoints and health.
-7. Cut over DNS and GitHub Actions variables to canonical names.
-8. Retire the `-san` stack only after backups and validation are complete.
+| Item | Value |
+| --- | --- |
+| Resource group | `nl-prod-hov-rg` |
+| Web App | `nl-prod-hov-app` |
+| Default URL | `https://nl-prod-hov-app.azurewebsites.net` |
+| Data mode | `empty` until live operational integrations are configured |
+| Baserow/DocuSeal health state | `unconfigured`, not degraded |
+
+The old `nl-prod-hov-rg-san` resource group is no longer a production fallback.
+It was requested for deletion after the canonical app returned healthy.
+
+## Required Approach For Future Changes
+
+Azure cannot rename most resources in place. In Terraform, changing names
+against an existing state can plan replacements and can destroy or orphan live
+infrastructure. Keep these rules:
+
+1. Use `production-canonical.terraform.tfstate` for canonical production.
+2. Do not reintroduce `-san` names in active workflows, Terraform defaults, or
+   deployment scripts.
+3. Keep costly modules disabled unless a real production use case justifies
+   them.
+4. Treat Baserow, DocuSeal, Functions, Cosmos, PostgreSQL, Document
+   Intelligence, monitoring, and Application Gateway as optional add-ons.
+5. Run a targeted stale-name sweep over `.github`, `terraform`, and `config`
+   before merging infrastructure changes.
 
 ## Low-Usage Cost Target
 
 Current expected use is about four users, twice per day each. The production
 stack should optimize for idle cost first.
 
-Current `-san` spend from Azure Cost Management for 2026-06-10 through
+Legacy `-san` spend from Azure Cost Management for 2026-06-10 through
 2026-07-10 was about `$33.52`, almost entirely Cosmos DB:
 
 | Service | Cost |
@@ -59,17 +87,18 @@ Use this cheaper target instead:
 | Functions | Prefer Consumption plan or fold jobs into app until volume justifies B1 | save about `$14` |
 | Storage | Use LRS until backup/DR policy requires GRS | small saving |
 
-Practical goal for the canonical stack: keep idle/low-usage spend around
-`$50-$120/month`, not `$600+`.
+Practical goal for the canonical baseline: keep idle/low-usage spend in the
+low tens per month. Only move toward `$50-$120/month` after operational services
+are actually being used.
 
 ## Do Not Do
 
 - Do not pass canonical names to the existing `-san` state and run a broad
   `terraform apply`.
-- Do not destroy the `-san` resource group until the canonical stack has served
-  production traffic and backups have been verified.
-- Do not enable operational data in the app before Baserow and DocuSeal have
-  real API keys and table IDs configured.
+- Do not recreate the `-san` stack for production.
+- Do not enable operational data services before Baserow and DocuSeal have real
+  API keys, table IDs, owners, and a cost owner decision.
+- Do not make `/api/health` depend on disabled optional integrations.
 
 ## Terraform Notes
 
@@ -77,14 +106,14 @@ The canonical tfvars template documents the low-usage profile now used by the
 production defaults. The repository deployment workflows target canonical names
 and default to the `production-canonical.terraform.tfstate` backend key.
 
-Use a distinct backend key for the canonical state, for example:
+Use the canonical backend key:
 
 ```powershell
 terraform init -reconfigure `
   -backend-config="resource_group_name=hov-shared-tfstate-rg" `
   -backend-config="storage_account_name=hovsharedtfstatesa" `
   -backend-config="container_name=tfstate" `
-  -backend-config="key=house-of-veritas-prod-canonical.tfstate"
+  -backend-config="key=production-canonical.terraform.tfstate"
 ```
 
 Then plan with copied, secret-filled tfvars:


### PR DESCRIPTION
Summary: clarify that canonical production is the live low-cost baseline; separate optional Baserow, DocuSeal, Functions, WAF, database, monitoring, and OCR add-ons; mark the old -san stack as retired/deleting; update README top-level stack/status.

Validation: docs-only; grep sanity check over README and the updated docs.