### PR TITLE
Document canonical production domain status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 A comprehensive estate and asset management platform for private households and small estates, featuring secure document signing, operational tracking, inventory management, and AI-powered automation.
 
-**Domain:** [nexamesh.ai](https://nexamesh.ai) | **Region:** South Africa North | **Status:** Canonical production live
+**App URL:** [nl-prod-hov-app.azurewebsites.net](https://nl-prod-hov-app.azurewebsites.net) | **Region:** South Africa North | **Status:** Canonical production live
+
+`nexamesh.ai` currently serves the shared Neualliquid/Nexamesh portfolio surface
+for House of Veritas, Cog-Mesh, Omnipost, and Convolens. It is not bound
+directly to the House of Veritas App Service unless a custom-domain cutover is
+performed.
 
 ---
 

--- a/config/scripts/deployment-checklist.py
+++ b/config/scripts/deployment-checklist.py
@@ -724,7 +724,15 @@ class DeploymentChecker:
         resources.checks.append(self.check_vnet())
         resources.checks.append(self.check_storage_account())
         resources.checks.append(self.check_key_vault())
-        resources.checks.append(self.check_postgres())
+        if self.enable_operational_services:
+            resources.checks.append(self.check_postgres())
+        else:
+            resources.checks.append(CheckResult(
+                name="PostgreSQL Server",
+                status=Status.SKIP,
+                message="PostgreSQL is disabled for the low-usage canonical stack",
+                details="Set ENABLE_OPERATIONAL_SERVICES=true when validating the operational-data add-ons"
+            ))
         self.categories.append(resources)
         
         # Category 3: Application Services
@@ -824,9 +832,12 @@ class DeploymentChecker:
         
         steps = self.get_deployment_steps()
         for i, step in enumerate(steps, 1):
-            status_icon = "✅" if step["complete"] else "⏳"
+            if step.get("skipped"):
+                status_icon = "⏭️"
+            else:
+                status_icon = "✅" if step["complete"] else "⏳"
             print(f"  {status_icon} Step {i}: {step['name']}")
-            if not step["complete"]:
+            if not step["complete"] and not step.get("skipped"):
                 print(f"      Command: {step['command']}")
         
         print("\n" + "=" * 70)
@@ -917,41 +928,49 @@ class DeploymentChecker:
             {
                 "name": "Deploy PostgreSQL Database",
                 "complete": has_postgres,
+                "skipped": not self.enable_operational_services,
                 "command": "terraform apply -target=module.database"
             },
             {
                 "name": "Deploy DocuSeal Container",
                 "complete": has_docuseal,
+                "skipped": not self.enable_operational_services,
                 "command": "terraform apply -target=module.compute (docuseal)"
             },
             {
                 "name": "Deploy Baserow Container",
                 "complete": has_baserow,
+                "skipped": not self.enable_operational_services,
                 "command": "terraform apply -target=module.compute (baserow)"
             },
             {
                 "name": "Deploy Application Gateway",
                 "complete": has_gateway,
+                "skipped": not self.enable_application_gateway,
                 "command": "terraform apply -target=module.gateway"
             },
             {
                 "name": "Configure DNS Records",
                 "complete": False,  # Manual step
+                "skipped": not self.enable_application_gateway,
                 "command": "Create A records for docs.nexamesh.ai and ops.nexamesh.ai"
             },
             {
                 "name": "Configure SSL Certificates",
                 "complete": False,  # Requires manual check
+                "skipped": not self.enable_application_gateway,
                 "command": "certbot certonly && az keyvault certificate import"
             },
             {
                 "name": "Seed Initial Data",
                 "complete": False,  # Post-deployment
+                "skipped": not self.enable_operational_services,
                 "command": "python /app/config/scripts/seed-baserow.py"
             },
             {
                 "name": "Create User Accounts",
                 "complete": False,  # Post-deployment
+                "skipped": not self.enable_operational_services,
                 "command": "See /app/docs/04-configuration/01-docuseal-setup.md and /app/docs/04-configuration/02-baserow-setup.md"
             }
         ]

--- a/docs/03-deployment/07-canonical-azure-naming-migration.md
+++ b/docs/03-deployment/07-canonical-azure-naming-migration.md
@@ -10,7 +10,7 @@ environment and should not be used as the model for new production resources.
 | --- | --- | --- | --- |
 | Canonical production | Live low-usage application stack | `nl-prod-hov-*`, `nlprodhov*` | Active |
 | Optional operational services | Baserow, DocuSeal, Functions, WAF, database add-ons | Canonical names only | Disabled until justified |
-| Legacy demo | Original demo stack with region suffix | `*-san`, `*san` | Retired/deleting |
+| Legacy demo | Original demo stack with region suffix | `*-san`, `*san` | Retired/deleted |
 
 The production default is intentionally small: App Service, Storage, Key Vault,
 and VNet. Optional services must be enabled deliberately and cost-reviewed first.
@@ -41,7 +41,17 @@ The canonical stack has been created under the separate backend key
 | Baserow/DocuSeal health state | `unconfigured`, not degraded |
 
 The old `nl-prod-hov-rg-san` resource group is no longer a production fallback.
-It was requested for deletion after the canonical app returned healthy.
+Deletion has completed; Azure Resource Manager now returns
+`ResourceGroupNotFound` for `nl-prod-hov-rg-san`.
+
+As of 2026-07-10, `nexamesh.ai` has not been cut over to the canonical App
+Service. The canonical app has only the default hostname bound:
+`nl-prod-hov-app.azurewebsites.net`. Public DNS still resolves
+`www.nexamesh.ai` to the shared `nex-prod-marketing-swa` Static Web App, which
+serves the Neualliquid/Nexamesh portfolio surface for House of Veritas,
+Cog-Mesh, Omnipost, and Convolens. If House of Veritas should serve the apex or
+`www` domain directly from this App Service, add the custom hostname binding,
+certificate, and DNS records as a deliberate cutover step.
 
 ## Required Approach For Future Changes
 


### PR DESCRIPTION
## Summary

- Record that the retired nl-prod-hov-rg-san Azure resource group deletion has completed.
- Clarify that the canonical House of Veritas App Service is currently served at nl-prod-hov-app.azurewebsites.net.
- Clarify that nexamesh.ai remains a shared Neualliquid/Nexamesh portfolio surface for House of Veritas, Cog-Mesh, Omnipost, and Convolens, not a direct binding to the HOV App Service.

## Validation

- Verified Azure returns ResourceGroupNotFound for nl-prod-hov-rg-san.
- Verified nl-prod-hov-app is running and /api/health returns healthy with dataMode=empty.
- Verified www.nexamesh.ai resolves to the shared Static Web App target, not the HOV App Service.
- Ran git diff --check.
- Ran a targeted stale wording check for the changed docs.

Docs-only change; lint/build were not run.