### PR TITLE
feat(radar): Property Deal Radar — spec, data layer, compliance docs

### DIFF
--- a/docs/specs/property-deal-radar-compliance.md
+++ b/docs/specs/property-deal-radar-compliance.md
@@ -1,0 +1,143 @@
+# Property Deal Radar — Compliance & Attribution Page (content)
+
+- **Status:** DRAFT — content for the public `/radar` compliance/attribution surface. Pending legal sign-off (see `property-deal-radar-legal-signoff.md`).
+- **Owner:** Jurie
+- **Author:** agent session (springs-cheapest-properties — Radar 5, Compliance)
+- **Parent spec:** `property-deal-radar.md` (§3, §9, §10 — source of truth)
+- **Scope:** The user-facing legal/attribution content that must render on the public Radar page (footer + a linked `/radar/about` or `/radar/sources` page). This document is the *content*; FRONTEND (Radar) wires it into the page. No app code is produced here.
+
+> This is the long-lead legal-track material running in parallel with the data-layer build.
+> None of it enables the feature. Publication stays gated by `RADAR_ENABLED` and by the
+> human legal sign-off recorded in `property-deal-radar-legal-signoff.md`.
+
+---
+
+## 1. Purpose
+
+Property Deal Radar is a public, unauthenticated page that ranks residential renovation/flip
+opportunities in Springs. It presents **facts** (price, beds/baths, erf, suburb, property type)
+and a transparent weighted score, and **links out** to the original listing on the source portal.
+It does not mirror listing descriptions or photos.
+
+This page exists so a visitor can see, at a glance: where the numbers came from, how fresh they
+are, what is estimated versus verified, and how to raise an objection or takedown request.
+
+## 2. Sources used
+
+Per spec §3.2, the following portals are accessed for **structured facts only** (DOM/field
+extraction), never for prose summaries, descriptions, or photographs:
+
+| Source | What we take | What we never take |
+|---|---|---|
+| **Property24** | Price, beds/baths, erf/floor, property type, suburb, listing date, source URL | Listing description text, photos, agent copy |
+| **Private Property** | Price, beds/baths, erf, suburb, listing URL | Description text, photos |
+| **MyRoof** | Price, beds/baths, erf, distress/bank programme tag, listing URL | Description text, photos |
+
+Supplementary/low-confidence (used sparingly, defaulted to low confidence): Gumtree / OLX
+property sections. A **licensed data feed** (Lightstone / PropertyFox / Deeds Office / portal
+partner — spec §3, Option A) is the intended clean end-state and replaces the above at v3.
+
+Every displayed row carries its own source attribution (portal name + deep link). We do not
+present another portal's content as our own.
+
+## 3. Refresh cadence
+
+- The dataset refreshes on an automated schedule **daily at 04:00 UTC**.
+- Each row shows a `lastSeen` date so visitors can judge freshness.
+- A row not re-observed for N days is marked `delisted` and de-ranked/hidden (spec §7.6).
+- Prices and status can change on the source portal between refreshes — the source listing,
+  reached via the link-out, is always authoritative.
+
+## 4. Per-row provenance (required on every card)
+
+Every listing card and every API row MUST expose, per spec §5 and §9:
+
+- **`sourcePortal`** — which portal the facts came from.
+- **`sourceUrl`** — a working deep link to the original listing (the "authoritative source").
+- **`lastSeen`** — the date the row was last observed on the source.
+- **`confidence`** — `verified` (source detail page opened + parsed this run), `feed` (fact-only,
+  not opened this run), or `estimate` (derived value). Confidence is shown as a badge and
+  **never feeds the score**. Feed-only rows are visibly caveated and cannot hold the #1 slot.
+
+Provenance is not optional and is not a footnote: it renders on the row, not only on this page.
+
+## 5. Disclaimers (must render on the page)
+
+### 5.1 Not financial advice
+
+> **Not financial advice.** Property Deal Radar is an information and research tool. Scores and
+> rankings are directional signals generated from public listing facts and a transparent weighting
+> you control — they are **not** a recommendation to buy, sell, or invest, and they are **not**
+> personalised financial, investment, tax, or legal advice. Do your own due diligence and consult
+> a qualified professional before making any property decision.
+
+This mirrors the House of Veritas / global rule against personalised investment advice: the page
+gives **generic risk framing only** and must not tell any individual what they personally should buy.
+
+### 5.2 Physical risk is indicative, not a survey
+
+> **Physical-risk flags are indicative, not a survey.** Dolomite/sinkhole and flood indicators
+> reflect area-level data and heuristics for the East Rand mining ground. They are **not** a
+> geotechnical survey, engineering assessment, or guarantee for any specific stand. Commission a
+> professional survey before relying on them.
+
+### 5.3 Estimates are marked
+
+ARV, flip %, renovation-cost, and other derived values are **estimates**, shown with an "estimate"
+marker and an `arvConfidence` / sub-score confidence. They are modelled from public facts, not
+appraisals.
+
+### 5.4 AI-generated analyst note
+
+Where a per-listing `analystNote` is shown, it MUST be labelled as AI-generated and carry the
+"not financial advice" caveat (spec §5.1):
+
+> **AI-generated summary.** This note is written by an automated model from the listing's
+> structured facts. It may be incomplete or wrong, does not feed the score, and is not financial
+> advice.
+
+The note is produced only for `verified` rows, generated from validated structured fields (not by
+re-reading the page), and regenerated on refresh.
+
+## 6. Takedown / contact path (required)
+
+The page MUST provide a clear, monitored contact path for portals, agents, sellers, or any party
+to object to a row or request removal:
+
+- A visible **"Report / request takedown"** link on the page and near attribution.
+- Contact destination: a monitored channel (email/inbox routed via the HOV notification-service —
+  final address confirmed by the owner before go-live).
+- Commitment text:
+
+> **Takedown & corrections.** If you are a listing source, agent, or owner and want a row corrected
+> or removed, contact us at [takedown contact — TBD by owner]. We honour reasonable takedown
+> requests promptly and can disable the entire feature immediately via our kill-switch.
+
+- Operationally, a takedown request is an **exception escalation** (spec §3.1.5) and may trigger
+  the `RADAR_ENABLED=false` kill-switch (see `property-deal-radar-killswitch-popia.md`).
+
+## 7. ToS-safe framing (what we tell visitors, and what we actually do)
+
+- We store and display **facts + a link-out**, not copyrighted descriptions or images (spec §10, §3 Option B/C).
+- We access source pages **programmatically for fact extraction only**, honouring robots.txt and
+  rate limits (spec §3.2, §3.3; enforced per `property-deal-radar-ingestion-compliance-spec.md`).
+- We attribute every row and link back to the source as the authoritative listing.
+- This mirrors `lib/services/marketplace-service.ts`: **compliant path first, deep-link fallback,
+  never a raw crawl.** Radar takes the same posture on the read side that marketplace-service takes
+  on the write side — no headless scrape (spec §3 Option D is explicitly rejected).
+
+## 8. Where this content renders
+
+- **Footer** on `/radar`: condensed attribution line, "not financial advice", takedown link.
+- **`/radar/about` (or `/radar/sources`)**: the full content of this document.
+- **Per-row**: provenance line (§4) and estimate/confidence badges.
+
+FRONTEND (Radar) owns the wiring; this document owns the words. Copy changes to disclaimers or the
+takedown commitment should be reviewed against this file and the legal sign-off memo.
+
+## 9. Cross-references
+
+- Residual-risk & legal gate: `property-deal-radar-legal-signoff.md`
+- Ingestion robots.txt / rate-limit acceptance criteria: `property-deal-radar-ingestion-compliance-spec.md`
+- Kill-switch semantics + POPIA boundary: `property-deal-radar-killswitch-popia.md`
+- Parent spec: `property-deal-radar.md`

--- a/docs/specs/property-deal-radar-ingestion-compliance-spec.md
+++ b/docs/specs/property-deal-radar-ingestion-compliance-spec.md
@@ -1,0 +1,99 @@
+# Property Deal Radar — Ingestion robots.txt & Rate-Limit Adherence Spec
+
+- **Status:** DRAFT — acceptance criteria for the Radar 3 ingestion function. Not implemented here.
+- **Owner:** Jurie
+- **Author:** agent session (springs-cheapest-properties — Radar 5, Compliance)
+- **Parent spec:** `property-deal-radar.md` (§3.2 extraction principles, §3.3 residual risk, §6, §7)
+- **Implements against:** the `DealRadarRefresh` Azure Function (Python timerTrigger, spec §6) — **Radar 3, not this workstream.**
+- **Scope:** Defines what the ingestion job MUST honour when accessing source portals. Written as
+  testable acceptance criteria so Radar 3 can implement and TESTING can verify. **No app code here.**
+
+> These are compliance *requirements*, not implementation. Radar 3 owns the code; this document is
+> the contract it must satisfy. Meeting every AC below is a prerequisite item in the legal sign-off
+> checklist (`property-deal-radar-legal-signoff.md` §5).
+
+---
+
+## 1. Principle
+
+Radar accesses source portals **programmatically for structured-fact extraction only**, and does so
+as a well-behaved client: it respects `robots.txt`, throttles aggressively, identifies itself,
+stays low-volume, and fails safe. This mirrors `lib/services/marketplace-service.ts`: compliant
+path first, deep-link fallback, **never a raw crawl** (spec §3, Option D rejected).
+
+## 2. robots.txt adherence — acceptance criteria
+
+- **AC-1 — Fetch and honour.** Before accessing any path on a source host, the job MUST fetch and
+  parse that host's `robots.txt` and obey its `Disallow`/`Allow` rules for the job's user-agent.
+- **AC-2 — Disallowed = skip.** If `robots.txt` disallows a path the job would fetch, the job MUST
+  NOT fetch it. It logs the skip and continues; it does not attempt a workaround.
+- **AC-3 — Cache with TTL.** `robots.txt` is fetched at most once per host per run (cache for the
+  run, TTL ≤ 24h) to avoid hammering the robots endpoint itself.
+- **AC-4 — Fail-closed on ambiguity.** If `robots.txt` cannot be fetched/parsed, or its meaning is
+  ambiguous for a path, the job treats that path as **disallowed** for this run (fail closed), logs
+  it, and — if this blocks the whole source — raises a source-shape-drift alarm rather than
+  guessing.
+- **AC-4b — Crawl-delay respected.** If `robots.txt` specifies a `Crawl-delay`, the job MUST use the
+  greater of that value and the configured throttle (AC-5).
+
+## 3. Rate-limiting & politeness — acceptance criteria
+
+- **AC-5 — Minimum inter-request delay.** The job enforces a configurable minimum delay between
+  requests to the same host (default target ≥ 2–5s; final value confirmed at sign-off). No burst
+  parallelism against a single host.
+- **AC-6 — Per-host concurrency = 1.** At most one in-flight request per source host at a time.
+- **AC-7 — Daily volume cap.** A configurable max requests-per-host-per-run cap (sized to the small
+  Springs area set, ~9 seed rows + area listing pages). Exceeding the cap stops that host's run and
+  logs it; it does not "try harder".
+- **AC-8 — Off-peak schedule.** Runs on the daily 04:00 UTC timer (spec §6/§7). No ad-hoc
+  high-frequency re-runs; a same-day re-run is idempotent and adds no meaningful extra load
+  (spec §7.9).
+- **AC-9 — Timeouts.** Every outbound request uses an explicit timeout (align with HOV convention —
+  external calls are time-bounded; cf. `AbortSignal.timeout()` in TS services). No unbounded hangs.
+- **AC-10 — Backoff on throttle signals.** On HTTP 429 / 503 / `Retry-After`, the job backs off
+  (honours `Retry-After` when present, else exponential backoff) and, if the source keeps refusing,
+  aborts that source for the run and alarms — it does NOT rotate IPs, spoof, or evade.
+
+## 4. Identification & honesty — acceptance criteria
+
+- **AC-11 — Honest User-Agent.** Requests send a stable, identifiable User-Agent that names the
+  Radar bot and a contact URL/inbox (the same takedown/contact path as
+  `property-deal-radar-compliance.md` §6). No impersonation of a normal browser to evade controls.
+- **AC-12 — No anti-bot evasion.** The job MUST NOT use IP rotation, CAPTCHA-solving, header
+  spoofing, cookie/session replay, or any technique whose purpose is to circumvent a portal's access
+  controls. Hitting such a control = treat the source as disallowed for the run + alarm.
+- **AC-13 — Facts only.** The job extracts only structured fields (price, beds/baths, erf/floor,
+  type, suburb, listing date, source URL, distress tag). It MUST NOT store listing description prose
+  or images (spec §3.2, §10). LLM prose summaries are never a source of truth (spec §3.2 principle 1).
+
+## 5. Confidence, validation & fail-safe — acceptance criteria
+
+- **AC-14 — Confidence gating.** A row is `verified` only if its source detail page was actually
+  opened + parsed this run; otherwise it stays `feed` (spec §3.1.3, §5). Confidence never feeds the
+  score.
+- **AC-15 — Kill-switch honoured.** When `RADAR_ENABLED=false`, the ingestion job MUST NOT publish
+  (see `property-deal-radar-killswitch-popia.md`). Ingestion either no-ops or writes only to
+  quarantine; nothing reaches the public path.
+- **AC-16 — Exception escalation, not silent retry.** robots.txt blocks, repeated throttling,
+  source-shape drift, or takedown hits raise a human-facing alarm via the HOV notification-service
+  (spec §3.1.5) instead of aggressive retrying.
+- **AC-17 — Auditable compliance log.** Each run logs, per host: robots.txt outcome, request count
+  vs cap, applied delay, any backoff/skip/abort events. Logs MUST NOT contain PII (v1 has none) and
+  follow HOV structured-logging rules (no `console.log`; no leaking secrets). This log is the
+  evidence the sign-off checklist (M1, M2) is actually being met in production.
+
+## 6. Test hooks for TESTING (Radar 3 verification)
+
+- Golden-file normalize test against captured source fixtures (spec §11) — no live portal calls in tests.
+- Unit test: robots.txt parser obeys `Disallow`/`Allow`/`Crawl-delay`; fail-closed on parse error (AC-1..AC-4b).
+- Unit test: throttle enforces min-delay and per-host concurrency = 1 (AC-5, AC-6) using fake timers.
+- Unit test: 429/503/`Retry-After` triggers backoff then source-abort, never IP rotation (AC-10, AC-12).
+- Unit test: `RADAR_ENABLED=false` ⇒ no publish path reached (AC-15).
+- Unit test: unopened row stays `feed`, never auto-`verified` (AC-14).
+
+## 7. Cross-references
+
+- Residual risk & legal gate: `property-deal-radar-legal-signoff.md` (AC compliance is a sign-off item)
+- User-facing attribution/disclaimers: `property-deal-radar-compliance.md`
+- Kill-switch semantics: `property-deal-radar-killswitch-popia.md`
+- Parent spec: `property-deal-radar.md` (§3.1 autonomous loop, §3.2 extraction principles, §6, §7)

