### PR TITLE
Replace remaining app console calls with logger

### DIFF
--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -37,9 +37,9 @@ function getDefaultRequesterId(): number {
       )
     }
     // Log warning for invalid env value but continue with fallback in non-production
-    console.warn(
-      `Invalid DEFAULT_EXPENSE_REQUESTER_ID: ${process.env.DEFAULT_EXPENSE_REQUESTER_ID}, using fallback`
-    )
+    logger.warn("Invalid DEFAULT_EXPENSE_REQUESTER_ID, using fallback", {
+      value: process.env.DEFAULT_EXPENSE_REQUESTER_ID,
+    })
   }
   // In production, require the environment variable to be set
   if (process.env.NODE_ENV === "production") {

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label"
 import { RESPONSIBILITIES } from "@/lib/access-config"
 import { apiFetch, apiFetchSafe } from "@/lib/api-client"
 import { useAuth } from "@/lib/auth-context"
+import { logger } from "@/lib/logger"
 import { useLoginModal } from "@/lib/login-modal-context"
 import {
   ArrowRight,
@@ -97,10 +98,13 @@ export default function OnboardingPage() {
         }
       })
       .catch((err) => {
-        console.error("Failed to fetch user:", err)
         // Extract status from error response
         const status =
           err?.status ?? err?.response?.status ?? (err instanceof Response ? err.status : undefined)
+        logger.error("Failed to fetch onboarding user", {
+          error: err instanceof Error ? err.message : String(err),
+          status,
+        })
         const isAuthError = status === 401 || status === 403
         if (isAuthError) {
           setAuthError(true)
@@ -218,8 +222,6 @@ export default function OnboardingPage() {
   }
 
   if (error) {
-    // Log full error details for debugging, but show generic message to users
-    console.error("Onboarding load error:", error)
     return (
       <div className="flex min-h-screen flex-col items-center justify-center bg-black/60 p-4">
         <div

--- a/components/widget-error-boundary.tsx
+++ b/components/widget-error-boundary.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { logger } from "@/lib/logger"
 import { Component, type ReactNode } from "react"
 
 interface Props {
@@ -20,7 +21,11 @@ export class WidgetErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
-    console.error("WidgetErrorBoundary caught an error:", error, info)
+    logger.error("WidgetErrorBoundary caught an error", {
+      error: error.message,
+      stack: error.stack,
+      componentStack: info.componentStack,
+    })
   }
 
   render() {

--- a/lib/motion-context.tsx
+++ b/lib/motion-context.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { createContext, ReactNode, useContext, useEffect, useState } from "react"
+import { logger } from "@/lib/logger"
 
 interface MotionContextType {
   motionEnabled: boolean
@@ -25,7 +26,9 @@ export function MotionProvider({ children }: { children: ReactNode }) {
           setMotionEnabledState(saved === "true")
         }
       } catch (e) {
-        console.warn("Failed to read motion preference from localStorage:", e)
+        logger.warn("Failed to read motion preference from localStorage", {
+          error: e instanceof Error ? e.message : String(e),
+        })
       }
       setMounted(true)
     }
@@ -40,7 +43,9 @@ export function MotionProvider({ children }: { children: ReactNode }) {
         localStorage.setItem(STORAGE_KEY, String(newValue))
       } catch (e) {
         // Silently fail if localStorage is not available (e.g., quota exceeded, private mode)
-        console.warn("Failed to save motion preference to localStorage:", e)
+        logger.warn("Failed to save motion preference to localStorage", {
+          error: e instanceof Error ? e.message : String(e),
+        })
       }
       return newValue
     })


### PR DESCRIPTION
Summary:
- Replace remaining app-code console warnings/errors with structured logger calls.
- Preserve lib/logger.ts as the intentional console sink.
- Include error/status metadata at the call sites.

Verification:
- rg console sweep: only lib/logger.ts remains.
- pnpm run lint: PASS.
- pnpm exec tsc --noEmit: PASS.
- pnpm test: PASS, 32 files / 194 tests.