### PR TITLE
chore(renovate): modernize config + broaden vuln coverage (prep Renovate takeover)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended", ":semanticCommits", ":automergePatch", "group:allNonMajor"],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
+  "dependencyDashboard": true,
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
@@ -14,12 +15,12 @@
       "automerge": false
     },
     {
-      "matchPackagePatterns": ["^@radix-ui/"],
+      "matchPackageNames": ["@radix-ui/**"],
       "groupName": "radix-ui",
       "automerge": true
     },
     {
-      "matchPackagePatterns": ["^@testing-library/"],
+      "matchPackageNames": ["@testing-library/**"],
       "groupName": "testing-library",
       "automerge": true
     },
@@ -39,5 +40,6 @@
     "enabled": true,
     "labels": ["security"]
   },
+  "osvVulnerabilityAlerts": true,
   "schedule": ["before 6am on monday"]
 }


### PR DESCRIPTION
## Prep for making Renovate the sole dependency bot

**Context:** `renovate.json` has been in the repo for a while, but Renovate has **never actually run** here — no onboarding PR, no Dependency Dashboard — which means the **Mend Renovate GitHub App was never installed** on the org. Meanwhile **Dependabot security updates** are the only dependency bot currently operating (source of the vulnerability alerts). This PR modernizes the dormant config so it's ready to take over cleanly.

### Changes (no behavioural change to existing rules)
- **Migrate deprecated `matchPackagePatterns` → glob `matchPackageNames`** (`@radix-ui/**`, `@testing-library/**`). The old key is deprecated and warns on current Renovate.
- **`dependencyDashboard: true`** — explicit dashboard visibility once live.
- **`osvVulnerabilityAlerts: true`** — Renovate raises security PRs from OSV *in addition to* GitHub advisories, so it can fully replace Dependabot's security-update role.

Validated with the official `renovate-config-validator` → **passes**.

### Two-step rollout (this PR is step 0)
1. **You:** install the Renovate GitHub App on the `neuralliquid` org (github.com/apps/renovate) → grant `house-of-veritas`. Renovate opens an onboarding PR + dashboard and this config goes live. (Runs on Mend infra — no Actions minutes consumed.)
2. **After Renovate is confirmed running:** disable Dependabot **security updates** (`automated-security-fixes`) to avoid duplicate security PRs. Keep Dependabot **alerts** (passive graph) on — Renovate uses that advisory data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)