--- a/docs/specs/property-deal-radar-killswitch-popia.md
+++ b/docs/specs/property-deal-radar-killswitch-popia.md
@@ -1,0 +1,83 @@
+# Property Deal Radar — Kill-switch (`RADAR_ENABLED`) & POPIA Boundary Note
+
+- **Status:** DRAFT — semantics & boundary definition. No flag is set or changed here.
+- **Owner:** Jurie
+- **Author:** agent session (springs-cheapest-properties — Radar 5, Compliance)
+- **Parent spec:** `property-deal-radar.md` (§6 data mode, §9 kill switch, §9 POPIA, §8 v2 alerts)
+- **Scope:** Defines what the `RADAR_ENABLED` kill-switch means and where the POPIA boundary sits.
+  Documentation only — **this workstream does not add, set, or flip any flag or touch code.**
+
+> The `RADAR_ENABLED` flag does not yet exist in `.env.example`. Adding it belongs to the
+> data-layer / flag work (Radar 4/6), not to this compliance track. This document specifies the
+> intended behaviour so that whoever wires it implements it correctly, and so the legal sign-off
+> (`property-deal-radar-legal-signoff.md`) can reference concrete semantics.
+
+---
+
+## 1. `RADAR_ENABLED` semantics
+
+`RADAR_ENABLED` is the feature's compliance kill-switch. It follows HOV's "ships dark, empty unless
+configured" convention (spec §6; CLAUDE.md Data Mode).
+
+| State | Meaning |
+|---|---|
+| **unset / `false`** (default) | Radar ships **dark**. Ingestion does not publish to the public path; the public `/radar` route serves an empty/disabled state. This is the default at all times until a signed sign-off flips it. |
+| **`true`** (Springs, post-sign-off only) | Radar publishes and the public page serves ranked rows for the configured area (Springs). May only be set after the sign-off block in `property-deal-radar-legal-signoff.md` §5 is completed by humans. |
+
+Required behaviour when wired (Radar 4/6):
+
+- **Ships dark.** Default (unset/`false`) = disabled. No demo/fallback rows appear implicitly; this
+  is not "demo mode" (that is `ALLOW_DEMO_DATA`, a separate flag — do not conflate).
+- **Disables publish instantly.** Flipping to `false` MUST stop publication effectively immediately
+  (next request / next cache revalidation), without a redeploy. The public route reads the flag at
+  request time (or via short-TTL cache) so an objection or takedown can be honoured fast.
+- **Ingestion respects it.** With `RADAR_ENABLED=false`, the ingestion job does not write to the
+  published path (ingestion-compliance-spec AC-15) — at most it writes to quarantine.
+- **Read-time gate on the API + page.** `app/api/radar/route.ts` and `app/radar/page.tsx`
+  (spec §6) both check the flag; when off, they return the empty/disabled state, not stale rows.
+- **No agent may set it.** Enabling for Springs is a human action gated on legal sign-off. No agent,
+  script, or automated step may flip `RADAR_ENABLED=true`.
+
+Kill-switch triggers (any of): a portal objection, a takedown request (compliance page §6), a
+source-shape-drift or anomaly alarm the team can't immediately clear, or legal advice to pause.
+
+## 2. POPIA boundary
+
+**v1 is out of POPIA scope — deliberately, and only because it collects no personal information.**
+
+- **v1 (this launch):** public, unauthenticated, no login. Weightings live in `localStorage`
+  client-side (spec §4). Radar processes **property listing facts**, not personal information about
+  identifiable data subjects. No emails, names, phone numbers, or accounts are collected or stored.
+  Therefore POPIA processing obligations (consent, purpose limitation, retention, data-subject
+  rights) are **not engaged** by v1. This must remain true for the sign-off to hold (see
+  `property-deal-radar-legal-signoff.md` §4 Q10).
+
+  - Caveat to confirm at sign-off: agent contact names / agency names that may appear in listing
+    facts or `canonicalKey` matching (spec §5.2) could constitute personal information about an
+    identifiable individual. Flag for the reviewer: decide whether agent names are displayed/stored
+    and whether that crosses into PI. Default posture: do not surface agent personal details on the
+    public page beyond what attribution strictly requires.
+
+- **v2 (deferred — email/WhatsApp deal alerts, spec §8):** the moment Radar captures an email (or
+  phone) to send alerts, it collects **personal information** and **POPIA is engaged**. That triggers,
+  at minimum: lawful basis / consent capture, purpose limitation (alerts only), a privacy notice,
+  retention + deletion policy, unsubscribe/opt-out, and data-subject request handling. This crosses
+  the public/unauth boundary and is explicitly **out of scope for v1** (spec §13 decision 4).
+
+**Boundary line:** POPIA is not engaged **until the first piece of personal information is
+collected**. v1 must not collect any. When v2 alerts are designed, POPIA compliance is a required
+gate for *that* release — a separate sign-off, not covered by the v1 legal sign-off.
+
+## 3. Relationship to other gates
+
+- The kill-switch is mitigation **M6** in the residual-risk memo and acceptance criterion **AC-15**
+  in the ingestion spec.
+- "Kill-switch verified to disable publish instantly" is a checkbox in the sign-off block
+  (`property-deal-radar-legal-signoff.md` §5) — it must be demonstrably true before Springs go-live.
+
+## 4. Cross-references
+
+- Legal sign-off & residual risk: `property-deal-radar-legal-signoff.md`
+- Ingestion adherence (AC-15 kill-switch honour): `property-deal-radar-ingestion-compliance-spec.md`
+- User-facing takedown path that can trigger the switch: `property-deal-radar-compliance.md` §6
+- Parent spec: `property-deal-radar.md` (§6, §8 v2, §9)

