### PR TITLE
fix: remove default dummy operational data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ terraform/crash.log
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 
+# Local agent tooling
+.serena/
+
 # Coverage
 coverage/
 

--- a/app/api/assets/enhanced/route.ts
+++ b/app/api/assets/enhanced/route.ts
@@ -4,6 +4,8 @@ import { ASSET_CATEGORIES, type AssetCategory } from "@/lib/constants/asset-cate
 
 export { ASSET_CATEGORIES, type AssetCategory }
 
+const DEMO_DATA_ENABLED = process.env.ALLOW_DEMO_DATA === "true"
+
 // Azure AI Configuration (with mock fallback)
 const AZURE_AI_CONFIG = {
   endpoint: process.env.AZURE_AI_ENDPOINT,
@@ -60,8 +62,7 @@ export interface Asset {
   updatedAt: string
 }
 
-// In-memory asset store (in production, use MongoDB)
-let assets: Asset[] = [
+const DEMO_ASSETS: Asset[] = [
   {
     id: "asset_001",
     name: "Toyota Hilux 2.8 GD-6",
@@ -192,6 +193,9 @@ let assets: Asset[] = [
     updatedAt: "2026-02-20T10:00:00Z",
   },
 ]
+
+// In-memory asset store (in production, use MongoDB)
+let assets: Asset[] = DEMO_DATA_ENABLED ? [...DEMO_ASSETS] : []
 
 // GET - List assets with filters
 export const GET = withAuth(async (request) => {

--- a/app/api/insurance-claims/route.ts
+++ b/app/api/insurance-claims/route.ts
@@ -95,6 +95,11 @@ export const PATCH = withRole("admin")(async (request) => {
         updates.claimId = result.claimId
         updates.status = "Submitted"
         updates.submittedAt = toISODateString()
+      } else {
+        return NextResponse.json(
+          { error: "Insurance submission failed", details: result.message ?? "Unknown error" },
+          { status: 502 }
+        )
       }
     } else if (status) {
       updates.status = status

--- a/app/api/maintenance/schedule/route.ts
+++ b/app/api/maintenance/schedule/route.ts
@@ -3,6 +3,8 @@ import { logger } from "@/lib/logger"
 import { withRole } from "@/lib/auth/rbac"
 import { routeToInngest } from "@/lib/workflows"
 
+const DEMO_DATA_ENABLED = process.env.ALLOW_DEMO_DATA === "true"
+
 // Scheduled maintenance items (synced with calendar)
 interface ScheduledMaintenance {
   id: string
@@ -18,10 +20,11 @@ interface ScheduledMaintenance {
   status: "scheduled" | "in_progress" | "completed" | "cancelled"
   createdAt: string
   aiGenerated: boolean
+  actualCost?: number
+  notes?: string
 }
 
-// In-memory store for scheduled maintenance
-let scheduledMaintenance: ScheduledMaintenance[] = [
+const DEMO_SCHEDULED_MAINTENANCE: ScheduledMaintenance[] = [
   {
     id: "maint_001",
     assetId: "asset_2",
@@ -67,6 +70,11 @@ let scheduledMaintenance: ScheduledMaintenance[] = [
     aiGenerated: true,
   },
 ]
+
+// In-memory store for scheduled maintenance
+let scheduledMaintenance: ScheduledMaintenance[] = DEMO_DATA_ENABLED
+  ? [...DEMO_SCHEDULED_MAINTENANCE]
+  : []
 
 // GET - List scheduled maintenance
 export const GET = withRole(
@@ -140,7 +148,13 @@ export const POST = withRole(
       }
 
       const newSchedules: ScheduledMaintenance[] = []
-      const calendarEvents: any[] = []
+      const calendarEvents: Array<{
+        summary: string
+        description: string
+        start: string
+        end: string
+        assignedTo: string
+      }> = []
 
       for (const prediction of predictionsData.predictions) {
         // Skip if already scheduled
@@ -335,10 +349,10 @@ export const PUT = withRole(
       scheduledMaintenance[index].status = status
     }
     if (actualCost !== undefined) {
-      ;(scheduledMaintenance[index] as any).actualCost = actualCost
+      scheduledMaintenance[index].actualCost = actualCost
     }
     if (notes) {
-      ;(scheduledMaintenance[index] as any).notes = notes
+      scheduledMaintenance[index].notes = notes
     }
 
     return NextResponse.json({

--- a/app/api/marketplace/route.ts
+++ b/app/api/marketplace/route.ts
@@ -5,6 +5,8 @@ import {
 } from "@/lib/services/marketplace-service"
 import { withAuth, withRole } from "@/lib/auth/rbac"
 
+const DEMO_DATA_ENABLED = process.env.ALLOW_DEMO_DATA === "true"
+
 // Initialize marketplace service with environment configs
 const marketplaceConfigs = [
   {
@@ -133,8 +135,7 @@ interface MarketplaceListing {
   expiresAt?: string
 }
 
-// In-memory listings store
-let listings: MarketplaceListing[] = [
+const DEMO_LISTINGS: MarketplaceListing[] = [
   {
     id: "listing_001",
     assetId: "asset_003",
@@ -182,6 +183,9 @@ let listings: MarketplaceListing[] = [
     expiresAt: "2026-03-10T10:00:00Z",
   },
 ]
+
+// In-memory listings store
+let listings: MarketplaceListing[] = DEMO_DATA_ENABLED ? [...DEMO_LISTINGS] : []
 
 // GET - List marketplace listings or get platforms
 export const GET = withAuth(async (request) => {

--- a/lib/integrations/bank.ts
+++ b/lib/integrations/bank.ts
@@ -3,7 +3,7 @@
  * Used for payroll, reimbursements, loans/advances, and contractor payments.
  *
  * Configure BANK_API_URL and BANK_API_KEY to enable. When not configured,
- * submitPayment logs and returns a stub success (no actual transfer).
+ * submitPayment logs the attempted payment and returns a failure.
  *
  * Sends Idempotency-Key header (payment.reference or derived key) so the bank
  * API can deduplicate retries. The bank API should support this header.
@@ -39,9 +39,8 @@ export async function submitPayment(payment: PaymentRequest): Promise<PaymentRes
       reference: payment.reference,
     })
     return {
-      success: true,
-      transactionId: `stub-${Date.now()}`,
-      message: "Bank API not configured; payment logged only",
+      success: false,
+      message: "Bank API is not configured; payment was not submitted",
     }
   }
 

--- a/lib/integrations/insurance.ts
+++ b/lib/integrations/insurance.ts
@@ -3,7 +3,7 @@
  * Used for asset loss/damage and incident-related insurance claims.
  *
  * Configure INSURANCE_PORTAL_URL and INSURANCE_API_KEY to enable. When not configured,
- * submitClaim logs and returns a stub; getClaimStatus returns a placeholder status.
+ * submitClaim logs the attempted claim and returns a failure; getClaimStatus returns null.
  */
 
 import { logger } from "@/lib/logger"
@@ -43,9 +43,8 @@ export async function submitClaim(claim: ClaimRequest): Promise<ClaimResult> {
       amount: claim.amount,
     })
     return {
-      success: true,
-      claimId: `stub-claim-${Date.now()}`,
-      message: "Insurance portal not configured; claim logged only",
+      success: false,
+      message: "Insurance portal is not configured; claim was not submitted",
     }
   }
 
@@ -89,12 +88,8 @@ export async function submitClaim(claim: ClaimRequest): Promise<ClaimResult> {
 
 export async function getClaimStatus(claimId: string): Promise<ClaimStatusResult | null> {
   if (!isConfigured()) {
-    logger.info("Insurance portal not configured, returning stub status", { claimId })
-    return {
-      claimId,
-      status: "Submitted",
-      updatedAt: new Date().toISOString(),
-    }
+    logger.info("Insurance portal not configured, claim status unavailable", { claimId })
+    return null
   }
 
   try {


### PR DESCRIPTION
## Summary

- Gate enhanced assets, marketplace listings, and scheduled maintenance seed records behind `ALLOW_DEMO_DATA=true`.
- Stop unconfigured bank and insurance integrations from returning fake success IDs/statuses.
- Ignore local `.serena/` agent tooling output.

## Why

Clean-default mode should start empty unless real integrations or explicit demo flags are configured. The previous defaults could expose seeded operational records or make unconfigured external actions look successful.

## Validation

- `pnpm run lint`
- `pnpm test` (37 files, 278 tests)
- `pnpm run build`

Build passes with the existing Turbopack NFT tracing warning from `app/api/files/route.ts` via `next.config.mjs`.
