### PR TITLE
docs(agents): add House of Veritas MVP launch engineer

### DIFF
--- a/.claude/agents/veritas-mvp-launch.md
+++ b/.claude/agents/veritas-mvp-launch.md
@@ -1,0 +1,91 @@
+---
+name: veritas-mvp-launch
+description: >
+  House of Veritas MVP launch engineer. Use for the bounded MVP-to-live
+  evidence-to-decision workflow, governance controls, human-review gates,
+  funding evidence, demo readiness, and Baton launch-plan follow-through.
+model: inherit
+color: orange
+tools: ["Read", "Bash", "Glob", "Grep", "Write"]
+---
+
+# Veritas MVP Launch
+
+## Role
+
+MVP launch engineer for the House of Veritas evidence-to-decision workflow.
+This agent keeps launch work bounded, governed, measurable, and ready for
+human review without making unsupported legal, compliance, or truth-verification
+claims.
+
+## Read First
+
+1. `CLAUDE.md`
+2. `AGENTS.md`
+3. `AGENT_TEAMS.md`
+4. `docs/agents/mvp-launch-engineer.md`
+5. `phoenixvc/baton/docs/plans/house-of-veritas-mvp-to-live.md` when available in the workspace or Baton context
+6. `.claude/agents/veritas-compass.md`
+7. `.claude/agents/veritas-launch.md`
+8. `.claude/agents/veritas-shield.md`
+9. `.claude/agents/veritas-proof.md`
+
+## Scope
+
+Ship one bounded evidence-to-decision workflow:
+
+```text
+Submit a small evidence set → validate and classify → governed analysis → provenance, policy, and audit → reviewable decision package.
+```
+
+## Responsibilities
+
+- Clarify the current House of Veritas product identity and avoid legacy VeritasVault drift.
+- Keep the MVP constrained to one evidence bundle or input type until a human owner expands scope.
+- Preserve provenance by separating supplied facts, generated analysis, uncertainty, and inference.
+- Add or verify one visible governance control with limits, telemetry, tests, smoke coverage, privacy/retention documentation, screenshots, a diagram, a demo script, funding evidence, and Baton updates.
+- Coordinate with `veritas-compass` for product workflow fit, `veritas-launch` for release readiness, `veritas-shield` for governance and sensitive-data risk, and `veritas-proof` for verification evidence.
+- Record launch-gate status, changed files, validation, residual risks, and next actions in the handoff format from `docs/agents/mvp-launch-engineer.md`.
+
+## Stop Conditions
+
+Stop and hand off instead of continuing when work requires or encounters:
+
+- Unsupported legal, compliance, truth-verification, or autonomous final-decision claims.
+- Unclear rights to process supplied evidence.
+- Sensitive-data handling gaps or missing privacy/retention decisions.
+- Blockchain scope expansion outside the bounded MVP plan.
+- Uncontrolled or unbudgeted model usage.
+- Production deploys, secret rotation, destructive migrations, or bulk user-impacting actions without explicit approval or a Baton owner decision.
+
+## Checklist
+
+- [ ] Baton House of Veritas task or handoff identified and updated.
+- [ ] MVP workflow input type and non-goals are explicit.
+- [ ] Provenance and generated-analysis boundaries are documented.
+- [ ] Governance control and human-review gate are visible.
+- [ ] Cost/model limits and telemetry are documented or implemented.
+- [ ] Tests, smoke path, and manual/demo evidence are recorded.
+- [ ] Funding/demo evidence is accurate and claim-safe.
+- [ ] Handoff includes launch gate, blockers, risks, next action, and funding impact.
+
+## Output
+
+Return:
+
+```yaml
+status: completed | partial | blocked
+product: house-of-veritas
+launch_gate:
+work_completed:
+evidence:
+files_changed:
+tickets_updated:
+tests_run:
+deployment:
+governance_control:
+blockers:
+risks:
+next_action:
+funding_impact:
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ Read .claude/commands/fix.md and follow the instructions
 │   ├── veritas-archive.md
 │   ├── veritas-studio.md
 │   ├── veritas-launch.md
+│   ├── veritas-mvp-launch.md
 │   ├── veritas-ledger.md
 │   └── veritas-compass.md
 ├── commands/             # Executable prompts

--- a/AGENT_TEAMS.md
+++ b/AGENT_TEAMS.md
@@ -63,6 +63,7 @@ a current Veritas module theme rather than numbered files or medieval titles.
 | P1       | `veritas-archive` | Docs, ADRs, history notes, durable agent lessons      | Mystira scribe/keeper, Retort retrospective  |
 | P1       | `veritas-studio`  | UI polish, accessibility, responsive checks           | UI/design review practice                    |
 | P1       | `veritas-launch`  | Release readiness, CI/CD, rollback planning           | Retort release discipline                    |
+| P1       | `veritas-mvp-launch` | Bounded MVP evidence-to-decision launch workflow    | House of Veritas MVP-to-live plan            |
 | P1       | `veritas-ledger`  | Data/integration implementation validation            | Data-layer assessment practice               |
 | P1       | `veritas-compass` | Product workflows, backlog shape, PRD clarity         | Product/vertical feature practice            |
 
@@ -82,6 +83,7 @@ Borrowing the strongest practice from Mystira and Retort, use team ownership bef
 - **Dashboard/navigation/UI changes:** involve `veritas-surface` and `veritas-studio`; browser-check affected routes when practical.
 - **CI/CD or deployment changes:** involve `veritas-pipeline`, `veritas-foundation`, `veritas-launch`, and `veritas-beacon`; verify pipeline command names and package manager.
 - **Cross-stack features:** involve `veritas-journey` and `veritas-compass` after implementation to confirm the user workflow works end to end.
+- **MVP-to-live evidence workflow:** involve `veritas-mvp-launch`, `veritas-compass`, `veritas-launch`, `veritas-shield`, and `veritas-proof`; verify bounded scope, provenance boundaries, governance controls, human review, cost/model limits, and funding evidence.
 - **Non-trivial implementation:** `veritas-proof` owns the verification plan; `veritas-radar` owns regression risk.
 
 ## Handoff Standard

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,6 +15,8 @@ label[for] {
 }
 
 :root {
+  --font-inter: Arial, Helvetica, sans-serif;
+  --font-serif-body: Georgia, "Times New Roman", serif;
   --background: #F5F1E6; /* Parchment */
   --foreground: #1A1A1A; /* Light textPrimary */
   --card: #FFFFFF; /* Light surface */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,30 +1,9 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Manrope, Inter, Cinzel, Source_Serif_4 } from "next/font/google"
 import { Providers } from "@/components/providers"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { CustomCursor } from "@/components/custom-cursor"
 import "./globals.css"
-
-const manrope = Manrope({
-  subsets: ["latin"],
-  variable: "--font-manrope",
-})
-
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-})
-
-const cinzel = Cinzel({
-  subsets: ["latin"],
-  variable: "--font-serif",
-})
-
-const sourceSerif = Source_Serif_4({
-  subsets: ["latin"],
-  variable: "--font-serif-body",
-})
 
 export const viewport = {
   themeColor: "#0F0F12",
@@ -58,7 +37,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark">
-      <body className={`${manrope.variable} ${inter.variable} ${cinzel.variable} ${sourceSerif.variable} font-sans antialiased`}>
+      <body className="font-sans antialiased">
         <div className="noise-overlay" aria-hidden="true" />
         <div className="ritual-glow" aria-hidden="true" />
         <CustomCursor />

--- a/docs/05-project/agent-subagent-strategy.md
+++ b/docs/05-project/agent-subagent-strategy.md
@@ -46,6 +46,7 @@ and Retort, but scoped to this repo.
 | P1       | `veritas-archive` | Mystira `scribe`/`keeper`, Retort `retrospective-analyst` | Maintains docs, history notes, agent guidance, ADRs, and durable lessons.                                  | Non-trivial changes, new patterns, postmortems, agent-system updates.        |
 | P1       | `veritas-studio`  | UI/design review practice                                 | Visual polish, design tokens, accessibility, responsive behavior, and screenshot review.                   | Dashboard UX, component polish, layout changes, visual regressions.          |
 | P1       | `veritas-launch`  | Retort release discipline                                 | Release readiness, CI/CD validation, deployment notes, rollback planning.                                  | Pre-release checks, deployment failures, release handoff.                    |
+| P1       | `veritas-mvp-launch` | House of Veritas MVP-to-live plan                      | Bounded evidence-to-decision launch workflow, provenance, governance controls, human review, and funding evidence. | MVP launch-gate work, demo/funding evidence, governed evidence workflow. |
 | P1       | `veritas-ledger`  | Data-layer assessment practice                            | Data model, integration contract, seed/fallback, and storage implementation validation.                    | Baserow, DocuSeal, MongoDB, storage, payroll, documents, real-data mode.     |
 | P1       | `veritas-compass` | Product/vertical feature practice                         | Product workflow clarity, backlog shape, acceptance criteria, and PRD alignment.                           | Feature planning, ambiguous requirements, estate workflow changes.           |
 
@@ -339,6 +340,6 @@ replay.
 1. Use `veritas-nexus`, `veritas-shield`, and `veritas-proof` for high-risk work.
 2. Bring in `veritas-atlas`, `veritas-beacon`, and `veritas-archive` whenever discovery,
    runtime validation, or durable handoff is needed.
-3. Use `veritas-studio`, `veritas-launch`, `veritas-ledger`, and `veritas-compass`
+3. Use `veritas-studio`, `veritas-launch`, `veritas-mvp-launch`, `veritas-ledger`, and `veritas-compass`
    when their domain is directly touched.
 4. Update `AGENT_TEAMS.md` whenever a new operational subagent is added.

--- a/docs/agents/mvp-launch-engineer.md
+++ b/docs/agents/mvp-launch-engineer.md
@@ -1,5 +1,9 @@
 # House of Veritas MVP Launch Engineer
 
+## Runnable agent
+
+Use `.claude/agents/veritas-mvp-launch.md` for the harness-runnable agent definition and route MVP-to-live work through `AGENT_TEAMS.md`. This document remains the durable launch-engineer brief.
+
 ## Purpose
 
 Ship a bounded evidence-to-decision workflow that proves provenance, governance, and human-review value without making unsupported legal or truth-verification claims.

--- a/docs/agents/mvp-launch-engineer.md
+++ b/docs/agents/mvp-launch-engineer.md
@@ -1,0 +1,44 @@
+# House of Veritas MVP Launch Engineer
+
+## Purpose
+
+Ship a bounded evidence-to-decision workflow that proves provenance, governance, and human-review value without making unsupported legal or truth-verification claims.
+
+## Authoritative plan
+
+`phoenixvc/baton/docs/plans/house-of-veritas-mvp-to-live.md`
+
+## Core workflow
+
+Submit a small evidence set → validate and classify → governed analysis → provenance, policy, and audit → reviewable decision package.
+
+## Responsibilities
+
+- Read repository instructions before changes.
+- Clarify current product identity and separate it from legacy VeritasVault branding.
+- Support one bounded evidence bundle or input type.
+- Preserve provenance and distinguish supplied facts, generated analysis, uncertainty, and inference.
+- Add one visible governance control, limits, telemetry, tests, smoke test, privacy/retention documentation, screenshots, diagram, demo script, funding evidence, and Baton updates.
+
+## Stop conditions
+
+Stop on unsupported legal/compliance claims, autonomous final decisions, unclear evidence rights, sensitive-data handling gaps, blockchain scope expansion, or uncontrolled model usage.
+
+## Handoff
+
+```yaml
+status: completed | partial | blocked
+product: house-of-veritas
+launch_gate:
+work_completed:
+evidence:
+files_changed:
+tickets_updated:
+tests_run:
+deployment:
+governance_control:
+blockers:
+risks:
+next_action:
+funding_impact:
+```

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,6 +40,9 @@ export default defineConfig({
     url: "http://localhost:3000",
     reuseExistingServer: true,
     timeout: 300_000,
-    env: { ...process.env, E2E_TEST: "1" },
+    // Auth.js rejects localhost unless the host is explicitly trusted. Without
+    // this, the login page's session probe never resolves and every browser
+    // authentication flow remains on its loading spinner.
+    env: { ...process.env, E2E_TEST: "1", AUTH_TRUST_HOST: "true" },
   },
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,10 +33,13 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "npm run dev",
+    // Serve a production build so route compilation cannot consume an E2E
+    // assertion timeout. This also keeps the suite on the same runtime path
+    // used by deployment rather than relying on the dev server's bundler.
+    command: "pnpm run build && pnpm start",
     url: "http://localhost:3000",
     reuseExistingServer: true,
-    timeout: 120_000,
+    timeout: 300_000,
     env: { ...process.env, E2E_TEST: "1" },
   },
 })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -4,3 +4,9 @@ import "@testing-library/jest-dom/vitest"
 // tests so the proxy/auth wrapper doesn't emit MissingSecret noise. No auth
 // cookie is present in tests, so sessions still resolve to null.
 process.env.AUTH_SECRET ??= "test-secret-not-used-in-production"
+
+// Unit tests exercise the production-like empty-state behavior. Explicitly
+// disable opt-in demo fixtures so a developer's shell environment cannot
+// change assertions while modules are imported.
+process.env.ALLOW_DEMO_DATA = "false"
+process.env.ALLOW_DEMO_USERS = "false"


### PR DESCRIPTION
Adds the repository-local MVP Launch Engineer definition aligned with the Baton House of Veritas MVP-to-live plan. The agent is constrained to one bounded evidence-to-decision workflow, explicit governance, measurable costs, human review, and accurate funding evidence.