--- a/docs/specs/property-deal-radar-legal-signoff.md
+++ b/docs/specs/property-deal-radar-legal-signoff.md
@@ -1,0 +1,122 @@
+# Property Deal Radar — Legal Sign-off Checklist & Residual-Risk Memo
+
+- **Status:** OPEN — legal sign-off NOT obtained. This document is the material a human
+  lawyer/owner reviews and signs. **This gate blocks Radar 6 (go-live / flag-on for Springs).**
+- **Owner:** Jurie (business owner / accountable person)
+- **Sign-off authority:** a qualified attorney (SA ToS/IP/POPIA) **and** the business owner. An
+  agent CANNOT provide, substitute for, or represent this sign-off.
+- **Author:** agent session (springs-cheapest-properties — Radar 5, Compliance)
+- **Parent spec:** `property-deal-radar.md` (§3, §3.3, §10 — source of truth)
+
+> ⚠️ **Explicit gate.** `RADAR_ENABLED` must NOT be flipped on for Springs until the sign-off
+> block in §5 of this document is completed and dated by a human. No agent may set that flag, and
+> no agent output constitutes legal approval. Radar 6 depends on this document being signed.
+
+---
+
+## 1. What we are actually doing (stated plainly for the reviewer)
+
+Property Deal Radar runs an automated daily job (04:00 UTC) that **programmatically accesses**
+public listing pages on Property24, Private Property and MyRoof, extracts **structured facts only**
+(price, beds/baths, erf/floor, property type, suburb, listing date, source URL), normalises and
+scores them, and publishes a public ranked page that **links out** to each source listing. It does
+**not** store or display listing descriptions or photographs. This is spec Option **B+C**
+(agent-curated facts + metadata/deep-link), run autonomously with an automated QA gate; the
+headless-scrape option (D) is rejected.
+
+## 2. Residual-risk honesty (spec §3.3 — do not soften this)
+
+The chosen approach **reduces but does not eliminate** legal risk. The reviewer must understand:
+
+1. **Access itself may breach ToS regardless of what we store.** Even "facts + link-out" *accesses*
+   portal pages by machine. Some portal Terms of Service prohibit automated access / scraping
+   **irrespective** of whether the retrieved content is copyrighted or stored. Storing only
+   non-copyrightable facts addresses the *copyright* risk; it does **not** by itself address the
+   *breach-of-contract / ToS* risk from the access.
+2. **"Facts are not copyrightable" is a defence, not a shield against everything.** Price, erf, beds
+   are facts; a portal's *compilation*, *database*, and *presentation* may still attract protection,
+   and their ToS is a separate contractual layer.
+3. **Low volume + attribution + link-out are mitigations, not immunity.** They make the posture
+   defensible and reduce the chance and severity of objection; they do not make it certainly lawful.
+4. **The clean end-state is a licensed feed (Option A).** Lightstone / PropertyFox / Deeds Office /
+   portal partner API is the only path that is simultaneously automated **and** contractually clean.
+   Treat it as the target, not a "nice to have" (spec §3, §3.3).
+
+**Bottom line for the owner:** proceeding on B+C is a deliberate, eyes-open acceptance of a residual
+grey-zone risk, mitigated as below, and reversible instantly via the kill-switch. It is a business/
+legal risk decision, not a technical one — which is why it needs a human signature.
+
+## 3. Mitigations in place (what reduces the risk)
+
+| # | Mitigation | Where implemented / specified |
+|---|---|---|
+| M1 | Honour `robots.txt` on every portal access | `property-deal-radar-ingestion-compliance-spec.md` (AC-1..AC-4); Radar 3 (ingestion) |
+| M2 | Throttle / rate-limit; low request volume; off-peak (04:00 UTC) | ingestion-compliance-spec AC-5..AC-8; Radar 3 |
+| M3 | Facts only — never mirror descriptions or photos | spec §3, §10; ingestion + compliance page |
+| M4 | Attribute every row (portal + deep link) + `lastSeen` + confidence | `property-deal-radar-compliance.md` §4; spec §5, §9 |
+| M5 | Public takedown / contact path, monitored | `property-deal-radar-compliance.md` §6 |
+| M6 | Kill-switch `RADAR_ENABLED=false` disables publish instantly | `property-deal-radar-killswitch-popia.md`; spec §6, §9 |
+| M7 | Ships dark; Springs-only, ~9 seed rows — small blast radius | spec §12, §13, Appendix A |
+| M8 | Licensed feed (Option A) roadmapped as clean end-state | spec §3 Target, §8 v3 |
+| M9 | "Not financial advice" + indicative-risk disclaimers | `property-deal-radar-compliance.md` §5; spec §10 |
+| M10 | No PII collected in v1 (no login, weightings client-side) | spec §4, §6; POPIA boundary below |
+
+## 4. Open questions a lawyer MUST answer before Springs go-live
+
+These are the questions the sign-off turns on. Each needs a written answer from the reviewing
+attorney; "unknown" is not a pass.
+
+1. **ToS — access clause.** Do the current Property24 / Private Property / MyRoof Terms of Service
+   prohibit automated access / scraping *per se*, independent of what is stored or republished? If
+   yes, does honouring robots.txt + low volume + link-out materially change the analysis, or is any
+   automated access a breach?
+2. **Facts vs compilation.** Is extracting and republishing only factual fields (price, erf, beds,
+   suburb, date) defensible under SA copyright law given the portals' database/compilation rights?
+   Where is the line between "facts" and their protected compilation?
+3. **Deep-linking / attribution.** Is deep-linking to source listings with attribution permitted, or
+   do any of the portals' terms bar linking/framing in a way that affects us?
+4. **Robots.txt as legal signal.** In SA, does honouring/ignoring robots.txt carry contractual or
+   evidential weight? (It is a mitigation; confirm its legal status so we don't over-rely on it.)
+5. **Distress/bank tags (MyRoof).** Any additional constraints around republishing bank-programme /
+   distress indicators (EasySell / SIE / Pre-Hammer) or seller-distress information?
+6. **Liability from scores/notes.** What is our exposure if a user relies on a score, ARV estimate,
+   or AI `analystNote` and loses money? Does the "not financial advice" disclaimer (compliance page
+   §5) adequately cap this, and is the wording sufficient under SA consumer-protection law (CPA)?
+7. **Physical-risk statements.** Is the dolomite/flood "indicative, not a survey" disclaimer enough
+   to avoid liability for publishing area-level risk flags on specific stands?
+8. **Takedown obligations.** What response time / process must the takedown path commit to, to be
+   defensible? Any statutory notice-and-takedown regime (e.g. ECTA) we should map onto?
+9. **Risk appetite / go/no-go.** Given the above, is B+C acceptable to launch on for Springs now, or
+   must we wait for a licensed feed (Option A)? If go, under what conditions (volume cap, source
+   allowlist, review cadence)?
+10. **POPIA trigger point.** Confirm v1 collects no personal information and is out of POPIA scope,
+    and define exactly what changes the moment v2 alerts capture emails (see
+    `property-deal-radar-killswitch-popia.md`).
+
+## 5. Sign-off block (human completes — required before Radar 6)
+
+Radar 6 (enable `RADAR_ENABLED` for Springs) is **BLOCKED** until every box below is checked and the
+signatures/date are filled in by humans. Leaving any box unchecked = not signed off = do not enable.
+
+- [ ] Attorney has reviewed §1–§4 and provided written answers to all ten open questions (§4).
+- [ ] The residual-risk position (§2) is understood and accepted by the business owner.
+- [ ] Mitigations M1–M10 (§3) are confirmed implemented (Radar 3 ingestion + Radar 4/6 flag + compliance page live).
+- [ ] `robots.txt` + rate-limit acceptance criteria (`property-deal-radar-ingestion-compliance-spec.md`) verified as met by Radar 3.
+- [ ] Compliance/attribution page content (`property-deal-radar-compliance.md`) is live on `/radar` incl. disclaimers + takedown path.
+- [ ] Kill-switch verified to disable publish instantly (`property-deal-radar-killswitch-popia.md`).
+- [ ] Launch conditions from Q9 (source allowlist, volume cap, review cadence) are documented and in place.
+- [ ] Go/no-go decision recorded: ______ (GO / NO-GO)
+
+| Role | Name | Signature | Date |
+|---|---|---|---|
+| Reviewing attorney (SA ToS/IP/POPIA) | | | |
+| Business owner (accountable) | Jurie | | |
+
+**Until this block is signed, `RADAR_ENABLED` stays `false`/unset. No agent may change it.**
+
+## 6. Cross-references
+
+- Compliance/attribution content: `property-deal-radar-compliance.md`
+- Ingestion robots.txt / rate-limit acceptance criteria: `property-deal-radar-ingestion-compliance-spec.md`
+- Kill-switch + POPIA boundary: `property-deal-radar-killswitch-popia.md`
+- Parent spec: `property-deal-radar.md`

--- a/docs/specs/property-deal-radar.md
+++ b/docs/specs/property-deal-radar.md
@@ -1,0 +1,338 @@
+# Property Deal Radar — Feature Spec (HOV public module)
+
+- **Status:** DECISIONS LOCKED — analyst note + canonicalKey approved (v0.4)
+- **Owner:** Jurie
+- **Author:** agent session (springs-cheapest-properties)
+- **Scope:** Public, unauthenticated page in House of Veritas that ranks residential
+  "deal" opportunities (fixer-uppers, distressed, value-add) in Springs and — later —
+  configurable areas, refreshed daily and scored on a transparent weighted matrix.
+- **Origin:** Grew out of a manual research session ranking Springs fixer-uppers by
+  effort / flip % / buy-in. This spec productises that workflow.
+
+---
+
+## 1. Goal & success criteria
+
+Give a buyer a single public page that answers *"what are the best renovation/flip
+opportunities in Springs right now, ranked by MY priorities?"* — with the weighting
+under the user's control and the underlying numbers grounded, dated, and attributed.
+
+Success = (a) daily-fresh dataset with no manual step, (b) a ranking that survives
+scrutiny (verified property type, real erf, dated comps), (c) the user can re-weight
+live and the order updates, (d) legally clean.
+
+## 2. Non-goals
+
+- Not a full property portal (no user listings, no agent CRM, no messaging).
+- Not financial advice — scores are directional, disclaimer required.
+- Not a replacement for Property24/PP — we **link out** to the source listing.
+- No authenticated/personalised accounts in v1 (public only; weightings live client-side).
+
+## 3. ⚠️ Load-bearing decision: data sourcing (legal)
+
+**Daily automated scraping of Property24 / Private Property / MyRoof violates their
+Terms of Service** and their content is copyrighted. This is the single decision that
+gates the whole build. Options, cheapest-risk first:
+
+| Option | How | Legality | Cost | Freshness | Reco |
+|---|---|---|---|---|---|
+| **A. Licensed data feed** | Lightstone / PropertyFox / Deeds Office / a portal partner API | ✅ Clean | R (subscription) | High | **Preferred if budget exists** |
+| **B. Agent-curated daily** | Scheduled Claude/agent run compiles + verifies a small area set, writes normalized rows; light human sign-off | ✅ Grey→clean (facts, links out, attributed, low volume) | Low | Daily | **Preferred MVP** — matches HOV's "official-or-manual" house style |
+| **C. Metadata + deep-link only** | Store only non-copyrightable facts (price, beds, erf, suburb) + link to source; never mirror descriptions/photos | ✅ Lower risk | Low | Daily | Fallback / combine with B |
+| **D. Headless scrape nightly** | Playwright crawls portals | ❌ ToS breach, fragile, IP-block risk | Low | Daily | **Not recommended** |
+
+**The impossible triangle:** *fully hands-off + ToS-clean + free* — pick two.
+Since the priority is **minimising ongoing human effort**, that resolves to two coherent
+shapes, and we build for both:
+
+- **Now (MVP): B+C run autonomously.** Agent-curated facts + link-out, but with the human
+  taken *out of the daily loop* — replaced by an automated QA gate (see §3.1). Humans are
+  touched **only on exception** (source-shape drift, anomaly, takedown). Clean + low-cost +
+  near-zero routine effort; the residual effort is occasional exception handling.
+- **Target (v3): A licensed feed.** A paid feed (Lightstone / PropertyFox / Deeds Office /
+  portal partner) is the *only* path that is simultaneously fully-automated **and** clean —
+  it removes even exception handling. It costs money; that's the price of erasing the last
+  bit of human effort. The schema is built feed-agnostic so A drops in behind it unchanged.
+
+We do **not** hard-scrape (Option D), regardless of effort savings — it breaks ToS and is
+brittle. This mirrors `marketplace-service.ts`: compliant path first, deep-link fallback,
+never a raw crawl.
+
+### 3.1 Minimising human effort — the autonomous ingestion loop
+
+Goal: the daily refresh runs unattended; a human is pulled in **only** when the machine
+can't vouch for the result. Achieved with automated gates, not manual review:
+
+1. **Scheduled agent run** (daily) fetches the configured area set and extracts *facts
+   only* (price, beds/baths, erf, floor, type, suburb, source URL) + normalises.
+2. **Auto-classify + auto-score** — property-type classifier (rejects new-dev units),
+   sub-scores, ARV/comps recompute — all deterministic code, no human.
+3. **Automated QA gate (publish blocker):**
+   - Schema/type validation; reject rows failing invariants.
+   - Anomaly checks: price ±X% vs suburb median outliers, erf==floor (sectional tell),
+     missing source URL, duplicate listingId, day-over-day row-count delta > threshold.
+   - Confidence auto-assigned: `feed` by default; `verified` only if the source page was
+     actually opened+parsed this run.
+4. **Publish** rows that pass; **quarantine** rows that fail into a review queue.
+5. **Escalate exception-only** — notify a human *just* for the quarantine queue or a
+   source-shape-drift alarm (via HOV notification-service). Empty queue = zero human touch.
+6. **Kill-switch** (`RADAR_ENABLED=false`) disables publish instantly on any objection.
+
+Net: steady state is **hands-off**; human effort scales with anomalies, not volume. The
+only way to also erase exception handling is the licensed feed (§3, Target).
+
+### 3.2 Source registry & extraction lessons
+
+Per-portal reality, learned from the manual research session that spawned this spec:
+
+| Source | Best for | Access that works | Structured-data quality | Hard lesson |
+|---|---|---|---|---|
+| **Property24** | Widest stock; best filters (price, erf, type, sort); suburb trend/median + **Sold Prices** | Browser DOM read + JS anchor/field extraction | High — real erf/floor, dates, zoning on detail pages | **Never trust LLM summarisation of the list page** — it invented suburbs (returned Rowhill/Delmas). Extract fields from DOM; **open the detail page** to confirm type/erf. |
+| **Private Property** | Reliable direct listing URLs; good freehold resale stock | Browser DOM read | Medium-high; clean per-listing URLs | Many "cheap Selcourt" rows were a **new-build estate** — description tells ("new phase / now selling / estate") flag them. |
+| **MyRoof** | **Distressed goldmine** — EasySell / SIE / Pre-Hammer / FNB Quick Sell; own structured cards | Browser with its **filter form / correct URL** (plain fetch fell back to nationwide) | Medium; card fields + bank tag; detail page confirms programme | Bank tag ⇒ route + risk (EasySell = make-offer/occupied; SIE = auction/cash/voetstoots). "In Transaction" ≈ already gone. |
+| **Gumtree / OLX (property)** | Private-seller / off-market long-tail | Browser; noisy | Low; free-text | High noise; use only as supplementary, low confidence by default. |
+| **Licensed feed (A)** | Clean automated truth incl. **actual sold/transfer prices** | API | Highest | The only fully-automated + ToS-clean option; the v3 target. |
+
+**Extraction principles (non-negotiable, from the hallucination incident):**
+1. Ingest **structured fields only** (DOM nodes / feed fields) — never an LLM's prose summary
+   of a listing as a source of truth.
+2. **Validate every row** against the source URL's own detail page before it can be marked
+   `verified`; unopened rows stay `feed` and are caveated in UI (§5, §3.1).
+3. Maintain a **validated area→portal-code registry** (e.g. P24: Selection Park=1151,
+   Geduld=1093, Strubenvale=1161, Struisbult=1163, Rowhill=1145, Casseldale=1106,
+   Selcourt=1146, Dersley=1114, Modder East=1098). Codes are guessed wrong easily — pin them.
+4. **Respect robots.txt + rate limits** on any portal access, even for fact extraction.
+
+### 3.3 Residual-risk honesty on Option B
+
+Even "facts + link-out" **accesses** portal pages programmatically, which some portal ToS
+prohibit *regardless of what is stored*. B minimises risk (facts not copyrighted, we link
+out, low volume, attributed) but does **not** eliminate it. Mitigations: honour robots.txt,
+throttle, attribute every row, expose a kill-switch + takedown path, and treat **A (licensed
+feed)** as the clean end-state, not a "nice to have". Legal sign-off before enabling Springs.
+
+## 4. Users
+
+- **Primary:** value/fixer-upper buyer-investor (the person driving this).
+- **Secondary:** first-time buyer wanting the cheapest sound house in a good area.
+- **Public/anonymous** — no login. Weightings persist in `localStorage` only.
+
+## 5. Data model — the dimensions
+
+Each opportunity is one normalized record. Beyond the original three drivers we add the
+dimensions below. Each is stored raw **and** as a 1–10 sub-score for the matrix.
+
+### Core drivers (from the research session)
+| Field | Meaning | Score direction |
+|---|---|---|
+| `buyIn` | Asking / expected entry price | lower = better |
+| `flipPct` | `(ARV − buyIn − renoEst) / allIn` | higher = better |
+| `effort` | Renovation/regularisation work required | less = better |
+
+### Added key dimensions
+| Field | Meaning | Why it matters |
+|---|---|---|
+| `dealScore` | Price vs suburb median (% under/over) | Undervaluation is the flip engine |
+| `arvEstimate` (+ `arvBasis`, `arvConfidence`) | After-repair value, **preferring sold/transfer prices** (P24 Sold Prices / Deeds / Lightstone) over asking comps | Denominator of flip % — asking comps bias high and inflate flip %; record the basis + confidence |
+| `canonicalKey` | Normalised address + erf + geo hash | Collapses the **same house listed on multiple portals** into one record with many sources |
+| `renoCostEstimate` | R estimate derived from effort + floor size | Turns "effort" into money |
+| `rentalYieldGross` | Annual rent ÷ all-in | For hold/buy-to-let path |
+| `areaQuality` | Suburb desirability + safety index | Resale liquidity + risk |
+| `daysOnMarket` | Listing age / time-to-sell proxy | Motivated seller / liquidity signal |
+| `distressFlag` | none / EasySell / SIE-auction / Pre-Hammer / deceased / cash-only | Discount + risk profile |
+| `erfSize` + `zoning` + `subdividePotential` | Land + General Residential + 2nd-dwelling/subdivide | Non-cosmetic upside (e.g. the Geduld "2-for-1") |
+| `propertyType` | freehold house / sectional / new-dev unit | **Guardrail** — new-dev units are not flips (the mistake we must not repeat) |
+| `holdingCost` | Rates + levies monthly | Carry cost during reno |
+| `affordability` | Bond repayment + min gross income | Buyer reachability |
+| `transferFriction` | Transfer duty / no-transfer-duty / sectional | Once-off cost |
+| `physicalRisk` | Dolomite/sinkhole + flood flag for the stand | East Rand mining-ground reality |
+| `proximity` | Schools / transport / mall / hospital | Desirability + rentability |
+| `confidence` | verified (page opened) vs feed-only vs estimate | **Honesty marker** — surfaced in UI |
+| `sourceUrl` + `sourcePortal` + `lastSeen` | Provenance + freshness | Attribution + delisting detection |
+| `analystNote` | Short LLM-written plain-English take (opportunity + risk) | **Non-scoring** display aid (§5.1) |
+
+### Scoring engine
+- Each dimension → 1–10 sub-score via documented rubric (stored, not hardcoded in UI).
+- Composite = Σ(weightᵢ × subScoreᵢ) / Σweightᵢ.
+- Default weights emphasise the three named drivers; **user can re-weight live**.
+- `confidence` never feeds the score — it's shown as a badge so low-confidence rows
+  are visibly caveated, not silently ranked. **Feed-only rows cannot be presented as
+  fact and cannot hold the #1 slot** without a `verified` upgrade (detail page parsed).
+  This directly encodes the trust failures from the research session.
+
+### 5.1 LLM analyst note (non-scoring) — approved
+
+A short generated take per listing ("4-bed + flat, cosmetic TLC, income unit already built;
+watch the cash-only clause"). Guardrails:
+- **Never feeds the composite score** — all scoring stays deterministic code (the hallucination
+  risk is quarantined to a clearly-labelled prose field).
+- Generated **from the validated structured fields**, not from re-reading the page, so it can't
+  invent facts the row doesn't contain.
+- Labelled as AI-generated + "not financial advice"; regenerated on refresh; cached to control cost.
+- Only produced for `verified` rows (feed-only rows get no note).
+
+### 5.2 canonicalKey matching (approved — spike then workstream)
+
+Purpose: collapse the same physical house across portals/days into one record. Challenge:
+portals hide street addresses ("contact agent for address"), so exact address match often fails.
+
+- **When address/geo present:** geocode → `geohash`; key = `geohash + erf-bucket`.
+- **When address hidden (common):** fuzzy composite key on `suburb + erfSize(±tol) + bedrooms +
+  price-band + agentName/agency`; treat as *candidate* match with a confidence score.
+- Matches below a confidence threshold stay **separate** records (never silently merge) and, if
+  ambiguous, drop into the QA quarantine queue for exception review.
+- **Spike first** (measure false-merge rate on the Springs seed set) before wiring into ingest.
+
+### 5.3 Classifier & dedupe heuristics (lessons from the research session)
+
+**Property-type classifier** (the guardrail that stops new-dev units ranking as flips):
+- `erfSize == floorSize` → sectional/new-dev tell (e.g. 40 m²/56 m² "houses").
+- Description tokens: `estate`, `new phase`, `now selling`, `units`, `development` → new-dev.
+- Presence of monthly **levy** + recent listing date + several **identical-price siblings**
+  in the same complex → new-dev sold unit-by-unit, not a resale house.
+- Title type `Sectional` / `Sec Title` → exclude from flip ranking (flag as sectional).
+
+**Data-quality normalisation** (real dirt seen this session):
+- Nonsense erf values (e.g. `100 000 m²`, `16 777 m²` on a flat) → clamp/flag, don't score.
+- **Price ranges** (auction "R400k–R800k") → store min/max, use expected/reserve for scoring.
+- `cash only`, `no approved building plans` → raise `effort`, lower buyer pool, tag risk.
+- `Under Offer` / `In Transaction` → status-flag; down-rank or hide, don't present as buyable.
+
+## 6. Architecture (grounded in HOV)
+
+```
+                 ┌─────────────────────────────────────────────┐
+  Daily 04:00 →  │ Azure Function (Python) timerTrigger         │
+                 │  ingest → normalize → dedupe → score → write │
+                 └───────────────┬─────────────────────────────┘
+                                 │ BaserowClient (shared/utils.py)
+                                 ▼
+                 ┌─────────────────────────────────────────────┐
+                 │ Baserow table: deal_radar_listings          │
+                 │  (facts + sub-scores + provenance + lastSeen)│
+                 └───────────────┬─────────────────────────────┘
+                                 │ read (cached)
+                                 ▼
+     Next.js API route  app/api/radar/route.ts  (public, ISR/edge-cached)
+                                 │
+                                 ▼
+     Public page  app/radar/page.tsx  (unauth; client-side weighting UI)
+                                 │  links out ↗
+                                 ▼
+                    Source listing on Property24 / PP / MyRoof
+```
+
+- **Ingestion:** new timer function `DealRadarRefresh` (`schedule: "0 0 4 * * *"` = daily
+  04:00 UTC), same shape as `RecurringTasks`, writing to a new Baserow table via the
+  existing `BaserowClient`. Idempotent upsert keyed on `sourcePortal + listingId`.
+- **Storage:** Baserow (operational DB already in stack). Table `deal_radar_listings`.
+- **API:** `app/api/radar/route.ts`, public, returns normalized rows; heavily cached
+  (revalidate ~1h). No auth wrapper (unlike `withRole()` routes).
+- **Page:** `app/radar/page.tsx`, added to public-paths allowlist (same class as
+  `kiosk`). Client component for the weighting sliders + live re-rank; SSR the initial
+  list for SEO/first paint.
+- **Data mode:** respect HOV convention — empty unless the table is populated; behind a
+  `RADAR_ENABLED` flag so it ships dark.
+
+## 7. Daily auto-update mechanism (detail)
+
+1. **Trigger:** timer cron daily 04:00 UTC.
+2. **Fetch:** per chosen data source (§3) pull current candidate set for configured areas.
+3. **Normalize:** map to the schema; classify `propertyType` (reject/flag new-dev units);
+   compute derived fields (`renoCostEstimate`, `flipPct`, `dealScore`, sub-scores).
+4. **ARV/comps refresh:** recompute suburb median + done-up ARV, **preferring sold/transfer
+   prices** over asking comps; store `arvBasis` + `arvConfidence`.
+5. **Dedupe & upsert:** two levels — within-portal on `sourcePortal+listingId`, and
+   **cross-portal on `canonicalKey`** (address+erf+geo) so one house = one record, many
+   sources; update `lastSeen`.
+6. **Delisting / status:** rows not seen for N days → `status: delisted`; detect
+   `Under Offer` / `In Transaction` and down-rank or hide.
+7. **Change log:** price drops / status changes recorded (powers "reduced" + alerts).
+8. **Observability:** log counts, failures; alert on zero-rows / source-shape change.
+9. **Idempotent + resumable:** a re-run same day is a no-op beyond `lastSeen`.
+
+## 8. Feature set
+
+### MVP (v1)
+- Public ranked list with live weighting. The three drivers (effort / flip % / buy-in) are
+  the headline sliders; the rest of §5's dimensions are weightable via an "advanced" panel
+  and available as filters, so v1 carries the full dimension set (not a reduced cut).
+- Per-card: price, suburb, erf, property type, distress flag, confidence badge, deal
+  score, **link out** to source, `lastSeen` date.
+- Filters: area, price band, property type (freehold-only toggle), distress-only,
+  erf-size min, exclude "Under Offer".
+- Honesty UI: confidence badge, "estimate" markers on ARV/flip, data-provenance line.
+- Legal footer: source attribution, "not financial advice", ToS-safe framing.
+
+### v2
+- **Email/WhatsApp deal alerts** (reuse HOV notification-service / ACS + Twilio) — "new
+  ≥15% under-median freehold in your areas". (Alerts require capturing an email →
+  triggers POPIA consent; may cross the public/unauth boundary — see open decisions.)
+- **Saved weightings & watchlist** (still client-side, shareable via URL-encoded state).
+- **Map view** (erf + proximity + dolomite/flood overlay).
+- **Comparable / ARV drill-down** per listing.
+- **Repossessed/auction calendar** (SIE / Pre-Hammer dates).
+
+### v3
+- Multi-area / any-SA-town config.
+- Licensed feed (Option A) behind same schema.
+- Admin curation console (approve/verify rows, override scores) — authenticated.
+
+## 9. Other things we need (often forgotten)
+
+- **Compliance/attribution page** — sources, refresh cadence, disclaimer.
+- **Data provenance on every row** — portal + URL + `lastSeen` + confidence.
+- **Rate limiting + caching/CDN** on the public route (abuse + cost control).
+- **POPIA** — only relevant once we collect emails for alerts; consent + purpose.
+- **SEO / OG tags** — it's a public page; make it findable & shareable.
+- **Empty & error states** — HOV convention: empty unless configured, no fake demo data.
+- **Monitoring** — ingestion health, source-shape drift, zero-row alarm.
+- **Kill switch** — `RADAR_ENABLED` flag to disable instantly if a source objects.
+
+## 10. Compliance & risk
+
+- **ToS/copyright:** store facts + link out; never mirror descriptions/photos (Option
+  B/C). Attribute sources. Honor takedown/kill-switch.
+- **Not financial advice** disclaimer (mirrors the global rule against personalised
+  investment advice).
+- **Physical-risk data** (dolomite/flood) is indicative, not a survey — label as such.
+- **Mission fit:** this is off HOV's estate-management core. Placement decision below.
+
+## 11. Testing
+
+- Unit: scoring rubric (each dimension → sub-score), composite math, within- and
+  **cross-portal dedupe** (`canonicalKey`), property-type classifier (must reject new-dev
+  units via the §5.3 tells), ARV-basis preference (sold > asking), data-quality clamps
+  (nonsense erf, price ranges, cash-only), delisting/status logic. (Vitest.)
+- API: `app/api/radar` returns shape, is uncached-safe, no PII. (tests/api.)
+- E2E: public page loads unauth, sliders re-rank, links out, empty state. (Playwright.)
+- Ingestion: golden-file normalize test against captured source fixtures.
+
+## 12. Rollout / phasing
+
+1. Approve this spec + resolve open decisions.
+2. Baton epic + tasks under `house-of-veritas` project.
+3. Schema + scoring lib + tests (data layer) → veritas-ledger / TESTING.
+4. Ingestion function (dark, flag-off) → seed with the ~9 verified Springs listings.
+5. Public page + API + weighting UI → FRONTEND.
+6. Compliance/attribution + disclaimers → SECURITY/DOCS.
+7. Enable flag for Springs; measure; then v2.
+
+## 13. Decisions (resolved)
+
+1. **Data source:** ✅ **B+C agent-curated, run autonomously** (§3 + §3.1) — facts + link-out,
+   automated QA gate, human on exception only. Schema built feed-agnostic so a **licensed
+   feed (A)** drops in at v3 to erase even exception handling. No hard-scrape.
+2. **Placement:** ✅ `/radar` path on the HOV app now; extractable to its own app later.
+3. **Area scope v1:** ✅ Springs only.
+4. **Alerts:** ✅ v2 (deferred; email capture handled under POPIA when it lands).
+5. **Dimensions:** ✅ **Full expanded set from §5 in v1** (not a reduced cut) — all raw
+   fields + sub-scores; `confidence` shown, never scored.
+
+---
+
+### Appendix A — seed dataset (verified this session)
+The ~9 Springs listings already read and scored (Geduld 2-for-1, Geduld EasySell repo,
+Struisbult dated 1,420 m², Springs SIE, Strubenvale fixer+flat, Selection Park +flatlet,
+Modder East cash-only, Modder East EasySell, Strubenvale 6-bed) seed the table so v1
+launches non-empty.

--- a/lib/services/radar/canonical-key.ts
+++ b/lib/services/radar/canonical-key.ts
@@ -1,0 +1,45 @@
+/**
+ * House of Veritas - Property Deal Radar: canonicalKey field normaliser (§5.2)
+ *
+ * Radar 1 defines the `canonicalKey` FIELD and a deterministic normaliser only.
+ * Fuzzy candidate matching / cross-portal dedupe is Radar 2 — NOT implemented here.
+ */
+
+export interface CanonicalKeyFields {
+  suburb: string
+  erfSizeM2?: number | null
+  /** Present only when the source exposes an address / geocode. */
+  geohash?: string | null
+  bedrooms?: number | null
+}
+
+/** erf bucket width (m²) — tolerates capture jitter without fuzzy matching. */
+export const ERF_BUCKET_M2 = 50
+
+function normaliseSuburb(suburb: string): string {
+  return suburb
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+function erfBucket(erfSizeM2: number | null | undefined): string {
+  if (erfSizeM2 == null || !Number.isFinite(erfSizeM2) || erfSizeM2 <= 0) return "na"
+  return String(Math.round(erfSizeM2 / ERF_BUCKET_M2) * ERF_BUCKET_M2)
+}
+
+/**
+ * Deterministic normalised key. When a geohash is present it anchors the key
+ * (geohash + erf bucket); otherwise it falls back to a composite of the
+ * non-address facts. This is purely the stored field — it performs NO matching.
+ */
+export function computeCanonicalKey(fields: CanonicalKeyFields): string {
+  const erf = erfBucket(fields.erfSizeM2)
+  if (fields.geohash) {
+    return `geo:${fields.geohash}:erf${erf}`
+  }
+  const suburb = normaliseSuburb(fields.suburb)
+  const beds = fields.bedrooms != null && fields.bedrooms > 0 ? String(fields.bedrooms) : "na"
+  return `sub:${suburb}:erf${erf}:bed${beds}`
+}

--- a/lib/services/radar/classifier.ts
+++ b/lib/services/radar/classifier.ts
@@ -1,0 +1,104 @@
+/**
+ * House of Veritas - Property Deal Radar: property-type classifier (§5.3)
+ *
+ * The guardrail that stops new-dev / sectional units ranking as flips (the mistake
+ * the research session must not repeat). Deterministic, pure — no LLM, no network.
+ * Any tell firing marks the row ineligible for flip ranking; the fired tells are
+ * returned in `reasons` for transparency.
+ */
+
+import type { PropertyClassification } from "./types"
+
+export interface ClassifierInput {
+  /** Title-deed type, e.g. "Freehold" | "Sectional" | "Sec Title". */
+  titleType?: string | null
+  erfSizeM2?: number | null
+  floorSizeM2?: number | null
+  description?: string | null
+  monthlyLevyCents?: number | null
+  /** ISO listing date, used with `now` for the recency tell. */
+  listedDate?: string | null
+  /** Prices of same-complex siblings; identical prices signal unit-by-unit sale. */
+  siblingPricesCents?: number[]
+  /** Injectable "current" ISO date for deterministic tests. Defaults to now. */
+  now?: string
+}
+
+/** New-development marketing tokens (§5.3). */
+export const NEW_DEV_TOKENS = [
+  "estate",
+  "new phase",
+  "now selling",
+  "units",
+  "development",
+] as const
+
+/** A listing newer than this is "recent" for the levy+recent+siblings tell. */
+export const RECENT_LISTING_DAYS = 45
+/** Number of identical-price siblings that signals a sold-unit-by-unit complex. */
+export const MIN_IDENTICAL_SIBLINGS = 2
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function isRecent(listedDate: string | null | undefined, now: string | undefined, days: number): boolean {
+  if (!listedDate) return false
+  const listed = Date.parse(listedDate)
+  const nowMs = now ? Date.parse(now) : Date.now()
+  if (Number.isNaN(listed) || Number.isNaN(nowMs)) return false
+  return nowMs >= listed && nowMs - listed <= days * DAY_MS
+}
+
+/** Size of the largest identical-price group among the siblings. */
+function maxIdenticalSiblings(prices: number[] | undefined): number {
+  if (!prices || prices.length === 0) return 0
+  const counts = new Map<number, number>()
+  let max = 0
+  for (const price of prices) {
+    const next = (counts.get(price) ?? 0) + 1
+    counts.set(price, next)
+    if (next > max) max = next
+  }
+  return max
+}
+
+export function classifyPropertyType(input: ClassifierInput): PropertyClassification {
+  const reasons: string[] = []
+
+  // Strongest signal: the title deed itself. Sectional title is never a flip house.
+  if (input.titleType && /sectional|sec\s*title/i.test(input.titleType)) {
+    reasons.push("title-sectional")
+    return { propertyType: "sectional", isFlipEligible: false, reasons }
+  }
+
+  // erf == floor: a "house" whose stand equals its under-roof area is a unit,
+  // not a freehold house on land (e.g. the 40 m² / 56 m² "houses").
+  if (
+    input.erfSizeM2 != null &&
+    input.floorSizeM2 != null &&
+    input.erfSizeM2 > 0 &&
+    input.erfSizeM2 === input.floorSizeM2
+  ) {
+    reasons.push("erf-equals-floor")
+  }
+
+  // Off-plan / sold-unit-by-unit marketing language.
+  const description = (input.description ?? "").toLowerCase()
+  for (const token of NEW_DEV_TOKENS) {
+    if (description.includes(token)) reasons.push(`token:${token}`)
+  }
+
+  // Monthly levy + recent listing + several identical-price siblings = a complex
+  // being sold unit-by-unit, not a resale house.
+  const hasLevy = input.monthlyLevyCents != null && input.monthlyLevyCents > 0
+  const recent = isRecent(input.listedDate, input.now, RECENT_LISTING_DAYS)
+  const identicalSiblings = maxIdenticalSiblings(input.siblingPricesCents)
+  if (hasLevy && recent && identicalSiblings >= MIN_IDENTICAL_SIBLINGS) {
+    reasons.push("levy+recent+identical-siblings")
+  }
+
+  if (reasons.length > 0) {
+    return { propertyType: "new-dev-unit", isFlipEligible: false, reasons }
+  }
+
+  return { propertyType: "freehold-house", isFlipEligible: true, reasons }
+}

--- a/lib/services/radar/data-quality.ts
+++ b/lib/services/radar/data-quality.ts
@@ -1,0 +1,98 @@
+/**
+ * House of Veritas - Property Deal Radar: data-quality normalisation (§5.3)
+ *
+ * Pure functions that clean the "real dirt" seen in the research session:
+ * nonsense erf values, auction price ranges, cash-only / no-plans risk, and
+ * non-buyable ("Under Offer" / "In Transaction") status. No network, no LLM.
+ */
+
+import { MAX_PLAUSIBLE_ERF_M2 } from "./rubrics"
+import type {
+  DataQualityFlag,
+  EffortLevel,
+  ListingStatus,
+  PriceInput,
+} from "./types"
+
+const EFFORT_ORDER: readonly EffortLevel[] = ["cosmetic", "moderate", "major", "severe"]
+
+/**
+ * Clamp/flag nonsense erf. Non-positive or implausibly large stands (e.g. the
+ * 100 000 m² / 16 777 m² "flats" seen this session) are dropped to null and
+ * flagged rather than scored.
+ */
+export function normaliseErf(
+  erfSizeM2: number | null | undefined
+): { value: number | null; flags: DataQualityFlag[] } {
+  const flags: DataQualityFlag[] = []
+  if (erfSizeM2 == null || Number.isNaN(erfSizeM2)) {
+    return { value: null, flags }
+  }
+  if (erfSizeM2 <= 0) {
+    flags.push({ kind: "erf-nonpositive", rawValue: erfSizeM2 })
+    return { value: null, flags }
+  }
+  if (erfSizeM2 > MAX_PLAUSIBLE_ERF_M2) {
+    flags.push({ kind: "erf-implausible", rawValue: erfSizeM2 })
+    return { value: null, flags }
+  }
+  return { value: erfSizeM2, flags }
+}
+
+/**
+ * Resolve the price used for scoring. Auctions expose a range (§5.3) — score on
+ * the expected/reserve value, never the optimistic max. Reserve defaults to the
+ * range minimum when no explicit expected is supplied.
+ */
+export function resolveBuyInCents(price: PriceInput): number {
+  if (price.kind === "fixed") return price.cents
+  return price.expectedCents ?? price.minCents
+}
+
+/** Flag a range price so the UI can caveat it. */
+export function priceRangeFlags(price: PriceInput): DataQualityFlag[] {
+  if (price.kind === "range") {
+    return [{ kind: "price-range", minCents: price.minCents, maxCents: price.maxCents }]
+  }
+  return []
+}
+
+/**
+ * `cash only` and `no approved building plans` both raise effort (more work /
+ * regularisation), shrink the buyer pool and are tagged as risk (§5.3). Effort is
+ * bumped one level per flag, capped at `severe`.
+ */
+export function applyEffortRisk(
+  effort: EffortLevel,
+  opts: { cashOnly?: boolean; noApprovedPlans?: boolean }
+): { effort: EffortLevel; flags: DataQualityFlag[] } {
+  const flags: DataQualityFlag[] = []
+  let idx = EFFORT_ORDER.indexOf(effort)
+  if (idx < 0) idx = 0
+  if (opts.noApprovedPlans) {
+    idx = Math.min(EFFORT_ORDER.length - 1, idx + 1)
+    flags.push({ kind: "no-approved-plans" })
+  }
+  if (opts.cashOnly) {
+    idx = Math.min(EFFORT_ORDER.length - 1, idx + 1)
+    flags.push({ kind: "cash-only" })
+  }
+  return { effort: EFFORT_ORDER[idx], flags }
+}
+
+/** Only `active` rows may be presented as buyable (§5.3). */
+export function isBuyable(status: ListingStatus): boolean {
+  return status.kind === "active"
+}
+
+/** Flags for non-buyable statuses so the UI can down-rank / hide them. */
+export function statusDataQualityFlags(status: ListingStatus): DataQualityFlag[] {
+  switch (status.kind) {
+    case "under-offer":
+      return [{ kind: "status-under-offer" }]
+    case "in-transaction":
+      return [{ kind: "status-in-transaction" }]
+    default:
+      return []
+  }
+}

--- a/lib/services/radar/index.ts
+++ b/lib/services/radar/index.ts
@@ -1,0 +1,13 @@
+/**
+ * House of Veritas - Property Deal Radar data layer (Radar 1).
+ *
+ * Pure, deterministic types + scoring. No UI, API, ingestion or network here.
+ * See docs/specs/property-deal-radar.md.
+ */
+
+export * from "./types"
+export * from "./rubrics"
+export * from "./data-quality"
+export * from "./classifier"
+export * from "./scoring"
+export * from "./canonical-key"

--- a/lib/services/radar/rubrics.ts
+++ b/lib/services/radar/rubrics.ts
@@ -1,0 +1,230 @@
+/**
+ * House of Veritas - Property Deal Radar: scoring rubrics
+ *
+ * Rubric thresholds live here as DATA (not hardcoded inline in a UI, per §5).
+ * Every threshold carries a "why" comment. All money thresholds are in integer
+ * cents (ZAR); helper `rands()` keeps them readable.
+ *
+ * Band tables are consumed by the generic scorers in `scoring.ts`:
+ *  - "lower-is-better" tables are ordered by ASCENDING threshold; the first band
+ *    whose threshold is >= the value wins.
+ *  - "higher-is-better" tables are ordered by DESCENDING threshold; the first band
+ *    whose threshold is <= the value wins.
+ */
+
+import type {
+  DistressKind,
+  EffortLevel,
+  SubScoreWeights,
+  TransferFrictionKind,
+} from "./types"
+
+/** Rand → integer cents. */
+export const rands = (rand: number): number => Math.round(rand * 100)
+
+export interface ScoreBand {
+  threshold: number
+  score: number
+}
+
+// ── Core drivers ─────────────────────────────────────────────────────────────
+
+/**
+ * buyIn — lower entry = more flip headroom AND a wider buyer pool on resale.
+ * Springs resale median sits ~R700k–R900k, so sub-R450k is exceptional entry.
+ */
+export const BUY_IN_BANDS: readonly ScoreBand[] = [
+  { threshold: rands(450_000), score: 10 }, // rock-bottom entry, max margin
+  { threshold: rands(650_000), score: 8 }, // below median, strong
+  { threshold: rands(850_000), score: 6 }, // ~median
+  { threshold: rands(1_100_000), score: 4 }, // above median / transfer-duty line
+  { threshold: rands(1_500_000), score: 2 }, // pricey for a Springs flip
+]
+
+/**
+ * flipPct — 20% is the conventional minimum viable flip margin; below ~12% the
+ * transfer/holding/agent costs eat the profit. Stored as a ratio (0.20 = 20%).
+ */
+export const FLIP_PCT_BANDS: readonly ScoreBand[] = [
+  { threshold: 0.4, score: 10 }, // exceptional
+  { threshold: 0.3, score: 8 }, // very strong
+  { threshold: 0.2, score: 6 }, // viable flip floor
+  { threshold: 0.12, score: 4 }, // thin
+  { threshold: 0.05, score: 2 }, // marginal
+]
+
+/**
+ * effort — cosmetic TLC flips fastest with least capital; "severe" covers gutting
+ * or regularising unpermitted work, which drags timeline, capital and risk.
+ */
+export const EFFORT_SUBSCORES: Record<EffortLevel, number> = {
+  cosmetic: 10, // paint / floors / fittings
+  moderate: 7, // kitchen + bath refit
+  major: 4, // structural, roof, rewire
+  severe: 2, // gut + regularise
+}
+
+// ── Added dimensions ─────────────────────────────────────────────────────────
+
+/**
+ * dealScore — percentage points under suburb median. >=15% under is the alert
+ * threshold named in §8; 25%+ is a genuine outlier (the flip engine).
+ */
+export const DEAL_SCORE_BANDS: readonly ScoreBand[] = [
+  { threshold: 25, score: 10 }, // deep discount
+  { threshold: 15, score: 8 }, // alert-worthy under-median
+  { threshold: 8, score: 6 }, // modest discount
+  { threshold: 0, score: 4 }, // at median
+  { threshold: -10, score: 2 }, // slightly over median
+]
+
+/** renoCost (cents) — lower spend = more of the margin survives. */
+export const RENO_COST_BANDS: readonly ScoreBand[] = [
+  { threshold: rands(80_000), score: 10 },
+  { threshold: rands(150_000), score: 8 },
+  { threshold: rands(300_000), score: 6 },
+  { threshold: rands(500_000), score: 4 },
+  { threshold: rands(800_000), score: 2 },
+]
+
+/**
+ * renoCostEstimate is derived from effort × floor size. Rates are R/m² of floor,
+ * stored in cents. Cosmetic ≈ finishes only; severe ≈ gut + regularise.
+ */
+export const RENO_RATE_CENTS_PER_M2: Record<EffortLevel, number> = {
+  cosmetic: rands(2_500), // R2 500/m² — paint, floors, fittings
+  moderate: rands(4_500), // R4 500/m² — kitchen/bath refit
+  major: rands(7_500), // R7 500/m² — structural, roof, rewire
+  severe: rands(11_000), // R11 000/m² — gut + regularise unpermitted work
+}
+
+/** rentalYieldGross (ratio) — SA gross residential yields run ~6–11%. */
+export const RENTAL_YIELD_BANDS: readonly ScoreBand[] = [
+  { threshold: 0.11, score: 10 },
+  { threshold: 0.09, score: 8 },
+  { threshold: 0.07, score: 6 },
+  { threshold: 0.05, score: 4 },
+  { threshold: 0.03, score: 2 },
+]
+
+/** areaQuality (0-100 desirability + safety index) — resale liquidity + risk. */
+export const AREA_QUALITY_BANDS: readonly ScoreBand[] = [
+  { threshold: 80, score: 10 },
+  { threshold: 65, score: 8 },
+  { threshold: 50, score: 6 },
+  { threshold: 35, score: 4 },
+  { threshold: 20, score: 2 },
+]
+
+/**
+ * daysOnMarket — a HIGHER value is better for the BUYER: a stale listing signals
+ * a motivated seller and negotiating leverage / likely price cut. A fresh listing
+ * floors at 2 (not 1): a genuine deal can also be new to market.
+ */
+export const DAYS_ON_MARKET_BANDS: readonly ScoreBand[] = [
+  { threshold: 120, score: 10 }, // very stale — strong leverage
+  { threshold: 90, score: 8 },
+  { threshold: 60, score: 6 },
+  { threshold: 30, score: 4 },
+  { threshold: 14, score: 3 },
+]
+
+/**
+ * distress — each programme is a discount opportunity net of execution friction.
+ * `none` is neutral (5): no distress discount, but no distress risk either.
+ */
+export const DISTRESS_SUBSCORES: Record<DistressKind, number> = {
+  none: 5, // neutral
+  "pre-hammer": 8, // pre-auction discount, less friction than a live auction
+  easysell: 7, // bank discount but occupied / make-an-offer friction
+  deceased: 7, // motivated estate, but executor/estate delays
+  "sie-auction": 6, // deep discount but cash / voetstoots / occupied risk
+  "cash-only": 5, // discount possible but a tiny buyer pool caps upside
+}
+
+/**
+ * transferFriction — SA transfer-duty exemption sits under ~R1.1m; avoiding duty
+ * saves a real once-off cost. Sectional avoids duty but carries complex friction.
+ */
+export const TRANSFER_FRICTION_SUBSCORES: Record<TransferFrictionKind, number> = {
+  "no-transfer-duty": 10,
+  sectional: 6,
+  "transfer-duty": 4,
+}
+
+/**
+ * landUpside — bigger stand + subdivide potential = non-cosmetic upside (the
+ * Geduld "2-for-1"). Base on erf size; add a bonus for subdivide potential.
+ */
+export const LAND_ERF_BANDS: readonly ScoreBand[] = [
+  { threshold: 1200, score: 8 }, // large stand, room for a 2nd dwelling
+  { threshold: 900, score: 6 },
+  { threshold: 600, score: 5 },
+  { threshold: 300, score: 4 },
+]
+export const LAND_ERF_FLOOR = 3
+/** Added to the erf base when the stand can be subdivided / carry a 2nd dwelling. */
+export const SUBDIVIDE_BONUS = 2
+
+/** holdingCost (monthly cents) — rates + levies are the carry cost during reno. */
+export const HOLDING_COST_BANDS: readonly ScoreBand[] = [
+  { threshold: rands(1_500), score: 10 },
+  { threshold: rands(3_000), score: 8 },
+  { threshold: rands(5_000), score: 6 },
+  { threshold: rands(8_000), score: 4 },
+]
+
+/** affordability (monthly bond cents) — lower repayment = reachable by more buyers. */
+export const AFFORDABILITY_BANDS: readonly ScoreBand[] = [
+  { threshold: rands(5_000), score: 10 },
+  { threshold: rands(8_000), score: 8 },
+  { threshold: rands(12_000), score: 6 },
+  { threshold: rands(18_000), score: 4 },
+  { threshold: rands(25_000), score: 2 },
+]
+
+/** proximity (0-100 schools/transport/mall/hospital index) — desirability + rentability. */
+export const PROXIMITY_BANDS: readonly ScoreBand[] = [
+  { threshold: 80, score: 10 },
+  { threshold: 65, score: 8 },
+  { threshold: 50, score: 6 },
+  { threshold: 35, score: 4 },
+  { threshold: 20, score: 2 },
+]
+
+// ── Composite weights ────────────────────────────────────────────────────────
+
+/**
+ * Default weights. The three named drivers (effort / flipPct / buyIn) carry the
+ * heaviest weight (§5); the rest are supporting signals. Users re-weight live in
+ * the UI (Radar frontend), so these are only defaults.
+ */
+export const DEFAULT_WEIGHTS: SubScoreWeights = {
+  effort: 3,
+  flipPct: 3,
+  buyIn: 3,
+  dealScore: 2,
+  areaQuality: 2,
+  renoCost: 1,
+  rentalYield: 1,
+  daysOnMarket: 1,
+  distress: 1,
+  landUpside: 1,
+  holdingCost: 1,
+  affordability: 1,
+  transferFriction: 1,
+  physicalRisk: 1,
+  proximity: 1,
+}
+
+/** Neutral fallback for a dimension whose raw fact is missing. */
+export const NEUTRAL_SUBSCORE = 5
+
+/**
+ * flipPct fallback when ARV is unknown: mildly penalised (3, not neutral 5) — an
+ * unknown flip margin should not read as an average one.
+ */
+export const FLIP_PCT_UNKNOWN_SUBSCORE = 3
+
+/** Residential stands above this (m²) are almost always a capture error (§5.3). */
+export const MAX_PLAUSIBLE_ERF_M2 = 4000

--- a/lib/services/radar/scoring.ts
+++ b/lib/services/radar/scoring.ts
@@ -1,0 +1,283 @@
+/**
+ * House of Veritas - Property Deal Radar: scoring engine (§5)
+ *
+ * Deterministic, pure functions. NO LLM, NO network. Each §5 dimension maps to a
+ * 1-10 sub-score via a documented rubric (see rubrics.ts). Composite is the
+ * weighted mean of the sub-scores; `confidence` NEVER feeds it.
+ */
+
+import { isBuyable, normaliseErf, resolveBuyInCents } from "./data-quality"
+import {
+  AFFORDABILITY_BANDS,
+  AREA_QUALITY_BANDS,
+  BUY_IN_BANDS,
+  DAYS_ON_MARKET_BANDS,
+  DEAL_SCORE_BANDS,
+  DEFAULT_WEIGHTS,
+  DISTRESS_SUBSCORES,
+  EFFORT_SUBSCORES,
+  FLIP_PCT_BANDS,
+  FLIP_PCT_UNKNOWN_SUBSCORE,
+  HOLDING_COST_BANDS,
+  LAND_ERF_BANDS,
+  LAND_ERF_FLOOR,
+  NEUTRAL_SUBSCORE,
+  PROXIMITY_BANDS,
+  RENO_COST_BANDS,
+  RENO_RATE_CENTS_PER_M2,
+  RENTAL_YIELD_BANDS,
+  SUBDIVIDE_BONUS,
+  TRANSFER_FRICTION_SUBSCORES,
+  type ScoreBand,
+} from "./rubrics"
+import type {
+  ArvBasis,
+  ArvComp,
+  ArvConfidence,
+  DealRadarDerived,
+  DealRadarFacts,
+  DealRadarListing,
+  DistressFlag,
+  EffortLevel,
+  PhysicalRisk,
+  RankedListing,
+  SubScores,
+  SubScoreWeights,
+  TransferFriction,
+} from "./types"
+
+// ── Generic band scorers ─────────────────────────────────────────────────────
+
+/** Lower raw value = better. Bands are ascending; first threshold >= value wins. */
+export function scoreLowerIsBetter(value: number, bands: readonly ScoreBand[], floor = 1): number {
+  for (const band of bands) {
+    if (value <= band.threshold) return band.score
+  }
+  return floor
+}
+
+/** Higher raw value = better. Bands are descending; first threshold <= value wins. */
+export function scoreHigherIsBetter(value: number, bands: readonly ScoreBand[], floor = 1): number {
+  for (const band of bands) {
+    if (value >= band.threshold) return band.score
+  }
+  return floor
+}
+
+// ── Per-dimension sub-scores ─────────────────────────────────────────────────
+
+export const scoreBuyIn = (buyInCents: number): number => scoreLowerIsBetter(buyInCents, BUY_IN_BANDS)
+export const scoreFlipPct = (flipPct: number): number => scoreHigherIsBetter(flipPct, FLIP_PCT_BANDS)
+export const scoreEffort = (effort: EffortLevel): number => EFFORT_SUBSCORES[effort]
+export const scoreDealScore = (dealScore: number): number => scoreHigherIsBetter(dealScore, DEAL_SCORE_BANDS)
+export const scoreRenoCost = (renoCents: number): number => scoreLowerIsBetter(renoCents, RENO_COST_BANDS)
+export const scoreRentalYield = (yieldGross: number): number => scoreHigherIsBetter(yieldGross, RENTAL_YIELD_BANDS)
+export const scoreAreaQuality = (index: number): number => scoreHigherIsBetter(index, AREA_QUALITY_BANDS)
+export const scoreDaysOnMarket = (days: number): number => scoreHigherIsBetter(days, DAYS_ON_MARKET_BANDS, 2)
+export const scoreDistress = (flag: DistressFlag): number => DISTRESS_SUBSCORES[flag.kind]
+export const scoreHoldingCost = (monthlyCents: number): number => scoreLowerIsBetter(monthlyCents, HOLDING_COST_BANDS, 2)
+export const scoreAffordability = (monthlyBondCents: number): number => scoreLowerIsBetter(monthlyBondCents, AFFORDABILITY_BANDS)
+export const scoreTransferFriction = (tf: TransferFriction): number => TRANSFER_FRICTION_SUBSCORES[tf.kind]
+export const scoreProximity = (index: number): number => scoreHigherIsBetter(index, PROXIMITY_BANDS)
+
+/** Dolomite is an East Rand mortgage/insurance killer; flood is serious but lesser. */
+export function scorePhysicalRisk(risk: PhysicalRisk): number {
+  if (risk.dolomite && risk.flood) return 2
+  if (risk.dolomite) return 4
+  if (risk.flood) return 6
+  return 10
+}
+
+/** Bigger stand + subdivide potential = non-cosmetic upside (the "2-for-1"). */
+export function scoreLandUpside(input: {
+  erfSizeM2: number | null
+  subdividePotential: boolean
+}): number {
+  const base = scoreHigherIsBetter(input.erfSizeM2 ?? 0, LAND_ERF_BANDS, LAND_ERF_FLOOR)
+  const bonus = input.subdividePotential ? SUBDIVIDE_BONUS : 0
+  return Math.min(10, base + bonus)
+}
+
+// ── Derived money/ratio maths ────────────────────────────────────────────────
+
+/**
+ * flipPct = (ARV − buyIn − renoEst) / allIn (§5). allIn includes optional extra
+ * acquisition costs (transfer duty, holding) which default to 0 so the core
+ * formula is exact. Returns null when there is no positive all-in basis.
+ */
+export function computeFlipPct(input: {
+  arvCents: number
+  buyInCents: number
+  renoCents: number
+  extraCostsCents?: number
+}): number | null {
+  const { arvCents, buyInCents, renoCents, extraCostsCents = 0 } = input
+  const allIn = buyInCents + renoCents + extraCostsCents
+  if (allIn <= 0) return null
+  return (arvCents - buyInCents - renoCents) / allIn
+}
+
+/** Percentage points under (positive) / over suburb median. */
+export function computeDealScore(buyInCents: number, suburbMedianCents: number): number | null {
+  if (suburbMedianCents <= 0) return null
+  return ((suburbMedianCents - buyInCents) / suburbMedianCents) * 100
+}
+
+/** Gross annual rental yield = (monthlyRent × 12) / allIn. */
+export function computeRentalYieldGross(monthlyRentCents: number, allInCents: number): number | null {
+  if (allInCents <= 0) return null
+  return (monthlyRentCents * 12) / allInCents
+}
+
+/** renoCostEstimate = R/m² (by effort) × floor size. */
+export function computeRenoCostCents(effort: EffortLevel, floorSizeM2: number): number {
+  return Math.round(RENO_RATE_CENTS_PER_M2[effort] * Math.max(0, floorSizeM2))
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? Math.round((sorted[mid - 1] + sorted[mid]) / 2) : sorted[mid]
+}
+
+/**
+ * ARV basis (§5): PREFER sold/transfer comps over asking comps, because asking
+ * comps bias high and inflate flip %. Sold comps can reach `high` confidence;
+ * asking comps are capped at `medium`. Records the basis + sample size.
+ */
+export function resolveArv(comps: readonly ArvComp[]): {
+  arvEstimateCents: number | null
+  basis: ArvBasis
+  confidence: ArvConfidence
+} {
+  const sold = comps.filter((c) => c.kind === "sold-transfer").map((c) => c.valueCents)
+  if (sold.length > 0) {
+    return {
+      arvEstimateCents: median(sold),
+      basis: { kind: "sold-transfer", sampleSize: sold.length },
+      confidence: sold.length >= 3 ? "high" : "medium",
+    }
+  }
+  const asking = comps.filter((c) => c.kind === "asking").map((c) => c.valueCents)
+  if (asking.length > 0) {
+    return {
+      arvEstimateCents: median(asking),
+      basis: { kind: "asking-comps", sampleSize: asking.length },
+      confidence: asking.length >= 3 ? "medium" : "low",
+    }
+  }
+  return { arvEstimateCents: null, basis: { kind: "none" }, confidence: "low" }
+}
+
+// ── Facts → derived → sub-scores ─────────────────────────────────────────────
+
+export function computeDerived(facts: DealRadarFacts): DealRadarDerived {
+  const buyInCents = resolveBuyInCents(facts.price)
+  const renoCents = facts.renoCostEstimateCents ?? 0
+  const allInCents = buyInCents + renoCents
+  const flipPct =
+    facts.arvEstimateCents != null
+      ? computeFlipPct({ arvCents: facts.arvEstimateCents, buyInCents, renoCents })
+      : null
+  const dealScore =
+    facts.suburbMedianCents != null ? computeDealScore(buyInCents, facts.suburbMedianCents) : null
+  const rentalYieldGross =
+    facts.monthlyRentCents != null ? computeRentalYieldGross(facts.monthlyRentCents, allInCents) : null
+  return { buyInCents, allInCents, flipPct, dealScore, rentalYieldGross }
+}
+
+/**
+ * Assemble all 1-10 sub-scores from facts. Missing raw facts fall back to a
+ * documented neutral (5), except flipPct which is mildly penalised (3) when ARV
+ * is unknown. `confidence` is never scored here.
+ */
+export function computeSubScores(
+  facts: DealRadarFacts,
+  derived: DealRadarDerived = computeDerived(facts)
+): SubScores {
+  const erf = normaliseErf(facts.erfSizeM2).value
+  return {
+    buyIn: scoreBuyIn(derived.buyInCents),
+    flipPct: derived.flipPct == null ? FLIP_PCT_UNKNOWN_SUBSCORE : scoreFlipPct(derived.flipPct),
+    effort: scoreEffort(facts.effort),
+    dealScore: derived.dealScore == null ? NEUTRAL_SUBSCORE : scoreDealScore(derived.dealScore),
+    renoCost: facts.renoCostEstimateCents == null ? NEUTRAL_SUBSCORE : scoreRenoCost(facts.renoCostEstimateCents),
+    rentalYield: derived.rentalYieldGross == null ? NEUTRAL_SUBSCORE : scoreRentalYield(derived.rentalYieldGross),
+    areaQuality: facts.areaQualityIndex == null ? NEUTRAL_SUBSCORE : scoreAreaQuality(facts.areaQualityIndex),
+    daysOnMarket: facts.daysOnMarket == null ? NEUTRAL_SUBSCORE : scoreDaysOnMarket(facts.daysOnMarket),
+    distress: scoreDistress(facts.distressFlag),
+    landUpside: scoreLandUpside({ erfSizeM2: erf, subdividePotential: facts.subdividePotential }),
+    holdingCost: facts.holdingCostMonthlyCents == null ? NEUTRAL_SUBSCORE : scoreHoldingCost(facts.holdingCostMonthlyCents),
+    affordability: facts.monthlyBondCents == null ? NEUTRAL_SUBSCORE : scoreAffordability(facts.monthlyBondCents),
+    transferFriction: scoreTransferFriction(facts.transferFriction),
+    physicalRisk: scorePhysicalRisk(facts.physicalRisk),
+    proximity: facts.proximityIndex == null ? NEUTRAL_SUBSCORE : scoreProximity(facts.proximityIndex),
+  }
+}
+
+// ── Composite ────────────────────────────────────────────────────────────────
+
+/** Composite = Σ(weightᵢ · subScoreᵢ) / Σweightᵢ. `confidence` is never included. */
+export function computeComposite(
+  subScores: SubScores,
+  weights: SubScoreWeights = DEFAULT_WEIGHTS
+): number {
+  let weighted = 0
+  let total = 0
+  for (const key of Object.keys(weights) as (keyof SubScores)[]) {
+    const w = weights[key]
+    weighted += w * subScores[key]
+    total += w
+  }
+  return total === 0 ? 0 : weighted / total
+}
+
+// ── Ranking with the confidence/status guards ────────────────────────────────
+
+/** A row may hold the #1 slot only if it is buyable AND verified (§5). */
+function eligibleForTop(listing: DealRadarListing): boolean {
+  return isBuyable(listing.status) && listing.confidence.kind === "verified"
+}
+
+/**
+ * Rank listings by composite, then enforce the trust guards from §5:
+ *  - Non-buyable rows (Under Offer / In Transaction) sort below all buyable rows.
+ *  - A feed-only (unverified) row cannot HOLD the #1 slot: if the natural leader
+ *    is not verified+buyable, the highest-composite verified+buyable row is
+ *    promoted to #1 (`guardApplied`). If no verified row exists at all, the #1
+ *    row stays but is marked `provisionalTop`.
+ */
+export function rankListings(
+  listings: readonly DealRadarListing[],
+  weights: SubScoreWeights = DEFAULT_WEIGHTS
+): RankedListing[] {
+  const scored = listings.map((listing) => ({
+    listing,
+    composite: computeComposite(listing.subScores, weights),
+  }))
+
+  scored.sort((a, b) => {
+    const aBuyable = isBuyable(a.listing.status) ? 0 : 1
+    const bBuyable = isBuyable(b.listing.status) ? 0 : 1
+    if (aBuyable !== bBuyable) return aBuyable - bBuyable
+    return b.composite - a.composite
+  })
+
+  let guardApplied = false
+  if (scored.length > 0 && !eligibleForTop(scored[0].listing)) {
+    const promoteIdx = scored.findIndex((s) => eligibleForTop(s.listing))
+    if (promoteIdx > 0) {
+      const [top] = scored.splice(promoteIdx, 1)
+      scored.unshift(top)
+      guardApplied = true
+    }
+  }
+
+  return scored.map((entry, index) => ({
+    listing: entry.listing,
+    composite: entry.composite,
+    rank: index + 1,
+    guardApplied: index === 0 ? guardApplied : false,
+    provisionalTop: index === 0 ? !eligibleForTop(entry.listing) : false,
+  }))
+}

--- a/lib/services/radar/types.ts
+++ b/lib/services/radar/types.ts
@@ -1,0 +1,217 @@
+/**
+ * House of Veritas - Property Deal Radar: data model
+ *
+ * Radar 1 (data layer). Types for a `deal_radar_listings` record: raw facts +
+ * 1-10 sub-scores + provenance + status + confidence + canonicalKey + analystNote.
+ * See docs/specs/property-deal-radar.md §5.
+ *
+ * Money is ALWAYS stored as integer cents (ZAR). Never floating-point Rand.
+ * Discriminated unions (with a `kind` tag) encode the states the spec implies.
+ */
+
+// ── Provenance ───────────────────────────────────────────────────────────────
+
+export type SourcePortal =
+  | "property24"
+  | "private-property"
+  | "myroof"
+  | "gumtree"
+  | "olx"
+  | "licensed-feed"
+
+export interface Provenance {
+  sourceUrl: string
+  sourcePortal: SourcePortal
+  /** ISO date (YYYY-MM-DD) the row was last confirmed present at the source. */
+  lastSeen: string
+}
+
+// ── Honesty markers ──────────────────────────────────────────────────────────
+
+/**
+ * Confidence in the row. Never feeds the composite score (§5) — it is a badge.
+ * `verified` = detail page opened + parsed this run; `feed` = list/feed only;
+ * `estimate` = fully derived.
+ */
+export type Confidence =
+  | { kind: "verified" }
+  | { kind: "feed" }
+  | { kind: "estimate" }
+
+/** Buyability status (§5.3). Only `active` is presented as buyable. */
+export type ListingStatus =
+  | { kind: "active" }
+  | { kind: "under-offer" }
+  | { kind: "in-transaction" }
+  | { kind: "delisted"; lastSeen: string }
+
+// ── Property type / classification (§5.3 guardrail) ──────────────────────────
+
+export type PropertyType = "freehold-house" | "sectional" | "new-dev-unit" | "unknown"
+
+export interface PropertyClassification {
+  propertyType: PropertyType
+  /** False for sectional / new-dev units — they must not rank as flips. */
+  isFlipEligible: boolean
+  /** The §5.3 tells that fired, for transparency/debugging. */
+  reasons: string[]
+}
+
+// ── Raw fact primitives ──────────────────────────────────────────────────────
+
+/**
+ * Asking / expected entry price. Auctions expose a range (§5.3) — store min/max,
+ * score on the expected (reserve) value, never the optimistic max.
+ */
+export type PriceInput =
+  | { kind: "fixed"; cents: number }
+  | { kind: "range"; minCents: number; maxCents: number; expectedCents?: number }
+
+export type EffortLevel = "cosmetic" | "moderate" | "major" | "severe"
+
+export type DistressKind =
+  | "none"
+  | "easysell"
+  | "sie-auction"
+  | "pre-hammer"
+  | "deceased"
+  | "cash-only"
+
+export type DistressFlag = { kind: DistressKind }
+
+export type TransferFrictionKind = "no-transfer-duty" | "transfer-duty" | "sectional"
+
+export type TransferFriction = { kind: TransferFrictionKind }
+
+export interface PhysicalRisk {
+  /** Dolomite / sinkhole ground — an East Rand mortgage/insurance killer. */
+  dolomite: boolean
+  flood: boolean
+}
+
+// ── ARV basis (§5, §7.4): prefer sold/transfer over asking comps ─────────────
+
+export type ArvCompKind = "sold-transfer" | "asking"
+
+export interface ArvComp {
+  kind: ArvCompKind
+  valueCents: number
+}
+
+export type ArvBasis =
+  | { kind: "sold-transfer"; sampleSize: number }
+  | { kind: "asking-comps"; sampleSize: number }
+  | { kind: "none" }
+
+/** Asking comps bias high, so they can never earn `high`. */
+export type ArvConfidence = "high" | "medium" | "low"
+
+// ── Data-quality flags (§5.3) ────────────────────────────────────────────────
+
+export type DataQualityFlag =
+  | { kind: "erf-implausible"; rawValue: number }
+  | { kind: "erf-nonpositive"; rawValue: number }
+  | { kind: "price-range"; minCents: number; maxCents: number }
+  | { kind: "cash-only" }
+  | { kind: "no-approved-plans" }
+  | { kind: "status-under-offer" }
+  | { kind: "status-in-transaction" }
+
+// ── Facts, derived, sub-scores ───────────────────────────────────────────────
+
+/** Raw, normalised facts for one opportunity — the inputs to scoring. */
+export interface DealRadarFacts {
+  listingId: string
+  suburb: string
+  price: PriceInput
+  bedrooms?: number
+  bathrooms?: number
+  erfSizeM2: number | null
+  floorSizeM2: number | null
+  zoning?: string
+  subdividePotential: boolean
+  effort: EffortLevel
+  distressFlag: DistressFlag
+  suburbMedianCents: number | null
+  arvEstimateCents: number | null
+  renoCostEstimateCents: number | null
+  monthlyRentCents: number | null
+  monthlyBondCents: number | null
+  holdingCostMonthlyCents: number | null
+  transferFriction: TransferFriction
+  /** Suburb desirability + safety index, 0-100. */
+  areaQualityIndex: number | null
+  /** Schools / transport / mall / hospital index, 0-100. */
+  proximityIndex: number | null
+  daysOnMarket: number | null
+  physicalRisk: PhysicalRisk
+}
+
+/** Numbers derived from facts (money in cents, ratios unitless). */
+export interface DealRadarDerived {
+  buyInCents: number
+  allInCents: number
+  /** (ARV − buyIn − renoEst) / allIn. Null when ARV/median unknown. */
+  flipPct: number | null
+  /** Percentage points under (positive) / over suburb median. */
+  dealScore: number | null
+  /** (monthlyRent × 12) / allIn. */
+  rentalYieldGross: number | null
+}
+
+/**
+ * 1-10 sub-scores, one per scored §5 dimension. `confidence` is deliberately
+ * absent — it is a badge, never a scored dimension.
+ */
+export interface SubScores {
+  buyIn: number
+  flipPct: number
+  effort: number
+  dealScore: number
+  renoCost: number
+  rentalYield: number
+  areaQuality: number
+  daysOnMarket: number
+  distress: number
+  landUpside: number
+  holdingCost: number
+  affordability: number
+  transferFriction: number
+  physicalRisk: number
+  proximity: number
+}
+
+export type SubScoreWeights = Record<keyof SubScores, number>
+
+// ── The full record ──────────────────────────────────────────────────────────
+
+export interface DealRadarListing {
+  facts: DealRadarFacts
+  derived: DealRadarDerived
+  propertyType: PropertyType
+  classification: PropertyClassification
+  subScores: SubScores
+  /** Weighted composite (1-10). Never includes `confidence`. */
+  composite: number
+  arvBasis: ArvBasis
+  arvConfidence: ArvConfidence
+  /** Normalised match key (field only — dedupe is Radar 2). */
+  canonicalKey: string
+  status: ListingStatus
+  confidence: Confidence
+  /** Non-scoring AI prose take (§5.1); only for verified rows. */
+  analystNote: string | null
+  dataQualityFlags: DataQualityFlag[]
+  provenance: Provenance
+}
+
+export interface RankedListing {
+  listing: DealRadarListing
+  composite: number
+  /** 1-based rank after the confidence/status guards. */
+  rank: number
+  /** True when the #1 slot was reassigned by the confidence/status guard. */
+  guardApplied: boolean
+  /** True when this #1 row is only feed-confidence because no verified row exists. */
+  provisionalTop: boolean
+}

--- a/tests/lib/services/radar/_fixtures.ts
+++ b/tests/lib/services/radar/_fixtures.ts
@@ -1,0 +1,93 @@
+import type {
+  Confidence,
+  DealRadarFacts,
+  DealRadarListing,
+  ListingStatus,
+  SubScores,
+} from "@/lib/services/radar"
+import { computeDerived, computeSubScores } from "@/lib/services/radar"
+
+/** Every sub-score set to the same value — handy for controlling composites. */
+export function uniformSubScores(value: number): SubScores {
+  return {
+    buyIn: value,
+    flipPct: value,
+    effort: value,
+    dealScore: value,
+    renoCost: value,
+    rentalYield: value,
+    areaQuality: value,
+    daysOnMarket: value,
+    distress: value,
+    landUpside: value,
+    holdingCost: value,
+    affordability: value,
+    transferFriction: value,
+    physicalRisk: value,
+    proximity: value,
+  }
+}
+
+/** A complete, well-formed set of facts for a plausible Springs fixer-upper. */
+export function makeFacts(overrides: Partial<DealRadarFacts> = {}): DealRadarFacts {
+  return {
+    listingId: "p24-000",
+    suburb: "Strubenvale",
+    price: { kind: "fixed", cents: 650_000 * 100 },
+    bedrooms: 3,
+    bathrooms: 1,
+    erfSizeM2: 800,
+    floorSizeM2: 140,
+    zoning: "Residential 1",
+    subdividePotential: false,
+    effort: "moderate",
+    distressFlag: { kind: "none" },
+    suburbMedianCents: 850_000 * 100,
+    arvEstimateCents: 1_050_000 * 100,
+    renoCostEstimateCents: 180_000 * 100,
+    monthlyRentCents: 7_500 * 100,
+    monthlyBondCents: 7_000 * 100,
+    holdingCostMonthlyCents: 2_500 * 100,
+    transferFriction: { kind: "no-transfer-duty" },
+    areaQualityIndex: 60,
+    proximityIndex: 55,
+    daysOnMarket: 40,
+    physicalRisk: { dolomite: false, flood: false },
+    ...overrides,
+  }
+}
+
+/** Build a full listing; sub-scores derive from facts unless overridden. */
+export function makeListing(
+  opts: {
+    facts?: Partial<DealRadarFacts>
+    subScores?: Partial<SubScores>
+    status?: ListingStatus
+    confidence?: Confidence
+    listingId?: string
+  } = {}
+): DealRadarListing {
+  const facts = makeFacts({ ...opts.facts, ...(opts.listingId ? { listingId: opts.listingId } : {}) })
+  const derived = computeDerived(facts)
+  const subScores = { ...computeSubScores(facts, derived), ...opts.subScores }
+  return {
+    facts,
+    derived,
+    propertyType: "freehold-house",
+    classification: { propertyType: "freehold-house", isFlipEligible: true, reasons: [] },
+    subScores,
+    composite: 0,
+    arvBasis: { kind: "sold-transfer", sampleSize: 3 },
+    arvConfidence: "high",
+    canonicalKey: "sub:strubenvale:erf800:bed3",
+    status: opts.status ?? { kind: "active" },
+    confidence: opts.confidence ?? { kind: "verified" },
+    analystNote: null,
+    dataQualityFlags: [],
+    provenance: {
+      sourceUrl: "https://www.property24.com/for-sale/strubenvale/000",
+      sourcePortal: "property24",
+      lastSeen: "2026-07-11",
+    },
+  }
+}

--- a/tests/lib/services/radar/canonical-key.test.ts
+++ b/tests/lib/services/radar/canonical-key.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest"
+import { computeCanonicalKey } from "@/lib/services/radar"
+
+describe("radar canonicalKey — deterministic field normaliser (Radar 1 only)", () => {
+  it("anchors on the geohash when address/geo is present", () => {
+    expect(computeCanonicalKey({ suburb: "Geduld", erfSizeM2: 991, geohash: "ke7dxk" })).toBe(
+      "geo:ke7dxk:erf1000"
+    )
+  })
+
+  it("falls back to a composite key when the address is hidden", () => {
+    expect(
+      computeCanonicalKey({ suburb: "Selection Park", erfSizeM2: 812, bedrooms: 3 })
+    ).toBe("sub:selection-park:erf800:bed3")
+  })
+
+  it("is stable across erf capture jitter within a bucket", () => {
+    const a = computeCanonicalKey({ suburb: "Strubenvale", erfSizeM2: 798, bedrooms: 3 })
+    const b = computeCanonicalKey({ suburb: "Strubenvale", erfSizeM2: 823, bedrooms: 3 })
+    expect(a).toBe(b) // both round to the 800 bucket
+  })
+
+  it("normalises suburb casing and punctuation", () => {
+    expect(computeCanonicalKey({ suburb: "  MODDER East  ", erfSizeM2: 600, bedrooms: 2 })).toBe(
+      "sub:modder-east:erf600:bed2"
+    )
+  })
+
+  it("marks missing erf / bedrooms as 'na' rather than fabricating", () => {
+    expect(computeCanonicalKey({ suburb: "Springs", erfSizeM2: null })).toBe("sub:springs:erfna:bedna")
+  })
+
+  it("is deterministic — same input, same key", () => {
+    const fields = { suburb: "Dersley", erfSizeM2: 750, bedrooms: 4 }
+    expect(computeCanonicalKey(fields)).toBe(computeCanonicalKey(fields))
+  })
+})

--- a/tests/lib/services/radar/classifier.test.ts
+++ b/tests/lib/services/radar/classifier.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest"
+import { classifyPropertyType } from "@/lib/services/radar"
+
+const rands = (rand: number) => rand * 100
+
+/** A clean freehold-house baseline that fires no tells. */
+const freehold = {
+  titleType: "Freehold",
+  erfSizeM2: 800,
+  floorSizeM2: 140,
+  description: "Family home needing cosmetic TLC, big stand",
+  monthlyLevyCents: null,
+  listedDate: "2026-07-01",
+  siblingPricesCents: [],
+  now: "2026-07-11",
+}
+
+describe("radar classifier — accepts genuine freehold houses", () => {
+  it("classifies a clean resale house as flip-eligible", () => {
+    const result = classifyPropertyType(freehold)
+    expect(result.propertyType).toBe("freehold-house")
+    expect(result.isFlipEligible).toBe(true)
+    expect(result.reasons).toEqual([])
+  })
+})
+
+describe("radar classifier — rejects non-flips via each §5.3 tell", () => {
+  it("tell: sectional title deed", () => {
+    const result = classifyPropertyType({ ...freehold, titleType: "Sectional" })
+    expect(result.propertyType).toBe("sectional")
+    expect(result.isFlipEligible).toBe(false)
+    expect(result.reasons).toContain("title-sectional")
+
+    // "Sec Title" variant also caught
+    expect(classifyPropertyType({ ...freehold, titleType: "Sec Title" }).isFlipEligible).toBe(false)
+  })
+
+  it("tell: erf size equals floor size", () => {
+    const result = classifyPropertyType({ ...freehold, erfSizeM2: 56, floorSizeM2: 56 })
+    expect(result.propertyType).toBe("new-dev-unit")
+    expect(result.isFlipEligible).toBe(false)
+    expect(result.reasons).toContain("erf-equals-floor")
+  })
+
+  it("tell: new-development marketing tokens", () => {
+    for (const token of ["estate", "new phase", "now selling", "units", "development"]) {
+      const result = classifyPropertyType({
+        ...freehold,
+        description: `Cheap Selcourt — ${token} available`,
+      })
+      expect(result.isFlipEligible).toBe(false)
+      expect(result.reasons).toContain(`token:${token}`)
+    }
+  })
+
+  it("tell: levy + recent listing + identical-price siblings", () => {
+    const result = classifyPropertyType({
+      ...freehold,
+      monthlyLevyCents: rands(1_200),
+      listedDate: "2026-07-05",
+      now: "2026-07-11",
+      siblingPricesCents: [rands(899_000), rands(899_000)],
+    })
+    expect(result.propertyType).toBe("new-dev-unit")
+    expect(result.isFlipEligible).toBe(false)
+    expect(result.reasons).toContain("levy+recent+identical-siblings")
+  })
+
+  it("levy tell does NOT fire without all three parts", () => {
+    // levy + recent but siblings not identical → no fire
+    const distinctSiblings = classifyPropertyType({
+      ...freehold,
+      monthlyLevyCents: rands(1_200),
+      listedDate: "2026-07-05",
+      now: "2026-07-11",
+      siblingPricesCents: [rands(899_000), rands(950_000)],
+    })
+    expect(distinctSiblings.reasons).not.toContain("levy+recent+identical-siblings")
+
+    // levy + identical siblings but listing is stale (not recent) → no fire
+    const stale = classifyPropertyType({
+      ...freehold,
+      monthlyLevyCents: rands(1_200),
+      listedDate: "2026-01-01",
+      now: "2026-07-11",
+      siblingPricesCents: [rands(899_000), rands(899_000)],
+    })
+    expect(stale.reasons).not.toContain("levy+recent+identical-siblings")
+    expect(stale.isFlipEligible).toBe(true)
+  })
+
+  it("collects multiple tells when several fire", () => {
+    const result = classifyPropertyType({
+      ...freehold,
+      erfSizeM2: 56,
+      floorSizeM2: 56,
+      description: "New phase now selling — modern units",
+    })
+    expect(result.isFlipEligible).toBe(false)
+    expect(result.reasons).toContain("erf-equals-floor")
+    expect(result.reasons).toContain("token:new phase")
+    expect(result.reasons).toContain("token:now selling")
+    expect(result.reasons).toContain("token:units")
+  })
+})

--- a/tests/lib/services/radar/data-quality.test.ts
+++ b/tests/lib/services/radar/data-quality.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest"
+import {
+  applyEffortRisk,
+  isBuyable,
+  normaliseErf,
+  priceRangeFlags,
+  resolveBuyInCents,
+  statusDataQualityFlags,
+} from "@/lib/services/radar"
+
+const rands = (rand: number) => rand * 100
+
+describe("radar data-quality — erf clamp", () => {
+  it("passes plausible erf through unchanged", () => {
+    expect(normaliseErf(800)).toEqual({ value: 800, flags: [] })
+  })
+
+  it("clamps nonsense large erf and flags it", () => {
+    expect(normaliseErf(100_000)).toEqual({
+      value: null,
+      flags: [{ kind: "erf-implausible", rawValue: 100_000 }],
+    })
+    expect(normaliseErf(16_777).flags[0].kind).toBe("erf-implausible")
+  })
+
+  it("flags non-positive erf", () => {
+    expect(normaliseErf(0)).toEqual({ value: null, flags: [{ kind: "erf-nonpositive", rawValue: 0 }] })
+    expect(normaliseErf(-5).flags[0].kind).toBe("erf-nonpositive")
+  })
+
+  it("treats null / NaN as simply missing (no flag)", () => {
+    expect(normaliseErf(null)).toEqual({ value: null, flags: [] })
+    expect(normaliseErf(undefined)).toEqual({ value: null, flags: [] })
+    expect(normaliseErf(NaN)).toEqual({ value: null, flags: [] })
+  })
+})
+
+describe("radar data-quality — auction price ranges", () => {
+  it("scores a fixed price on that price", () => {
+    expect(resolveBuyInCents({ kind: "fixed", cents: rands(650_000) })).toBe(rands(650_000))
+  })
+
+  it("scores a range on the expected/reserve, not the optimistic max", () => {
+    const withExpected = resolveBuyInCents({
+      kind: "range",
+      minCents: rands(400_000),
+      maxCents: rands(800_000),
+      expectedCents: rands(550_000),
+    })
+    expect(withExpected).toBe(rands(550_000))
+
+    // reserve defaults to the range minimum when no expected is given
+    const noExpected = resolveBuyInCents({
+      kind: "range",
+      minCents: rands(400_000),
+      maxCents: rands(800_000),
+    })
+    expect(noExpected).toBe(rands(400_000))
+  })
+
+  it("flags a range price for UI caveating", () => {
+    expect(
+      priceRangeFlags({ kind: "range", minCents: rands(400_000), maxCents: rands(800_000) })
+    ).toEqual([{ kind: "price-range", minCents: rands(400_000), maxCents: rands(800_000) }])
+    expect(priceRangeFlags({ kind: "fixed", cents: rands(650_000) })).toEqual([])
+  })
+})
+
+describe("radar data-quality — cash-only / no-plans risk", () => {
+  it("cash-only raises effort one level and tags risk", () => {
+    const result = applyEffortRisk("cosmetic", { cashOnly: true })
+    expect(result.effort).toBe("moderate")
+    expect(result.flags).toEqual([{ kind: "cash-only" }])
+  })
+
+  it("no-approved-plans raises effort and tags risk", () => {
+    const result = applyEffortRisk("moderate", { noApprovedPlans: true })
+    expect(result.effort).toBe("major")
+    expect(result.flags).toEqual([{ kind: "no-approved-plans" }])
+  })
+
+  it("both flags stack but effort caps at severe", () => {
+    const stacked = applyEffortRisk("major", { cashOnly: true, noApprovedPlans: true })
+    expect(stacked.effort).toBe("severe") // major → +1 (severe) → capped
+    expect(stacked.flags).toEqual([{ kind: "no-approved-plans" }, { kind: "cash-only" }])
+  })
+
+  it("no flags leave effort unchanged", () => {
+    expect(applyEffortRisk("cosmetic", {})).toEqual({ effort: "cosmetic", flags: [] })
+  })
+})
+
+describe("radar data-quality — status logic", () => {
+  it("only active rows are buyable", () => {
+    expect(isBuyable({ kind: "active" })).toBe(true)
+    expect(isBuyable({ kind: "under-offer" })).toBe(false)
+    expect(isBuyable({ kind: "in-transaction" })).toBe(false)
+    expect(isBuyable({ kind: "delisted", lastSeen: "2026-07-01" })).toBe(false)
+  })
+
+  it("non-buyable statuses raise the matching flag", () => {
+    expect(statusDataQualityFlags({ kind: "under-offer" })).toEqual([{ kind: "status-under-offer" }])
+    expect(statusDataQualityFlags({ kind: "in-transaction" })).toEqual([
+      { kind: "status-in-transaction" },
+    ])
+    expect(statusDataQualityFlags({ kind: "active" })).toEqual([])
+  })
+})

--- a/tests/lib/services/radar/scoring.test.ts
+++ b/tests/lib/services/radar/scoring.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from "vitest"
+import {
+  computeComposite,
+  computeDealScore,
+  computeFlipPct,
+  computeRenoCostCents,
+  computeRentalYieldGross,
+  DEFAULT_WEIGHTS,
+  rankListings,
+  resolveArv,
+  scoreAffordability,
+  scoreAreaQuality,
+  scoreBuyIn,
+  scoreDaysOnMarket,
+  scoreDealScore,
+  scoreDistress,
+  scoreEffort,
+  scoreFlipPct,
+  scoreHoldingCost,
+  scoreLandUpside,
+  scorePhysicalRisk,
+  scoreProximity,
+  scoreRentalYield,
+  scoreRenoCost,
+  scoreTransferFriction,
+  type SubScoreWeights,
+} from "@/lib/services/radar"
+import { makeListing, uniformSubScores } from "./_fixtures"
+
+const rands = (rand: number) => rand * 100
+
+describe("radar scoring — per-dimension rubrics", () => {
+  it("scoreBuyIn: lower price scores higher, floors at 1", () => {
+    expect(scoreBuyIn(rands(450_000))).toBe(10) // boundary, inclusive
+    expect(scoreBuyIn(rands(500_000))).toBe(8)
+    expect(scoreBuyIn(rands(850_000))).toBe(6)
+    expect(scoreBuyIn(rands(1_100_000))).toBe(4)
+    expect(scoreBuyIn(rands(2_000_000))).toBe(1) // beyond the last band
+  })
+
+  it("scoreFlipPct: higher margin scores higher", () => {
+    expect(scoreFlipPct(0.45)).toBe(10)
+    expect(scoreFlipPct(0.2)).toBe(6) // viable-flip boundary
+    expect(scoreFlipPct(0.12)).toBe(4)
+    expect(scoreFlipPct(0.1)).toBe(2)
+    expect(scoreFlipPct(-0.05)).toBe(1)
+  })
+
+  it("scoreEffort: cosmetic best, severe worst", () => {
+    expect(scoreEffort("cosmetic")).toBe(10)
+    expect(scoreEffort("moderate")).toBe(7)
+    expect(scoreEffort("major")).toBe(4)
+    expect(scoreEffort("severe")).toBe(2)
+  })
+
+  it("scoreDealScore: deeper under-median scores higher", () => {
+    expect(scoreDealScore(25)).toBe(10)
+    expect(scoreDealScore(15)).toBe(8)
+    expect(scoreDealScore(0)).toBe(4) // at median
+    expect(scoreDealScore(-15)).toBe(1) // over median
+  })
+
+  it("scoreRenoCost: cheaper reno scores higher", () => {
+    expect(scoreRenoCost(rands(80_000))).toBe(10)
+    expect(scoreRenoCost(rands(100_000))).toBe(8)
+    expect(scoreRenoCost(rands(1_000_000))).toBe(1)
+  })
+
+  it("scoreRentalYield: higher yield scores higher", () => {
+    expect(scoreRentalYield(0.11)).toBe(10)
+    expect(scoreRentalYield(0.07)).toBe(6)
+    expect(scoreRentalYield(0.01)).toBe(1)
+  })
+
+  it("scoreAreaQuality / scoreProximity: higher index scores higher", () => {
+    expect(scoreAreaQuality(80)).toBe(10)
+    expect(scoreAreaQuality(50)).toBe(6)
+    expect(scoreProximity(10)).toBe(1)
+  })
+
+  it("scoreDaysOnMarket: stale listings score higher, floor is 2", () => {
+    expect(scoreDaysOnMarket(120)).toBe(10)
+    expect(scoreDaysOnMarket(40)).toBe(4)
+    expect(scoreDaysOnMarket(3)).toBe(2) // fresh — floored at 2, not 1
+  })
+
+  it("scoreDistress: programmes reflect discount net of friction", () => {
+    expect(scoreDistress({ kind: "pre-hammer" })).toBe(8)
+    expect(scoreDistress({ kind: "easysell" })).toBe(7)
+    expect(scoreDistress({ kind: "sie-auction" })).toBe(6)
+    expect(scoreDistress({ kind: "none" })).toBe(5)
+    expect(scoreDistress({ kind: "cash-only" })).toBe(5)
+  })
+
+  it("scoreHoldingCost / scoreAffordability: lower cost scores higher", () => {
+    expect(scoreHoldingCost(rands(1_500))).toBe(10)
+    expect(scoreHoldingCost(rands(20_000))).toBe(2) // floor
+    expect(scoreAffordability(rands(5_000))).toBe(10)
+    expect(scoreAffordability(rands(30_000))).toBe(1)
+  })
+
+  it("scoreTransferFriction: no-duty best", () => {
+    expect(scoreTransferFriction({ kind: "no-transfer-duty" })).toBe(10)
+    expect(scoreTransferFriction({ kind: "sectional" })).toBe(6)
+    expect(scoreTransferFriction({ kind: "transfer-duty" })).toBe(4)
+  })
+
+  it("scorePhysicalRisk: dolomite penalised harder than flood", () => {
+    expect(scorePhysicalRisk({ dolomite: false, flood: false })).toBe(10)
+    expect(scorePhysicalRisk({ dolomite: false, flood: true })).toBe(6)
+    expect(scorePhysicalRisk({ dolomite: true, flood: false })).toBe(4)
+    expect(scorePhysicalRisk({ dolomite: true, flood: true })).toBe(2)
+  })
+
+  it("scoreLandUpside: bigger stand + subdivide potential scores higher", () => {
+    expect(scoreLandUpside({ erfSizeM2: 1200, subdividePotential: false })).toBe(8)
+    expect(scoreLandUpside({ erfSizeM2: 1200, subdividePotential: true })).toBe(10) // 8 + 2, capped
+    expect(scoreLandUpside({ erfSizeM2: 800, subdividePotential: true })).toBe(7) // 5 + 2
+    expect(scoreLandUpside({ erfSizeM2: null, subdividePotential: false })).toBe(3) // floor
+  })
+})
+
+describe("radar scoring — derived money maths", () => {
+  it("computeFlipPct: (ARV − buyIn − renoEst) / allIn", () => {
+    const flip = computeFlipPct({
+      arvCents: rands(1_050_000),
+      buyInCents: rands(650_000),
+      renoCents: rands(180_000),
+    })
+    // profit 220k / allIn 830k
+    expect(flip).toBeCloseTo(220_000 / 830_000, 6)
+  })
+
+  it("computeFlipPct: extra acquisition costs enter the denominator", () => {
+    const flip = computeFlipPct({
+      arvCents: rands(1_000_000),
+      buyInCents: rands(600_000),
+      renoCents: rands(200_000),
+      extraCostsCents: rands(50_000),
+    })
+    // numerator = 1_000_000 − 600_000 − 200_000 = 200_000; allIn = 850_000
+    expect(flip).toBeCloseTo(200_000 / 850_000, 6)
+  })
+
+  it("computeFlipPct: null when there is no positive all-in basis", () => {
+    expect(computeFlipPct({ arvCents: 0, buyInCents: 0, renoCents: 0 })).toBeNull()
+  })
+
+  it("computeDealScore: percentage points under median", () => {
+    expect(computeDealScore(rands(650_000), rands(850_000))).toBeCloseTo((200 / 850) * 100, 6)
+    expect(computeDealScore(rands(650_000), 0)).toBeNull()
+  })
+
+  it("computeRentalYieldGross: annualised rent over all-in", () => {
+    expect(computeRentalYieldGross(rands(7_500), rands(900_000))).toBeCloseTo(
+      (7_500 * 12) / 900_000,
+      6
+    )
+    expect(computeRentalYieldGross(rands(7_500), 0)).toBeNull()
+  })
+
+  it("computeRenoCostCents: rate/m² by effort × floor size", () => {
+    expect(computeRenoCostCents("cosmetic", 100)).toBe(rands(2_500) * 100)
+    expect(computeRenoCostCents("severe", 100)).toBe(rands(11_000) * 100)
+    expect(computeRenoCostCents("moderate", 0)).toBe(0)
+  })
+})
+
+describe("radar scoring — ARV basis preference (sold > asking)", () => {
+  it("prefers sold/transfer comps even when asking comps are more numerous", () => {
+    const result = resolveArv([
+      { kind: "asking", valueCents: rands(1_300_000) },
+      { kind: "asking", valueCents: rands(1_250_000) },
+      { kind: "sold-transfer", valueCents: rands(1_000_000) },
+    ])
+    expect(result.basis.kind).toBe("sold-transfer")
+    expect(result.arvEstimateCents).toBe(rands(1_000_000)) // ignores the higher asking comps
+  })
+
+  it("sold comps reach high confidence only with a real sample", () => {
+    const few = resolveArv([{ kind: "sold-transfer", valueCents: rands(1_000_000) }])
+    expect(few.confidence).toBe("medium")
+    const many = resolveArv([
+      { kind: "sold-transfer", valueCents: rands(1_000_000) },
+      { kind: "sold-transfer", valueCents: rands(1_100_000) },
+      { kind: "sold-transfer", valueCents: rands(1_050_000) },
+    ])
+    expect(many.confidence).toBe("high")
+    expect(many.basis).toEqual({ kind: "sold-transfer", sampleSize: 3 })
+  })
+
+  it("asking-only comps are capped below high confidence", () => {
+    const asking = resolveArv([
+      { kind: "asking", valueCents: rands(1_200_000) },
+      { kind: "asking", valueCents: rands(1_300_000) },
+      { kind: "asking", valueCents: rands(1_250_000) },
+    ])
+    expect(asking.basis.kind).toBe("asking-comps")
+    expect(asking.confidence).toBe("medium") // never "high"
+  })
+
+  it("no comps → null estimate, none basis, low confidence", () => {
+    const none = resolveArv([])
+    expect(none.arvEstimateCents).toBeNull()
+    expect(none.basis).toEqual({ kind: "none" })
+    expect(none.confidence).toBe("low")
+  })
+})
+
+describe("radar scoring — composite math", () => {
+  it("weighted mean of uniform sub-scores equals that value", () => {
+    expect(computeComposite(uniformSubScores(10))).toBe(10)
+    expect(computeComposite(uniformSubScores(1))).toBe(1)
+    expect(computeComposite(uniformSubScores(5))).toBeCloseTo(5, 6)
+  })
+
+  it("applies weights per Σ(wᵢ·sᵢ)/Σwᵢ", () => {
+    // Only buyIn and flipPct carry weight → composite is their mean.
+    const zero = Object.fromEntries(
+      Object.keys(DEFAULT_WEIGHTS).map((k) => [k, 0])
+    ) as SubScoreWeights
+    const weights: SubScoreWeights = { ...zero, buyIn: 1, flipPct: 1 }
+    const subScores = { ...uniformSubScores(1), buyIn: 10, flipPct: 6 }
+    expect(computeComposite(subScores, weights)).toBe(8) // (10 + 6) / 2
+  })
+
+  it("default weights emphasise the three headline drivers", () => {
+    expect(DEFAULT_WEIGHTS.effort).toBe(3)
+    expect(DEFAULT_WEIGHTS.flipPct).toBe(3)
+    expect(DEFAULT_WEIGHTS.buyIn).toBe(3)
+    // headline drivers outweigh a supporting dimension
+    expect(DEFAULT_WEIGHTS.buyIn).toBeGreaterThan(DEFAULT_WEIGHTS.proximity)
+  })
+
+  it("confidence is not a sub-score key and cannot feed the composite", () => {
+    expect(Object.keys(DEFAULT_WEIGHTS)).not.toContain("confidence")
+  })
+})
+
+describe("radar scoring — ranking guard (confidence can't hold #1)", () => {
+  it("promotes the top verified row above a higher-composite feed row", () => {
+    const feedTop = makeListing({
+      listingId: "feed",
+      subScores: uniformSubScores(9),
+      confidence: { kind: "feed" },
+    })
+    const verified = makeListing({
+      listingId: "verified",
+      subScores: uniformSubScores(7),
+      confidence: { kind: "verified" },
+    })
+    const ranked = rankListings([feedTop, verified])
+    expect(ranked[0].listing.facts.listingId).toBe("verified")
+    expect(ranked[0].guardApplied).toBe(true)
+    expect(ranked[0].provisionalTop).toBe(false)
+    // the feed row keeps its higher composite but is demoted out of #1
+    expect(ranked[1].listing.facts.listingId).toBe("feed")
+    expect(ranked[1].composite).toBeGreaterThan(ranked[0].composite)
+  })
+
+  it("leaves a verified leader untouched", () => {
+    const verifiedTop = makeListing({
+      listingId: "vtop",
+      subScores: uniformSubScores(9),
+      confidence: { kind: "verified" },
+    })
+    const feed = makeListing({
+      listingId: "feed",
+      subScores: uniformSubScores(6),
+      confidence: { kind: "feed" },
+    })
+    const ranked = rankListings([feed, verifiedTop])
+    expect(ranked[0].listing.facts.listingId).toBe("vtop")
+    expect(ranked[0].guardApplied).toBe(false)
+  })
+
+  it("marks the #1 provisional when no verified row exists", () => {
+    const feedA = makeListing({ listingId: "a", subScores: uniformSubScores(8), confidence: { kind: "feed" } })
+    const feedB = makeListing({ listingId: "b", subScores: uniformSubScores(6), confidence: { kind: "estimate" } })
+    const ranked = rankListings([feedA, feedB])
+    expect(ranked[0].listing.facts.listingId).toBe("a")
+    expect(ranked[0].provisionalTop).toBe(true)
+    expect(ranked[0].guardApplied).toBe(false)
+  })
+
+  it("sorts non-buyable rows below buyable ones regardless of composite", () => {
+    const underOffer = makeListing({
+      listingId: "under-offer",
+      subScores: uniformSubScores(10),
+      confidence: { kind: "verified" },
+      status: { kind: "under-offer" },
+    })
+    const active = makeListing({
+      listingId: "active",
+      subScores: uniformSubScores(6),
+      confidence: { kind: "verified" },
+      status: { kind: "active" },
+    })
+    const ranked = rankListings([underOffer, active])
+    expect(ranked[0].listing.facts.listingId).toBe("active")
+    expect(ranked[1].listing.facts.listingId).toBe("under-offer")
+  })
+
+  it("returns an empty ranking for no listings", () => {
+    expect(rankListings([])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Property Deal Radar — foundation (ships dark)

Public `/radar` module that ranks Springs fixer-upper / distressed / value-add deals on a transparent, user-weightable matrix. This PR lands the **first parallel wave** of the Baton epic — no ingestion, API, or UI yet, and nothing enabled.

Spec: `docs/specs/property-deal-radar.md` (v0.4, decisions locked).

### Radar 1 — deterministic data layer (`lib/services/radar/`)
- `DealRadarListing` model: every §5 dimension, integer-cents money, discriminated unions for price / distress / status / confidence / ARV basis.
- Scoring lib: 15 dimension sub-scores via documented rubrics → weighted composite. **`confidence` is structurally excluded from the score** (spec §5 honesty rule enforced by type shape).
- `rankListings` guard: non-buyable rows (Under Offer / In Transaction) sink; **#1 must be buyable + verified** — a higher-composite feed-only row is demoted in *position only*, never in score.
- ARV prefers **sold/transfer** comps over asking (asking biases flip% high); property-type classifier rejects new-dev / sectional units from flip ranking (§5.3 tells); data-quality clamps (nonsense erf, auction price ranges, cash-only / no-plans).
- Pure — no network, no LLM.

### Radar 5 — compliance docs (`docs/specs/`)
- Public attribution/disclaimer page content; robots.txt / rate-limit acceptance criteria (AC-1..AC-17) for the future ingestion job; kill-switch + POPIA boundary.
- **Legal sign-off memo with an explicit human-signature gate.** Enabling `RADAR_ENABLED` for Springs is BLOCKED until that block is signed — Radar 6 cannot proceed without it.

### Verification
- `pnpm exec tsc --noEmit` → clean (exit 0)
- `pnpm exec vitest run tests/lib/services/radar` → **58/58 pass** (4 files)
- Both re-run independently, not just agent-reported.

### Not in this PR (downstream tasks)
- Radar 2 — canonicalKey dedupe spike + matching
- Radar 3 — autonomous ingestion function + QA gate
- Radar 4 — public page + API + weighting UI
- Radar 6 — monitoring + enable (gated on legal sign-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)