### PR TITLE
Add work planning scopes and job workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ terraform/crash.log
 .claude/worktrees/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.serena/
 
 # Coverage
 coverage/

--- a/app/api/projects/[id]/allocations/route.ts
+++ b/app/api/projects/[id]/allocations/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server"
+import { withRole } from "@/lib/auth/rbac"
+import { readFile, writeFile, mkdir } from "fs/promises"
+import { join } from "path"
+import { logger } from "@/lib/logger"
+
+const ALLOCATIONS_PATH = join(process.cwd(), "data", "job-allocations.json")
+
+export type JobAllocationType = "material" | "labour"
+
+export interface JobAllocation {
+  id: string
+  projectId: string
+  type: JobAllocationType
+  name: string
+  areaId?: string
+  quantity?: number
+  unit?: string
+  hours?: number
+  rateCents?: number
+  costCents?: number
+  notes?: string
+  createdAt: string
+  updatedAt: string
+}
+
+async function loadAllocations(): Promise<JobAllocation[]> {
+  try {
+    const data = await readFile(ALLOCATIONS_PATH, "utf-8")
+    const parsed = JSON.parse(data)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+async function saveAllocations(allocations: JobAllocation[]): Promise<void> {
+  await mkdir(join(process.cwd(), "data"), { recursive: true })
+  await writeFile(ALLOCATIONS_PATH, JSON.stringify(allocations, null, 2), "utf-8")
+}
+
+function normalizeType(value: unknown): JobAllocationType {
+  return value === "labour" ? "labour" : "material"
+}
+
+function numberFromBody(value: unknown): number | undefined {
+  if (value === "" || value === null || value === undefined) return undefined
+  const n = Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params
+  const { searchParams } = new URL(request.url)
+  const type = searchParams.get("type")
+
+  try {
+    let allocations = (await loadAllocations()).filter((allocation) => allocation.projectId === id)
+    if (type === "material" || type === "labour") {
+      allocations = allocations.filter((allocation) => allocation.type === type)
+    }
+    return NextResponse.json({ allocations })
+  } catch (error) {
+    logger.error("Failed to load job allocations", {
+      error: error instanceof Error ? error.message : String(error),
+      projectId: id,
+    })
+    return NextResponse.json({ error: "Failed to load job allocations" }, { status: 500 })
+  }
+}
+
+export const POST = withRole("admin", "operator", "employee")(async (request, context) => {
+  const params = await context.params
+  const projectId = params?.id
+  if (!projectId) return NextResponse.json({ error: "Project ID required" }, { status: 400 })
+
+  try {
+    const body = await request.json()
+    const name = typeof body.name === "string" ? body.name.trim() : ""
+    if (!name) return NextResponse.json({ error: "name is required" }, { status: 400 })
+
+    const type = normalizeType(body.type)
+    const quantity = numberFromBody(body.quantity)
+    const hours = numberFromBody(body.hours)
+    const rateCents = numberFromBody(body.rateCents)
+    const costCents = numberFromBody(body.costCents)
+    const now = new Date().toISOString()
+    const allocation: JobAllocation = {
+      id: `alloc-${Date.now()}`,
+      projectId,
+      type,
+      name,
+      areaId: typeof body.areaId === "string" && body.areaId ? body.areaId : undefined,
+      quantity: type === "material" ? quantity : undefined,
+      unit: type === "material" && typeof body.unit === "string" ? body.unit.trim() || undefined : undefined,
+      hours: type === "labour" ? hours : undefined,
+      rateCents: type === "labour" ? rateCents : undefined,
+      costCents,
+      notes: typeof body.notes === "string" && body.notes.trim() ? body.notes.trim() : undefined,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    const allocations = await loadAllocations()
+    allocations.push(allocation)
+    await saveAllocations(allocations)
+    return NextResponse.json({ allocation })
+  } catch (error) {
+    logger.error("Failed to create job allocation", {
+      error: error instanceof Error ? error.message : String(error),
+      projectId,
+    })
+    return NextResponse.json({ error: "Failed to create job allocation" }, { status: 500 })
+  }
+})

--- a/app/api/projects/[id]/areas/route.ts
+++ b/app/api/projects/[id]/areas/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server"
+import { withRole } from "@/lib/auth/rbac"
+import { readFile, writeFile, mkdir } from "fs/promises"
+import { join } from "path"
+import { logger } from "@/lib/logger"
+
+const AREAS_PATH = join(process.cwd(), "data", "job-areas.json")
+
+export type JobAreaKind = "room" | "area" | "component" | "zone"
+
+export interface JobArea {
+  id: string
+  projectId: string
+  name: string
+  kind: JobAreaKind
+  notes?: string
+  createdAt: string
+  updatedAt: string
+}
+
+async function loadAreas(): Promise<JobArea[]> {
+  try {
+    const data = await readFile(AREAS_PATH, "utf-8")
+    const parsed = JSON.parse(data)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+async function saveAreas(areas: JobArea[]): Promise<void> {
+  await mkdir(join(process.cwd(), "data"), { recursive: true })
+  await writeFile(AREAS_PATH, JSON.stringify(areas, null, 2), "utf-8")
+}
+
+function normalizeKind(value: unknown): JobAreaKind {
+  if (value === "room" || value === "area" || value === "component" || value === "zone") {
+    return value
+  }
+  return "area"
+}
+
+export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params
+  try {
+    const areas = await loadAreas()
+    return NextResponse.json({ areas: areas.filter((area) => area.projectId === id) })
+  } catch (error) {
+    logger.error("Failed to load job areas", {
+      error: error instanceof Error ? error.message : String(error),
+      projectId: id,
+    })
+    return NextResponse.json({ error: "Failed to load job areas" }, { status: 500 })
+  }
+}
+
+export const POST = withRole("admin", "operator", "employee")(async (request, context) => {
+  const params = await context.params
+  const projectId = params?.id
+  if (!projectId) return NextResponse.json({ error: "Project ID required" }, { status: 400 })
+
+  try {
+    const body = await request.json()
+    const name = typeof body.name === "string" ? body.name.trim() : ""
+    if (!name) return NextResponse.json({ error: "name is required" }, { status: 400 })
+
+    const areas = await loadAreas()
+    const now = new Date().toISOString()
+    const area: JobArea = {
+      id: `area-${Date.now()}`,
+      projectId,
+      name,
+      kind: normalizeKind(body.kind),
+      notes: typeof body.notes === "string" && body.notes.trim() ? body.notes.trim() : undefined,
+      createdAt: now,
+      updatedAt: now,
+    }
+    areas.push(area)
+    await saveAreas(areas)
+    return NextResponse.json({ area })
+  } catch (error) {
+    logger.error("Failed to create job area", {
+      error: error instanceof Error ? error.message : String(error),
+      projectId,
+    })
+    return NextResponse.json({ error: "Failed to create job area" }, { status: 500 })
+  }
+})

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import { readFile, writeFile, mkdir } from "fs/promises"
 import { join } from "path"
-import type { Project } from "@/lib/projects"
+import { toStoredProjectType, withProjectKind, type Project } from "@/lib/projects"
 import { logger } from "@/lib/logger"
 import { routeToInngest } from "@/lib/workflows"
 
@@ -29,7 +29,7 @@ export async function GET(_request: Request, context: { params: Promise<{ id: st
     const projects = await loadProjects()
     const project = projects.find((p) => p.id === id)
     if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 })
-    return NextResponse.json({ project })
+    return NextResponse.json({ project: withProjectKind(project) })
   } catch (err) {
     logger.error("Failed to load project", {
       error: err instanceof Error ? err.message : String(err),
@@ -50,9 +50,15 @@ export const PATCH = withRole("admin")(async (request, context) => {
 
     const p = projects[idx]
     const prevStatus = p.status
+    const storedType = toStoredProjectType(body.type)
+    const updates = { ...body }
+    if (body.type !== undefined) {
+      if (storedType) updates.type = storedType
+      else delete updates.type
+    }
     projects[idx] = {
       ...p,
-      ...body,
+      ...updates,
       id: p.id,
       members: body.members ?? p.members,
       updatedAt: new Date().toISOString(),
@@ -70,7 +76,7 @@ export const PATCH = withRole("admin")(async (request, context) => {
       })
     }
 
-    return NextResponse.json({ project: projects[idx] })
+    return NextResponse.json({ project: withProjectKind(projects[idx]) })
   } catch (err) {
     logger.error("Failed to update project", {
       error: err instanceof Error ? err.message : String(err),

--- a/app/api/projects/[id]/task-groups/route.ts
+++ b/app/api/projects/[id]/task-groups/route.ts
@@ -56,7 +56,11 @@ export async function GET(request: Request, context: { params: Promise<{ id: str
 
   try {
     const [tasks, metadata] = await Promise.all([getTasks({ status: undefined }), loadMetadata()])
-    const projectTasks = tasks.filter((task) => task.project === projectName)
+    const projectMetadata = metadata.filter((item) => item.projectId === id)
+    const projectTasks = tasks.filter(
+      (task) =>
+        task.project === projectName || projectMetadata.some((item) => item.taskId === task.id)
+    )
     return NextResponse.json({ tasks: attachMetadata(projectTasks, metadata, id) })
   } catch (error) {
     logger.error("Failed to load grouped job tasks", {

--- a/app/api/projects/[id]/task-groups/route.ts
+++ b/app/api/projects/[id]/task-groups/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server"
+import { withRole } from "@/lib/auth/rbac"
+import { getTasks, createTask, type Task } from "@/lib/services/baserow"
+import { readFile, writeFile, mkdir } from "fs/promises"
+import { join } from "path"
+import { logger } from "@/lib/logger"
+
+const META_PATH = join(process.cwd(), "data", "job-task-groups.json")
+
+export interface JobTaskMetadata {
+  taskId: number
+  projectId: string
+  areaId?: string
+  groupName?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface GroupedJobTask extends Task {
+  areaId?: string
+  groupName?: string
+}
+
+async function loadMetadata(): Promise<JobTaskMetadata[]> {
+  try {
+    const data = await readFile(META_PATH, "utf-8")
+    const parsed = JSON.parse(data)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+async function saveMetadata(metadata: JobTaskMetadata[]): Promise<void> {
+  await mkdir(join(process.cwd(), "data"), { recursive: true })
+  await writeFile(META_PATH, JSON.stringify(metadata, null, 2), "utf-8")
+}
+
+function attachMetadata(tasks: Task[], metadata: JobTaskMetadata[], projectId: string): GroupedJobTask[] {
+  return tasks.map((task) => {
+    const match = metadata.find((item) => item.projectId === projectId && item.taskId === task.id)
+    return {
+      ...task,
+      areaId: match?.areaId,
+      groupName: match?.groupName,
+    }
+  })
+}
+
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params
+  const { searchParams } = new URL(request.url)
+  const projectName = searchParams.get("projectName")
+
+  if (!projectName) return NextResponse.json({ error: "projectName is required" }, { status: 400 })
+
+  try {
+    const [tasks, metadata] = await Promise.all([getTasks({ status: undefined }), loadMetadata()])
+    const projectTasks = tasks.filter((task) => task.project === projectName)
+    return NextResponse.json({ tasks: attachMetadata(projectTasks, metadata, id) })
+  } catch (error) {
+    logger.error("Failed to load grouped job tasks", {
+      error: error instanceof Error ? error.message : String(error),
+      projectId: id,
+    })
+    return NextResponse.json({ error: "Failed to load grouped job tasks" }, { status: 500 })
+  }
+}
+
+export const POST = withRole("admin", "operator", "employee")(async (request, context) => {
+  const params = await context.params
+  const projectId = params?.id
+  if (!projectId) return NextResponse.json({ error: "Project ID required" }, { status: 400 })
+
+  try {
+    const body = await request.json()
+    const title = typeof body.title === "string" ? body.title.trim() : ""
+    const projectName = typeof body.projectName === "string" ? body.projectName.trim() : ""
+    if (!title) return NextResponse.json({ error: "title is required" }, { status: 400 })
+    if (!projectName) return NextResponse.json({ error: "projectName is required" }, { status: 400 })
+
+    const task = await createTask({
+      title,
+      description: typeof body.description === "string" ? body.description : undefined,
+      priority: body.priority || "Medium",
+      status: "Not Started",
+      project: projectName,
+      assignedTo: typeof body.assignedTo === "number" ? body.assignedTo : undefined,
+      dueDate: typeof body.dueDate === "string" ? body.dueDate : undefined,
+    })
+
+    if (!task) return NextResponse.json({ error: "Failed to create task" }, { status: 500 })
+
+    const metadata = await loadMetadata()
+    const now = new Date().toISOString()
+    const taskMeta: JobTaskMetadata = {
+      taskId: task.id,
+      projectId,
+      areaId: typeof body.areaId === "string" && body.areaId ? body.areaId : undefined,
+      groupName: typeof body.groupName === "string" && body.groupName.trim() ? body.groupName.trim() : undefined,
+      createdAt: now,
+      updatedAt: now,
+    }
+    metadata.push(taskMeta)
+    await saveMetadata(metadata)
+
+    return NextResponse.json({ task: { ...task, areaId: taskMeta.areaId, groupName: taskMeta.groupName } })
+  } catch (error) {
+    logger.error("Failed to create grouped job task", {
+      error: error instanceof Error ? error.message : String(error),
+      projectId,
+    })
+    return NextResponse.json({ error: "Failed to create grouped job task" }, { status: 500 })
+  }
+})

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -57,7 +57,7 @@ export async function GET(request: Request) {
 export const POST = withRole("admin")(async (request: Request) => {
   try {
     const body = await request.json()
-    const { name, description, type, parentId, status, startDate, endDate, budget, members } = body
+    const { name, description, type, scopeKind, parentId, status, startDate, endDate, budget, members } = body
 
     if (!name || !type) {
       return NextResponse.json({ error: "name and type are required" }, { status: 400 })
@@ -73,6 +73,7 @@ export const POST = withRole("admin")(async (request: Request) => {
       name,
       description: description || undefined,
       type: storedType,
+      scopeKind: storedType === "major" ? scopeKind || "site" : undefined,
       parentId: storedType === "subproject" ? parentId : undefined,
       status: status || "planned",
       startDate,

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import { readFile, writeFile, mkdir } from "fs/promises"
 import { join } from "path"
-import type { Project } from "@/lib/projects"
+import { toStoredProjectType, withProjectKind, type Project } from "@/lib/projects"
 import { logger } from "@/lib/logger"
 
 const PROJECTS_PATH = join(process.cwd(), "data", "projects.json")
@@ -25,7 +25,7 @@ async function saveProjects(projects: Project[]): Promise<void> {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const parentId = searchParams.get("parentId")
-  const type = searchParams.get("type")
+  const type = toStoredProjectType(searchParams.get("type"))
   const member = searchParams.get("member")
 
   try {
@@ -36,11 +36,15 @@ export async function GET(request: Request) {
 
     const major = projects.filter((p) => p.type === "major")
     const subprojects = projects.filter((p) => p.type === "subproject")
+    const scopes = major.map(withProjectKind)
+    const jobs = subprojects.map(withProjectKind)
 
     return NextResponse.json({
-      projects,
-      major,
-      subprojects,
+      projects: projects.map(withProjectKind),
+      scopes,
+      jobs,
+      major: scopes,
+      subprojects: jobs,
     })
   } catch (err) {
     logger.error("Failed to load projects", {
@@ -62,13 +66,14 @@ export const POST = withRole("admin")(async (request: Request) => {
     const projects = await loadProjects()
     const id = `proj-${Date.now()}`
     const now = new Date().toISOString()
+    const storedType = toStoredProjectType(type) ?? "subproject"
 
     const project: Project = {
       id,
       name,
       description: description || undefined,
-      type: type === "major" ? "major" : "subproject",
-      parentId: type === "subproject" ? parentId : undefined,
+      type: storedType,
+      parentId: storedType === "subproject" ? parentId : undefined,
       status: status || "planned",
       startDate,
       endDate,
@@ -81,7 +86,7 @@ export const POST = withRole("admin")(async (request: Request) => {
     projects.push(project)
     await saveProjects(projects)
 
-    return NextResponse.json({ project })
+    return NextResponse.json({ project: withProjectKind(project) })
   } catch (err) {
     logger.error("Failed to create project", {
       error: err instanceof Error ? err.message : String(err),

--- a/app/api/projects/suggestions/[id]/route.ts
+++ b/app/api/projects/suggestions/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import { readFile, writeFile, mkdir } from "fs/promises"
 import { join } from "path"
-import type { Project, ProjectMember } from "@/lib/projects"
+import { withProjectKind, type Project, type ProjectMember } from "@/lib/projects"
 import type { ProjectSuggestion } from "../route"
 import { logger } from "@/lib/logger"
 import { routeToInngest } from "@/lib/workflows"
@@ -100,7 +100,7 @@ export const PATCH = withRole("admin")(async (request, context) => {
         },
       })
 
-      return NextResponse.json({ suggestion: suggestions[idx], project })
+      return NextResponse.json({ suggestion: suggestions[idx], project: withProjectKind(project) })
     }
 
     return NextResponse.json({ suggestion: suggestions[idx] })

--- a/app/api/projects/suggestions/[id]/route.ts
+++ b/app/api/projects/suggestions/[id]/route.ts
@@ -80,6 +80,7 @@ export const PATCH = withRole("admin")(async (request, context) => {
         name: suggestion.name,
         description: suggestion.description,
         type: suggestion.type,
+        scopeKind: suggestion.scopeKind,
         parentId: suggestion.parentId,
         status: "planned",
         members: [] as ProjectMember[],

--- a/app/api/projects/suggestions/route.ts
+++ b/app/api/projects/suggestions/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { withAuth, withRole } from "@/lib/auth/rbac"
 import { readFile, writeFile, mkdir } from "fs/promises"
 import { join } from "path"
-import type { Project } from "@/lib/projects"
+import { toStoredProjectType, type Project, type ProjectStorageType } from "@/lib/projects"
 import { logger } from "@/lib/logger"
 
 const SUGGESTIONS_PATH = join(process.cwd(), "data", "project-suggestions.json")
@@ -12,7 +12,7 @@ export interface ProjectSuggestion {
   id: string
   name: string
   description?: string
-  type: "major" | "subproject"
+  type: ProjectStorageType
   parentId?: string
   suggestedBy: string
   suggestedAt: string
@@ -78,12 +78,13 @@ export const POST = withAuth(async (request: Request) => {
 
     const suggestions = await loadSuggestions()
     const id = `sug-${Date.now()}`
+    const storedType = toStoredProjectType(type) ?? "subproject"
     const suggestion: ProjectSuggestion = {
       id,
       name: name.trim(),
       description: description?.trim(),
-      type: type === "major" ? "major" : "subproject",
-      parentId: type === "subproject" ? parentId : undefined,
+      type: storedType,
+      parentId: storedType === "subproject" ? parentId : undefined,
       suggestedBy: auth,
       suggestedAt: new Date().toISOString(),
       status: "pending",

--- a/app/api/projects/suggestions/route.ts
+++ b/app/api/projects/suggestions/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { withAuth, withRole } from "@/lib/auth/rbac"
 import { readFile, writeFile, mkdir } from "fs/promises"
 import { join } from "path"
-import { toStoredProjectType, type Project, type ProjectStorageType } from "@/lib/projects"
+import { toStoredProjectType, type Project, type ProjectStorageType, type ScopeKind } from "@/lib/projects"
 import { logger } from "@/lib/logger"
 
 const SUGGESTIONS_PATH = join(process.cwd(), "data", "project-suggestions.json")
@@ -13,6 +13,7 @@ export interface ProjectSuggestion {
   name: string
   description?: string
   type: ProjectStorageType
+  scopeKind?: ScopeKind
   parentId?: string
   suggestedBy: string
   suggestedAt: string
@@ -70,7 +71,7 @@ export const POST = withAuth(async (request: Request) => {
   try {
     const auth = request.headers.get("x-user-id") || "unknown"
     const body = await request.json()
-    const { name, description, type, parentId } = body
+    const { name, description, type, scopeKind, parentId } = body
 
     if (!name || typeof name !== "string" || !name.trim()) {
       return NextResponse.json({ error: "name is required" }, { status: 400 })
@@ -84,6 +85,7 @@ export const POST = withAuth(async (request: Request) => {
       name: name.trim(),
       description: description?.trim(),
       type: storedType,
+      scopeKind: storedType === "major" ? scopeKind || "site" : undefined,
       parentId: storedType === "subproject" ? parentId : undefined,
       suggestedBy: auth,
       suggestedAt: new Date().toISOString(),

--- a/app/dashboard/[persona]/projects/[id]/page.tsx
+++ b/app/dashboard/[persona]/projects/[id]/page.tsx
@@ -1,0 +1,27 @@
+import DashboardLayout from "@/components/dashboard-layout"
+import { JobDetailPageContent } from "@/components/job-detail-page-content"
+import { notFound } from "next/navigation"
+
+const PERSONAS = ["hans", "charl", "lucky", "irma"] as const
+
+type Persona = (typeof PERSONAS)[number]
+
+function isPersona(value: string): value is Persona {
+  return PERSONAS.includes(value as Persona)
+}
+
+export default async function JobDetailPage({
+  params,
+}: {
+  params: Promise<{ persona: string; id: string }>
+}) {
+  const { persona, id } = await params
+
+  if (!isPersona(persona)) notFound()
+
+  return (
+    <DashboardLayout persona={persona}>
+      <JobDetailPageContent persona={persona} projectId={id} />
+    </DashboardLayout>
+  )
+}

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -7,6 +7,7 @@ import { NotificationPanel } from "@/components/notification-panel"
 import { OnboardingTutorial } from "@/components/onboarding-tutorial"
 import { RealTimeIndicator } from "@/components/realtime-indicator"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
+import { ScopeSelector } from "@/components/scope-selector"
 import { UserProfileDropdown } from "@/components/user-profile-dropdown"
 import { WidgetErrorBoundary } from "@/components/widget-error-boundary"
 import { apiFetch } from "@/lib/api-client"
@@ -324,6 +325,7 @@ export default function DashboardLayout({ children, persona }: DashboardLayoutPr
 
             {/* Right Side Actions */}
             <div className="flex items-center gap-4">
+              <ScopeSelector />
               <ConnectionStatus />
               <WidgetErrorBoundary>
                 <RealTimeIndicator />

--- a/components/job-detail-page-content.tsx
+++ b/components/job-detail-page-content.tsx
@@ -22,6 +22,7 @@ import { logger } from "@/lib/logger"
 import type { Project } from "@/lib/projects"
 import type { JobArea, JobAreaKind } from "@/app/api/projects/[id]/areas/route"
 import type { GroupedJobTask } from "@/app/api/projects/[id]/task-groups/route"
+import type { JobAllocation } from "@/app/api/projects/[id]/allocations/route"
 
 const STATUS_COLORS: Record<string, string> = {
   planned: "bg-muted text-muted-foreground",
@@ -48,6 +49,7 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
   const [loading, setLoading] = useState(true)
   const [areas, setAreas] = useState<JobArea[]>([])
   const [tasks, setTasks] = useState<GroupedJobTask[]>([])
+  const [allocations, setAllocations] = useState<JobAllocation[]>([])
   const [areaForm, setAreaForm] = useState({
     name: "",
     kind: "area" as JobAreaKind,
@@ -58,6 +60,17 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
     areaId: "_none",
     groupName: "",
     priority: "Medium",
+  })
+  const [allocationForm, setAllocationForm] = useState({
+    type: "material" as "material" | "labour",
+    name: "",
+    areaId: "_none",
+    quantity: "",
+    unit: "",
+    hours: "",
+    rate: "",
+    cost: "",
+    notes: "",
   })
 
   const fetchJob = useCallback(async () => {
@@ -79,9 +92,15 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
           { label: "JobTasks" }
         )
         setTasks(tasksData?.tasks || [])
+        const allocationsData = await apiFetch<{ allocations?: JobAllocation[] }>(
+          `/api/projects/${loadedJob.id}/allocations`,
+          { label: "JobAllocations" }
+        )
+        setAllocations(allocationsData?.allocations || [])
       } else {
         setAreas([])
         setTasks([])
+        setAllocations([])
       }
 
       if (loadedJob?.parentId) {
@@ -108,6 +127,56 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
     fetchJob()
   }, [fetchJob])
 
+  const refreshAllocations = async (currentJob: Project) => {
+    const allocationsData = await apiFetch<{ allocations?: JobAllocation[] }>(
+      `/api/projects/${currentJob.id}/allocations`,
+      { label: "JobAllocations" }
+    )
+    setAllocations(allocationsData?.allocations || [])
+  }
+
+  const handleCreateAllocation = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!job || !allocationForm.name.trim()) return
+
+    const rateCents = allocationForm.rate ? Math.round(Number(allocationForm.rate) * 100) : undefined
+    const costCents = allocationForm.cost ? Math.round(Number(allocationForm.cost) * 100) : undefined
+
+    try {
+      await apiFetch(`/api/projects/${job.id}/allocations`, {
+        method: "POST",
+        body: {
+          type: allocationForm.type,
+          name: allocationForm.name,
+          areaId: allocationForm.areaId === "_none" ? undefined : allocationForm.areaId,
+          quantity: allocationForm.quantity || undefined,
+          unit: allocationForm.unit || undefined,
+          hours: allocationForm.hours || undefined,
+          rateCents,
+          costCents,
+          notes: allocationForm.notes || undefined,
+        },
+        label: "CreateJobAllocation",
+      })
+      setAllocationForm({
+        type: allocationForm.type,
+        name: "",
+        areaId: "_none",
+        quantity: "",
+        unit: "",
+        hours: "",
+        rate: "",
+        cost: "",
+        notes: "",
+      })
+      await refreshAllocations(job)
+    } catch (error) {
+      logger.error("Failed to create allocation", {
+        error: error instanceof Error ? error.message : String(error),
+        projectId: job.id,
+      })
+    }
+  }
   const refreshTasks = async (currentJob: Project) => {
     const tasksData = await apiFetch<{ tasks?: GroupedJobTask[] }>(
       `/api/projects/${currentJob.id}/task-groups?projectName=${encodeURIComponent(currentJob.name)}`,
@@ -445,11 +514,25 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
             </div>
           )}
         </TabsContent>
-        <TabsContent value="materials">
-          <PlaceholderCard icon={<Package className="h-5 w-5" />} title="Materials / Parts" body="Materials and parts will support allocations across jobs in a later slice." />
+        <TabsContent value="materials" className="space-y-4">
+          <AllocationForm
+            type="material"
+            areas={areas}
+            allocations={allocations.filter((allocation) => allocation.type === "material")}
+            allocationForm={allocationForm}
+            setAllocationForm={setAllocationForm}
+            onSubmit={handleCreateAllocation}
+          />
         </TabsContent>
-        <TabsContent value="labour">
-          <PlaceholderCard icon={<Hammer className="h-5 w-5" />} title="Labour" body="Labour will support split allocations instead of strict job ownership." />
+        <TabsContent value="labour" className="space-y-4">
+          <AllocationForm
+            type="labour"
+            areas={areas}
+            allocations={allocations.filter((allocation) => allocation.type === "labour")}
+            allocationForm={allocationForm}
+            setAllocationForm={setAllocationForm}
+            onSubmit={handleCreateAllocation}
+          />
         </TabsContent>
         <TabsContent value="documents">
           <PlaceholderCard icon={<FileText className="h-5 w-5" />} title="Documents" body="Photos, quotes, approvals and completion records will attach here." />
@@ -470,5 +553,204 @@ function PlaceholderCard({ icon, title, body }: { icon: ReactNode; title: string
         </div>
       </CardContent>
     </Card>
+  )
+}
+type AllocationFormState = {
+  type: "material" | "labour"
+  name: string
+  areaId: string
+  quantity: string
+  unit: string
+  hours: string
+  rate: string
+  cost: string
+  notes: string
+}
+
+function centsToCurrency(cents?: number): string {
+  if (!cents) return "-"
+  return new Intl.NumberFormat("en-ZA", { style: "currency", currency: "ZAR" }).format(cents / 100)
+}
+
+function AllocationForm({
+  type,
+  areas,
+  allocations,
+  allocationForm,
+  setAllocationForm,
+  onSubmit,
+}: {
+  type: "material" | "labour"
+  areas: JobArea[]
+  allocations: JobAllocation[]
+  allocationForm: AllocationFormState
+  setAllocationForm: React.Dispatch<React.SetStateAction<AllocationFormState>>
+  onSubmit: (event: React.FormEvent) => void
+}) {
+  const isMaterial = type === "material"
+
+  return (
+    <>
+      <Card className="border-border bg-card/80">
+        <CardHeader>
+          <CardTitle>{isMaterial ? "Materials / Parts" : "Labour"}</CardTitle>
+          <CardDescription>
+            {isMaterial
+              ? "Record materials or parts allocated to this job. Add separate records when a purchase is split."
+              : "Record labour allocated to this job. Split time by adding separate records."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            onSubmit={onSubmit}
+            className="grid gap-3 md:grid-cols-[1fr_180px_140px_140px_auto]"
+            onFocus={() => setAllocationForm((form) => ({ ...form, type }))}
+          >
+            <div>
+              <Label>{isMaterial ? "Material / part" : "Person / crew"}</Label>
+              <Input
+                value={allocationForm.type === type ? allocationForm.name : ""}
+                onChange={(event) =>
+                  setAllocationForm((form) => ({ ...form, type, name: event.target.value }))
+                }
+                className="mt-1 border-border bg-background"
+                placeholder={isMaterial ? "e.g. Tiles" : "e.g. Charl"}
+              />
+            </div>
+            <div>
+              <Label>Area</Label>
+              <Select
+                value={allocationForm.type === type ? allocationForm.areaId : "_none"}
+                onValueChange={(value) => setAllocationForm((form) => ({ ...form, type, areaId: value }))}
+              >
+                <SelectTrigger className="mt-1 border-border bg-background">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="_none">No area</SelectItem>
+                  {areas.map((area) => (
+                    <SelectItem key={area.id} value={area.id}>
+                      {area.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {isMaterial ? (
+              <>
+                <div>
+                  <Label>Quantity</Label>
+                  <Input
+                    value={allocationForm.type === type ? allocationForm.quantity : ""}
+                    onChange={(event) =>
+                      setAllocationForm((form) => ({ ...form, type, quantity: event.target.value }))
+                    }
+                    className="mt-1 border-border bg-background"
+                    inputMode="decimal"
+                  />
+                </div>
+                <div>
+                  <Label>Unit</Label>
+                  <Input
+                    value={allocationForm.type === type ? allocationForm.unit : ""}
+                    onChange={(event) =>
+                      setAllocationForm((form) => ({ ...form, type, unit: event.target.value }))
+                    }
+                    className="mt-1 border-border bg-background"
+                    placeholder="bags, m2"
+                  />
+                </div>
+              </>
+            ) : (
+              <>
+                <div>
+                  <Label>Hours</Label>
+                  <Input
+                    value={allocationForm.type === type ? allocationForm.hours : ""}
+                    onChange={(event) =>
+                      setAllocationForm((form) => ({ ...form, type, hours: event.target.value }))
+                    }
+                    className="mt-1 border-border bg-background"
+                    inputMode="decimal"
+                  />
+                </div>
+                <div>
+                  <Label>Rate</Label>
+                  <Input
+                    value={allocationForm.type === type ? allocationForm.rate : ""}
+                    onChange={(event) =>
+                      setAllocationForm((form) => ({ ...form, type, rate: event.target.value }))
+                    }
+                    className="mt-1 border-border bg-background"
+                    inputMode="decimal"
+                  />
+                </div>
+              </>
+            )}
+            <div className="flex items-end">
+              <Button type="submit" className="bg-primary text-primary-foreground hover:bg-primary/90">
+                Add
+              </Button>
+            </div>
+            <div className="md:col-span-5">
+              <Label>Estimated cost</Label>
+              <Input
+                value={allocationForm.type === type ? allocationForm.cost : ""}
+                onChange={(event) =>
+                  setAllocationForm((form) => ({ ...form, type, cost: event.target.value }))
+                }
+                className="mt-1 border-border bg-background"
+                inputMode="decimal"
+              />
+            </div>
+            <div className="md:col-span-5">
+              <Label>Notes</Label>
+              <Textarea
+                value={allocationForm.type === type ? allocationForm.notes : ""}
+                onChange={(event) =>
+                  setAllocationForm((form) => ({ ...form, type, notes: event.target.value }))
+                }
+                className="mt-1 border-border bg-background"
+                rows={2}
+              />
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {allocations.length === 0 ? (
+        <PlaceholderCard
+          icon={isMaterial ? <Package className="h-5 w-5" /> : <Hammer className="h-5 w-5" />}
+          title={isMaterial ? "No materials allocated" : "No labour allocated"}
+          body={isMaterial ? "Add materials or parts for this job." : "Add labour time or cost for this job."}
+        />
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2">
+          {allocations.map((allocation) => {
+            const area = areas.find((item) => item.id === allocation.areaId)
+            return (
+              <Card key={allocation.id} className="border-border bg-card/80">
+                <CardContent className="pt-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium text-foreground">{allocation.name}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {isMaterial
+                          ? `${allocation.quantity ?? "-"} ${allocation.unit || ""}`.trim()
+                          : `${allocation.hours ?? "-"} hours`}
+                      </p>
+                      {area && <p className="mt-1 text-sm text-muted-foreground">{area.name}</p>}
+                    </div>
+                    <Badge variant="outline" className="border-border text-muted-foreground">
+                      {centsToCurrency(allocation.costCents)}
+                    </Badge>
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+    </>
   )
 }

--- a/components/job-detail-page-content.tsx
+++ b/components/job-detail-page-content.tsx
@@ -21,6 +21,7 @@ import { apiFetch } from "@/lib/api-client"
 import { logger } from "@/lib/logger"
 import type { Project } from "@/lib/projects"
 import type { JobArea, JobAreaKind } from "@/app/api/projects/[id]/areas/route"
+import type { GroupedJobTask } from "@/app/api/projects/[id]/task-groups/route"
 
 const STATUS_COLORS: Record<string, string> = {
   planned: "bg-muted text-muted-foreground",
@@ -46,10 +47,17 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
   const [scope, setScope] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [areas, setAreas] = useState<JobArea[]>([])
+  const [tasks, setTasks] = useState<GroupedJobTask[]>([])
   const [areaForm, setAreaForm] = useState({
     name: "",
     kind: "area" as JobAreaKind,
     notes: "",
+  })
+  const [taskForm, setTaskForm] = useState({
+    title: "",
+    areaId: "_none",
+    groupName: "",
+    priority: "Medium",
   })
 
   const fetchJob = useCallback(async () => {
@@ -66,8 +74,14 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
           label: "JobAreas",
         })
         setAreas(areasData?.areas || [])
+        const tasksData = await apiFetch<{ tasks?: GroupedJobTask[] }>(
+          `/api/projects/${loadedJob.id}/task-groups?projectName=${encodeURIComponent(loadedJob.name)}`,
+          { label: "JobTasks" }
+        )
+        setTasks(tasksData?.tasks || [])
       } else {
         setAreas([])
+        setTasks([])
       }
 
       if (loadedJob?.parentId) {
@@ -94,6 +108,39 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
     fetchJob()
   }, [fetchJob])
 
+  const refreshTasks = async (currentJob: Project) => {
+    const tasksData = await apiFetch<{ tasks?: GroupedJobTask[] }>(
+      `/api/projects/${currentJob.id}/task-groups?projectName=${encodeURIComponent(currentJob.name)}`,
+      { label: "JobTasks" }
+    )
+    setTasks(tasksData?.tasks || [])
+  }
+
+  const handleCreateTask = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!job || !taskForm.title.trim()) return
+
+    try {
+      await apiFetch(`/api/projects/${job.id}/task-groups`, {
+        method: "POST",
+        body: {
+          title: taskForm.title,
+          projectName: job.name,
+          areaId: taskForm.areaId === "_none" ? undefined : taskForm.areaId,
+          groupName: taskForm.groupName || undefined,
+          priority: taskForm.priority,
+        },
+        label: "CreateJobTask",
+      })
+      setTaskForm({ title: "", areaId: "_none", groupName: "", priority: "Medium" })
+      await refreshTasks(job)
+    } catch (error) {
+      logger.error("Failed to create grouped task", {
+        error: error instanceof Error ? error.message : String(error),
+        projectId: job.id,
+      })
+    }
+  }
   const handleCreateArea = async (event: React.FormEvent) => {
     event.preventDefault()
     if (!job || !areaForm.name.trim()) return
@@ -301,8 +348,102 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
             </div>
           )}
         </TabsContent>
-        <TabsContent value="tasks">
-          <PlaceholderCard icon={<ClipboardList className="h-5 w-5" />} title="Tasks" body="Tasks will remain job-owned and can later be grouped by area." />
+        <TabsContent value="tasks" className="space-y-4">
+          <Card className="border-border bg-card/80">
+            <CardHeader>
+              <CardTitle>Tasks</CardTitle>
+              <CardDescription>Tasks stay owned by this job and can be grouped by area.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleCreateTask} className="grid gap-3 md:grid-cols-[1fr_180px_160px_auto]">
+                <div>
+                  <Label>Task</Label>
+                  <Input
+                    value={taskForm.title}
+                    onChange={(event) => setTaskForm((form) => ({ ...form, title: event.target.value }))}
+                    placeholder="e.g. Remove old basin"
+                    className="mt-1 border-border bg-background"
+                  />
+                </div>
+                <div>
+                  <Label>Area</Label>
+                  <Select
+                    value={taskForm.areaId}
+                    onValueChange={(value) => setTaskForm((form) => ({ ...form, areaId: value }))}
+                  >
+                    <SelectTrigger className="mt-1 border-border bg-background">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="_none">No area</SelectItem>
+                      {areas.map((area) => (
+                        <SelectItem key={area.id} value={area.id}>
+                          {area.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <Label>Priority</Label>
+                  <Select
+                    value={taskForm.priority}
+                    onValueChange={(value) => setTaskForm((form) => ({ ...form, priority: value }))}
+                  >
+                    <SelectTrigger className="mt-1 border-border bg-background">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Low">Low</SelectItem>
+                      <SelectItem value="Medium">Medium</SelectItem>
+                      <SelectItem value="High">High</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="flex items-end">
+                  <Button type="submit" className="bg-primary text-primary-foreground hover:bg-primary/90">
+                    Add task
+                  </Button>
+                </div>
+                <div className="md:col-span-4">
+                  <Label>Task group</Label>
+                  <Input
+                    value={taskForm.groupName}
+                    onChange={(event) => setTaskForm((form) => ({ ...form, groupName: event.target.value }))}
+                    placeholder="e.g. Plumbing, Prep, Finishing"
+                    className="mt-1 border-border bg-background"
+                  />
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+
+          {tasks.length === 0 ? (
+            <PlaceholderCard icon={<ClipboardList className="h-5 w-5" />} title="No tasks yet" body="Add the first job task and optionally place it in an area or task group." />
+          ) : (
+            <div className="space-y-3">
+              {tasks.map((task) => {
+                const area = areas.find((item) => item.id === task.areaId)
+                return (
+                  <Card key={task.id} className="border-border bg-card/80">
+                    <CardContent className="flex items-center justify-between gap-4 pt-4">
+                      <div>
+                        <p className="font-medium text-foreground">{task.title}</p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2">
+                          <Badge variant="outline" className="border-border text-muted-foreground">
+                            {task.status}
+                          </Badge>
+                          <Badge className="bg-accent/20 text-accent">{task.priority}</Badge>
+                          {area && <span className="text-sm text-muted-foreground">{area.name}</span>}
+                          {task.groupName && <span className="text-sm text-muted-foreground">{task.groupName}</span>}
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )
+              })}
+            </div>
+          )}
         </TabsContent>
         <TabsContent value="materials">
           <PlaceholderCard icon={<Package className="h-5 w-5" />} title="Materials / Parts" body="Materials and parts will support allocations across jobs in a later slice." />

--- a/components/job-detail-page-content.tsx
+++ b/components/job-detail-page-content.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import { useCallback, useEffect, useState, type ReactNode } from "react"
+import Link from "next/link"
+import { ArrowLeft, BriefcaseBusiness, CalendarDays, ClipboardList, FileText, Hammer, Layers3, Package, Users } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { apiFetch } from "@/lib/api-client"
+import { logger } from "@/lib/logger"
+import type { Project } from "@/lib/projects"
+
+const STATUS_COLORS: Record<string, string> = {
+  planned: "bg-muted text-muted-foreground",
+  in_progress: "bg-primary/20 text-primary",
+  on_hold: "bg-secondary/20 text-secondary",
+  completed: "bg-primary/40 text-primary-foreground",
+}
+
+const PERSONA_INFO: Record<string, string> = {
+  hans: "Hans",
+  charl: "Charl",
+  lucky: "Lucky",
+  irma: "Irma",
+}
+
+interface JobDetailPageContentProps {
+  persona: "hans" | "charl" | "lucky" | "irma"
+  projectId: string
+}
+
+export function JobDetailPageContent({ persona, projectId }: JobDetailPageContentProps) {
+  const [job, setJob] = useState<Project | null>(null)
+  const [scope, setScope] = useState<Project | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const fetchJob = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await apiFetch<{ project?: Project }>(`/api/projects/${projectId}`, {
+        label: "JobDetail",
+      })
+      const loadedJob = data?.project || null
+      setJob(loadedJob)
+
+      if (loadedJob?.parentId) {
+        const scopeData = await apiFetch<{ project?: Project }>(`/api/projects/${loadedJob.parentId}`, {
+          label: "JobScope",
+        })
+        setScope(scopeData?.project || null)
+      } else {
+        setScope(null)
+      }
+    } catch (error) {
+      logger.error("Failed to fetch job detail", {
+        error: error instanceof Error ? error.message : String(error),
+        projectId,
+      })
+      setJob(null)
+      setScope(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => {
+    fetchJob()
+  }, [fetchJob])
+
+  if (loading) {
+    return <div className="py-12 text-center text-muted-foreground">Loading job...</div>
+  }
+
+  if (!job || job.type !== "subproject") {
+    return (
+      <div className="space-y-4">
+        <Button asChild variant="outline" className="border-border text-foreground hover:bg-muted">
+          <Link href={`/dashboard/${persona}/projects`}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Work
+          </Link>
+        </Button>
+        <Card className="border-dashed border-border bg-card/80">
+          <CardContent className="py-10 text-center text-muted-foreground">
+            Job not found or this item is a scope, not a job.
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const memberNames = job.members?.map((member) => PERSONA_INFO[member.userId] || member.userId) || []
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-3">
+          <Button asChild variant="outline" className="border-border text-foreground hover:bg-muted">
+            <Link href={`/dashboard/${persona}/projects`}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Work
+            </Link>
+          </Button>
+          <div>
+            <h1 className="flex items-center gap-2 text-2xl font-bold text-foreground">
+              <BriefcaseBusiness className="h-8 w-8 text-primary" />
+              {job.name}
+            </h1>
+            <p className="mt-1 text-muted-foreground">
+              {scope ? `${scope.name} job workspace` : "Job workspace"}
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge className={STATUS_COLORS[job.status] || STATUS_COLORS.planned}>
+            {job.status.replace("_", " ")}
+          </Badge>
+          {scope && (
+            <Badge variant="outline" className="border-primary/30 text-primary/80">
+              {scope.name}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card className="border-border bg-card/80">
+          <CardContent className="flex items-center gap-3 pt-4">
+            <Layers3 className="h-5 w-5 text-primary" />
+            <div>
+              <p className="text-sm text-muted-foreground">Scope</p>
+              <p className="font-medium text-foreground">{scope?.name || "Unassigned"}</p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-border bg-card/80">
+          <CardContent className="flex items-center gap-3 pt-4">
+            <Users className="h-5 w-5 text-primary" />
+            <div>
+              <p className="text-sm text-muted-foreground">Team</p>
+              <p className="font-medium text-foreground">
+                {memberNames.length ? memberNames.join(", ") : "No team assigned"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-border bg-card/80">
+          <CardContent className="flex items-center gap-3 pt-4">
+            <CalendarDays className="h-5 w-5 text-primary" />
+            <div>
+              <p className="text-sm text-muted-foreground">Timeline</p>
+              <p className="font-medium text-foreground">{job.startDate || "Not scheduled"}</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Tabs defaultValue="overview" className="space-y-4">
+        <TabsList className="border border-border bg-card/80">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="areas">Areas</TabsTrigger>
+          <TabsTrigger value="tasks">Tasks</TabsTrigger>
+          <TabsTrigger value="materials">Materials</TabsTrigger>
+          <TabsTrigger value="labour">Labour</TabsTrigger>
+          <TabsTrigger value="documents">Documents</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview">
+          <Card className="border-border bg-card/80">
+            <CardHeader>
+              <CardTitle>Overview</CardTitle>
+              <CardDescription>{job.description || "No notes recorded for this job yet."}</CardDescription>
+            </CardHeader>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="areas">
+          <PlaceholderCard icon={<Layers3 className="h-5 w-5" />} title="Areas / Rooms / Components" body="The next slice will add subdivisions inside this job." />
+        </TabsContent>
+        <TabsContent value="tasks">
+          <PlaceholderCard icon={<ClipboardList className="h-5 w-5" />} title="Tasks" body="Tasks will remain job-owned and can later be grouped by area." />
+        </TabsContent>
+        <TabsContent value="materials">
+          <PlaceholderCard icon={<Package className="h-5 w-5" />} title="Materials / Parts" body="Materials and parts will support allocations across jobs in a later slice." />
+        </TabsContent>
+        <TabsContent value="labour">
+          <PlaceholderCard icon={<Hammer className="h-5 w-5" />} title="Labour" body="Labour will support split allocations instead of strict job ownership." />
+        </TabsContent>
+        <TabsContent value="documents">
+          <PlaceholderCard icon={<FileText className="h-5 w-5" />} title="Documents" body="Photos, quotes, approvals and completion records will attach here." />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function PlaceholderCard({ icon, title, body }: { icon: ReactNode; title: string; body: string }) {
+  return (
+    <Card className="border-dashed border-border bg-card/80">
+      <CardContent className="flex items-start gap-3 py-8">
+        <div className="rounded-lg bg-primary/10 p-2 text-primary">{icon}</div>
+        <div>
+          <p className="font-medium text-foreground">{title}</p>
+          <p className="mt-1 text-sm text-muted-foreground">{body}</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/job-detail-page-content.tsx
+++ b/components/job-detail-page-content.tsx
@@ -4,12 +4,23 @@ import { useCallback, useEffect, useState, type ReactNode } from "react"
 import Link from "next/link"
 import { ArrowLeft, BriefcaseBusiness, CalendarDays, ClipboardList, FileText, Hammer, Layers3, Package, Users } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { apiFetch } from "@/lib/api-client"
 import { logger } from "@/lib/logger"
 import type { Project } from "@/lib/projects"
+import type { JobArea, JobAreaKind } from "@/app/api/projects/[id]/areas/route"
 
 const STATUS_COLORS: Record<string, string> = {
   planned: "bg-muted text-muted-foreground",
@@ -34,6 +45,12 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
   const [job, setJob] = useState<Project | null>(null)
   const [scope, setScope] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
+  const [areas, setAreas] = useState<JobArea[]>([])
+  const [areaForm, setAreaForm] = useState({
+    name: "",
+    kind: "area" as JobAreaKind,
+    notes: "",
+  })
 
   const fetchJob = useCallback(async () => {
     setLoading(true)
@@ -43,6 +60,15 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
       })
       const loadedJob = data?.project || null
       setJob(loadedJob)
+
+      if (loadedJob?.type === "subproject") {
+        const areasData = await apiFetch<{ areas?: JobArea[] }>(`/api/projects/${loadedJob.id}/areas`, {
+          label: "JobAreas",
+        })
+        setAreas(areasData?.areas || [])
+      } else {
+        setAreas([])
+      }
 
       if (loadedJob?.parentId) {
         const scopeData = await apiFetch<{ project?: Project }>(`/api/projects/${loadedJob.parentId}`, {
@@ -68,6 +94,32 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
     fetchJob()
   }, [fetchJob])
 
+  const handleCreateArea = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!job || !areaForm.name.trim()) return
+
+    try {
+      await apiFetch(`/api/projects/${job.id}/areas`, {
+        method: "POST",
+        body: {
+          name: areaForm.name,
+          kind: areaForm.kind,
+          notes: areaForm.notes || undefined,
+        },
+        label: "CreateJobArea",
+      })
+      setAreaForm({ name: "", kind: "area", notes: "" })
+      const areasData = await apiFetch<{ areas?: JobArea[] }>(`/api/projects/${job.id}/areas`, {
+        label: "JobAreas",
+      })
+      setAreas(areasData?.areas || [])
+    } catch (error) {
+      logger.error("Failed to create job area", {
+        error: error instanceof Error ? error.message : String(error),
+        projectId: job.id,
+      })
+    }
+  }
   if (loading) {
     return <div className="py-12 text-center text-muted-foreground">Loading job...</div>
   }
@@ -175,8 +227,79 @@ export function JobDetailPageContent({ persona, projectId }: JobDetailPageConten
           </Card>
         </TabsContent>
 
-        <TabsContent value="areas">
-          <PlaceholderCard icon={<Layers3 className="h-5 w-5" />} title="Areas / Rooms / Components" body="The next slice will add subdivisions inside this job." />
+        <TabsContent value="areas" className="space-y-4">
+          <Card className="border-border bg-card/80">
+            <CardHeader>
+              <CardTitle>Areas / Rooms / Components</CardTitle>
+              <CardDescription>Break this job into physical or logical work areas.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleCreateArea} className="grid gap-3 md:grid-cols-[1fr_160px_auto]">
+                <div>
+                  <Label>Name</Label>
+                  <Input
+                    value={areaForm.name}
+                    onChange={(event) => setAreaForm((form) => ({ ...form, name: event.target.value }))}
+                    placeholder="e.g. Bathroom, front axle, coach 2"
+                    className="mt-1 border-border bg-background"
+                  />
+                </div>
+                <div>
+                  <Label>Type</Label>
+                  <Select
+                    value={areaForm.kind}
+                    onValueChange={(value) => setAreaForm((form) => ({ ...form, kind: value as JobAreaKind }))}
+                  >
+                    <SelectTrigger className="mt-1 border-border bg-background">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="room">Room</SelectItem>
+                      <SelectItem value="area">Area</SelectItem>
+                      <SelectItem value="component">Component</SelectItem>
+                      <SelectItem value="zone">Zone</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="flex items-end">
+                  <Button type="submit" className="bg-primary text-primary-foreground hover:bg-primary/90">
+                    Add area
+                  </Button>
+                </div>
+                <div className="md:col-span-3">
+                  <Label>Notes</Label>
+                  <Textarea
+                    value={areaForm.notes}
+                    onChange={(event) => setAreaForm((form) => ({ ...form, notes: event.target.value }))}
+                    className="mt-1 border-border bg-background"
+                    rows={2}
+                  />
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+
+          {areas.length === 0 ? (
+            <PlaceholderCard icon={<Layers3 className="h-5 w-5" />} title="No areas yet" body="Add the first room, area, component or zone for this job." />
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2">
+              {areas.map((area) => (
+                <Card key={area.id} className="border-border bg-card/80">
+                  <CardContent className="pt-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium text-foreground">{area.name}</p>
+                        {area.notes && <p className="mt-1 text-sm text-muted-foreground">{area.notes}</p>}
+                      </div>
+                      <Badge variant="outline" className="border-border text-muted-foreground">
+                        {area.kind}
+                      </Badge>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
         </TabsContent>
         <TabsContent value="tasks">
           <PlaceholderCard icon={<ClipboardList className="h-5 w-5" />} title="Tasks" body="Tasks will remain job-owned and can later be grouped by area." />

--- a/components/projects-page-content.tsx
+++ b/components/projects-page-content.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import { useState, useEffect, useCallback, useRef } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -829,6 +830,14 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
                             ) : null}
                           </div>
                         </div>
+                        <Button
+                          asChild
+                          size="sm"
+                          variant="outline"
+                          className="border-white/10 text-white/70 hover:bg-white/10 hover:text-white"
+                        >
+                          <Link href={`/dashboard/${persona}/projects/${job.id}`}>Open</Link>
+                        </Button>
                         {isAdmin &&
                           (() => {
                             const available = ["hans", "charl", "lucky", "irma"].filter(

--- a/components/projects-page-content.tsx
+++ b/components/projects-page-content.tsx
@@ -34,10 +34,11 @@ import {
   ImagePlus,
   Check,
   X,
+  Pencil,
 } from "lucide-react"
 import { AiSuggestIcon } from "@/components/ui/ai-suggest-icon"
 import { getStoredScopeId } from "@/components/scope-selector"
-import type { Project } from "@/lib/projects"
+import type { Project, ScopeKind } from "@/lib/projects"
 import type { ProjectSuggestion } from "@/app/api/projects/suggestions/route"
 import { logger } from "@/lib/logger"
 import { apiFetch } from "@/lib/api-client"
@@ -59,6 +60,12 @@ const STATUS_COLORS: Record<string, string> = {
 
 const ALL_SCOPES = "_all"
 
+const SCOPE_KIND_LABELS: Record<ScopeKind, string> = {
+  site: "Site",
+  asset: "Asset",
+  location: "Location",
+}
+
 interface ProjectsPageContentProps {
   persona: "hans" | "charl" | "lucky" | "irma"
   isAdmin: boolean
@@ -70,6 +77,8 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
   const [loading, setLoading] = useState(true)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [suggestDialogOpen, setSuggestDialogOpen] = useState(false)
+  const [editScopeOpen, setEditScopeOpen] = useState(false)
+  const [editingScope, setEditingScope] = useState<Project | null>(null)
   const [expandedMajor, setExpandedMajor] = useState<Set<string>>(new Set())
   const [selectedScopeId, setSelectedScopeId] = useState(ALL_SCOPES)
   const [photoPreview, setPhotoPreview] = useState<string | null>(null)
@@ -82,7 +91,15 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
     name: "",
     description: "",
     type: "subproject" as "major" | "subproject",
+    scopeKind: "site" as ScopeKind,
     parentId: "",
+    status: "planned",
+  })
+
+  const [editScopeForm, setEditScopeForm] = useState({
+    name: "",
+    description: "",
+    scopeKind: "site" as ScopeKind,
     status: "planned",
   })
 
@@ -223,6 +240,7 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
           name: formData.name,
           description: formData.description,
           type: formData.type,
+          scopeKind: formData.type === "major" ? formData.scopeKind : undefined,
           parentId: formData.type === "subproject" ? formData.parentId || undefined : undefined,
         },
         label: "SuggestProject",
@@ -268,11 +286,47 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
     }
   }
 
+  const openEditScope = (scope: Project) => {
+    setEditingScope(scope)
+    setEditScopeForm({
+      name: scope.name,
+      description: scope.description || "",
+      scopeKind: scope.scopeKind || "site",
+      status: scope.status,
+    })
+    setEditScopeOpen(true)
+  }
+
+  const handleUpdateScope = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!editingScope) return
+    try {
+      await apiFetch(`/api/projects/${editingScope.id}`, {
+        method: "PATCH",
+        body: {
+          name: editScopeForm.name,
+          description: editScopeForm.description || undefined,
+          type: "scope",
+          scopeKind: editScopeForm.scopeKind,
+          status: editScopeForm.status,
+        },
+        label: "UpdateScope",
+      })
+      setEditScopeOpen(false)
+      setEditingScope(null)
+      fetchProjects()
+    } catch (error) {
+      logger.error("Failed to update scope", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
   const resetForm = () => {
     setFormData({
       name: "",
       description: "",
       type: "subproject",
+      scopeKind: "site",
       parentId: selectedScopeId === ALL_SCOPES ? "" : selectedScopeId,
       status: "planned",
     })
@@ -369,6 +423,24 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
           </SelectContent>
         </Select>
       </div>
+      {formData.type === "major" && (
+        <div>
+          <Label>Scope category</Label>
+          <Select
+            value={formData.scopeKind}
+            onValueChange={(v) => setFormData((p) => ({ ...p, scopeKind: v as ScopeKind }))}
+          >
+            <SelectTrigger className="mt-1 border-white/10 bg-white/5">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="site">Site</SelectItem>
+              <SelectItem value="asset">Asset</SelectItem>
+              <SelectItem value="location">Location</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
       {formData.type === "subproject" && (
         <div>
           <Label>Scope</Label>
@@ -542,6 +614,83 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
         </div>
       </div>
 
+      <Dialog
+        open={editScopeOpen}
+        onOpenChange={(open) => {
+          setEditScopeOpen(open)
+          if (!open) setEditingScope(null)
+        }}
+      >
+        <DialogContent className="max-w-md border-white/10 bg-[#0d0d12] text-white">
+          <DialogHeader>
+            <DialogTitle>Edit Scope</DialogTitle>
+            <DialogDescription className="text-white/60">
+              Update the site, asset or location used to group jobs.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleUpdateScope} className="mt-4 space-y-4">
+            <div>
+              <Label>Name</Label>
+              <Input
+                value={editScopeForm.name}
+                onChange={(e) => setEditScopeForm((p) => ({ ...p, name: e.target.value }))}
+                className="mt-1 border-white/10 bg-white/5"
+                required
+              />
+            </div>
+            <div>
+              <Label>Scope category</Label>
+              <Select
+                value={editScopeForm.scopeKind}
+                onValueChange={(v) => setEditScopeForm((p) => ({ ...p, scopeKind: v as ScopeKind }))}
+              >
+                <SelectTrigger className="mt-1 border-white/10 bg-white/5">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="site">Site</SelectItem>
+                  <SelectItem value="asset">Asset</SelectItem>
+                  <SelectItem value="location">Location</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Status</Label>
+              <Select
+                value={editScopeForm.status}
+                onValueChange={(v) => setEditScopeForm((p) => ({ ...p, status: v }))}
+              >
+                <SelectTrigger className="mt-1 border-white/10 bg-white/5">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="planned">Planned</SelectItem>
+                  <SelectItem value="in_progress">In Progress</SelectItem>
+                  <SelectItem value="on_hold">On Hold</SelectItem>
+                  <SelectItem value="completed">Completed</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Notes</Label>
+              <Textarea
+                value={editScopeForm.description}
+                onChange={(e) => setEditScopeForm((p) => ({ ...p, description: e.target.value }))}
+                className="mt-1 border-white/10 bg-white/5"
+                rows={3}
+              />
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setEditScopeOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" className="bg-primary text-primary-foreground hover:bg-primary/90">
+                Save scope
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
       {isAdmin && suggestions.length > 0 && (
         <Card className="border-secondary/30 bg-secondary/10">
           <CardHeader>
@@ -626,10 +775,29 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
                       <Badge className={STATUS_COLORS[scope.status] || STATUS_COLORS.planned}>
                         {scope.status.replace("_", " ")}
                       </Badge>
+                      <Badge variant="outline" className="border-white/15 text-white/60">
+                        {SCOPE_KIND_LABELS[scope.scopeKind || "site"]}
+                      </Badge>
                     </div>
-                    <span className="text-sm text-white/50">
-                      {scopeJobs.length} job{scopeJobs.length !== 1 ? "s" : ""}
-                    </span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-white/50">
+                        {scopeJobs.length} job{scopeJobs.length !== 1 ? "s" : ""}
+                      </span>
+                      {isAdmin && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          className="h-8 px-2 text-white/60 hover:bg-white/10 hover:text-white"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            openEditScope(scope)
+                          }}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
                   </div>
                   {scope.description && (
                     <CardDescription className="text-white/60">{scope.description}</CardDescription>

--- a/components/projects-page-content.tsx
+++ b/components/projects-page-content.tsx
@@ -36,6 +36,7 @@ import {
   X,
 } from "lucide-react"
 import { AiSuggestIcon } from "@/components/ui/ai-suggest-icon"
+import { getStoredScopeId } from "@/components/scope-selector"
 import type { Project } from "@/lib/projects"
 import type { ProjectSuggestion } from "@/app/api/projects/suggestions/route"
 import { logger } from "@/lib/logger"
@@ -56,6 +57,8 @@ const STATUS_COLORS: Record<string, string> = {
   completed: "bg-primary/40 text-primary-foreground",
 }
 
+const ALL_SCOPES = "_all"
+
 interface ProjectsPageContentProps {
   persona: "hans" | "charl" | "lucky" | "irma"
   isAdmin: boolean
@@ -68,6 +71,7 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
   const [dialogOpen, setDialogOpen] = useState(false)
   const [suggestDialogOpen, setSuggestDialogOpen] = useState(false)
   const [expandedMajor, setExpandedMajor] = useState<Set<string>>(new Set())
+  const [selectedScopeId, setSelectedScopeId] = useState(ALL_SCOPES)
   const [photoPreview, setPhotoPreview] = useState<string | null>(null)
   const [photoBase64, setPhotoBase64] = useState<string | null>(null)
   const [aiLoading, setAiLoading] = useState(false)
@@ -113,8 +117,21 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
     fetchSuggestions()
   }, [fetchProjects, fetchSuggestions])
 
-  const majorProjects = projects.filter((p) => p.type === "major")
-  const subprojects = projects.filter((p) => p.type === "subproject")
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    setSelectedScopeId(getStoredScopeId())
+    const handleScopeChange = (event: Event) => {
+      const scopeId = (event as CustomEvent<{ scopeId?: string }>).detail?.scopeId
+      setSelectedScopeId(scopeId || ALL_SCOPES)
+    }
+    window.addEventListener("hov:scope-change", handleScopeChange)
+    return () => window.removeEventListener("hov:scope-change", handleScopeChange)
+  }, [])
+
+  const scopes = projects.filter((p) => p.type === "major")
+  const jobs = projects.filter((p) => p.type === "subproject")
+  const selectedScope = scopes.find((scope) => scope.id === selectedScopeId)
+  const visibleScopes = selectedScope ? [selectedScope] : scopes
 
   const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -162,7 +179,7 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
         body: {
           title: formData.name,
           description: formData.description,
-          context: `Project type: ${formData.type}, Parent: ${formData.parentId || "none"}`,
+          context: `Work type: ${formData.type === "major" ? "scope" : "job"}, Scope: ${formData.parentId || "none"}`,
         },
         label: "RefineDescription",
       })
@@ -252,7 +269,13 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
   }
 
   const resetForm = () => {
-    setFormData({ name: "", description: "", type: "subproject", parentId: "", status: "planned" })
+    setFormData({
+      name: "",
+      description: "",
+      type: "subproject",
+      parentId: selectedScopeId === ALL_SCOPES ? "" : selectedScopeId,
+      status: "planned",
+    })
     setPhotoPreview(null)
     setPhotoBase64(null)
   }
@@ -341,23 +364,23 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="major">Major Project</SelectItem>
-            <SelectItem value="subproject">Subproject (Work Package)</SelectItem>
+            <SelectItem value="major">Site, Asset or Location</SelectItem>
+            <SelectItem value="subproject">Job / Work Project</SelectItem>
           </SelectContent>
         </Select>
       </div>
       {formData.type === "subproject" && (
         <div>
-          <Label>Parent Project</Label>
+          <Label>Scope</Label>
           <Select
             value={formData.parentId}
             onValueChange={(v) => setFormData((p) => ({ ...p, parentId: v }))}
           >
             <SelectTrigger className="mt-1 border-white/10 bg-white/5">
-              <SelectValue placeholder="Select parent" />
+              <SelectValue placeholder="Select site, asset or location" />
             </SelectTrigger>
             <SelectContent>
-              {majorProjects.map((p) => (
+              {scopes.map((p) => (
                 <SelectItem key={p.id} value={p.id}>
                   {p.name}
                 </SelectItem>
@@ -372,7 +395,7 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
           value={formData.name}
           onChange={(e) => setFormData((p) => ({ ...p, name: e.target.value }))}
           className="mt-1 border-white/10 bg-white/5"
-          placeholder="e.g. Kitchen Cupboards"
+          placeholder={formData.type === "major" ? "e.g. 32 Singlehurst" : "e.g. Repair bathroom"}
           required
         />
       </div>
@@ -426,12 +449,12 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
         <div>
           <h1 className="flex items-center gap-2 text-2xl font-bold text-foreground">
             <FolderKanban className="h-8 w-8 text-primary" />
-            Projects
+            Work
           </h1>
           <p className="mt-1 text-white/60">
             {isAdmin
-              ? "Major projects and subprojects (House Revamp, Zeerust Arming, etc.)"
-              : "View projects and suggest new ones"}
+              ? "Jobs grouped by Sites, Assets & Locations."
+              : "View jobs and suggest new work"}
           </p>
         </div>
         <div className="flex gap-2">
@@ -440,20 +463,23 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
               open={dialogOpen}
               onOpenChange={(o) => {
                 setDialogOpen(o)
+                if (o && selectedScopeId !== ALL_SCOPES) {
+                  setFormData((p) => ({ ...p, type: "subproject", parentId: selectedScopeId }))
+                }
                 if (!o) resetForm()
               }}
             >
               <DialogTrigger asChild>
                 <Button className="bg-primary text-primary-foreground hover:bg-primary/90">
                   <Plus className="mr-2 h-4 w-4" />
-                  Add Project
+                  Add Scope / Job
                 </Button>
               </DialogTrigger>
               <DialogContent className="max-h-[90vh] max-w-md overflow-y-auto border-white/10 bg-[#0d0d12] text-white">
                 <DialogHeader>
-                  <DialogTitle>Add Project</DialogTitle>
+                  <DialogTitle>Add Scope or Job</DialogTitle>
                   <DialogDescription className="text-white/60">
-                    Create a major project or subproject. Use a photo for AI suggestions.
+                    Create a site, asset, location, or a job under one of them.
                   </DialogDescription>
                 </DialogHeader>
                 <form onSubmit={handleCreate} className="mt-4 space-y-4">
@@ -474,6 +500,9 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
             open={suggestDialogOpen}
             onOpenChange={(o) => {
               setSuggestDialogOpen(o)
+              if (o && selectedScopeId !== ALL_SCOPES) {
+                setFormData((p) => ({ ...p, type: "subproject", parentId: selectedScopeId }))
+              }
               if (!o) resetForm()
             }}
           >
@@ -483,14 +512,14 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
                 className={!isAdmin ? "bg-primary text-primary-foreground hover:bg-primary/90" : "border-white/20"}
               >
                 <Sparkles className="mr-2 h-4 w-4" />
-                Suggest Project
+                Suggest Work
               </Button>
             </DialogTrigger>
             <DialogContent className="max-h-[90vh] max-w-md overflow-y-auto border-white/10 bg-[#0d0d12] text-white">
               <DialogHeader>
-                <DialogTitle>Suggest a Project</DialogTitle>
+                <DialogTitle>Suggest Work</DialogTitle>
                 <DialogDescription className="text-white/60">
-                  Propose a new project or subproject. Admins will review and approve.
+                  Propose a new site, asset, location, or job. Admins will review and approve.
                 </DialogDescription>
               </DialogHeader>
               <form onSubmit={handleSuggest} className="mt-4 space-y-4">
@@ -518,7 +547,7 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
           <CardHeader>
             <CardTitle className="text-secondary">Pending suggestions</CardTitle>
             <CardDescription className="text-white/60">
-              {suggestions.length} project suggestion{suggestions.length !== 1 ? "s" : ""} awaiting
+              {suggestions.length} work suggestion{suggestions.length !== 1 ? "s" : ""} awaiting
               review
             </CardDescription>
           </CardHeader>
@@ -566,63 +595,66 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
         </div>
       ) : (
         <div className="space-y-4">
-          {majorProjects.map((major) => {
-            const subs = subprojects.filter((s) => s.parentId === major.id)
-            const isExpanded = expandedMajor.has(major.id)
+          {visibleScopes.map((scope) => {
+            const scopeJobs = jobs.filter((job) => job.parentId === scope.id)
+            const isExpanded = selectedScope ? true : expandedMajor.has(scope.id)
 
             return (
-              <Card key={major.id} className="border-white/10 bg-white/5">
+              <Card key={scope.id} className="border-white/10 bg-white/5">
                 <CardHeader
-                  className="cursor-pointer"
-                  onClick={() =>
+                  className={selectedScope ? "" : "cursor-pointer"}
+                  onClick={() => {
+                    if (selectedScope) return
                     setExpandedMajor((prev) => {
                       const next = new Set(prev)
-                      if (next.has(major.id)) next.delete(major.id)
-                      else next.add(major.id)
+                      if (next.has(scope.id)) next.delete(scope.id)
+                      else next.add(scope.id)
                       return next
                     })
-                  }
+                  }}
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      {subs.length > 0 ? (
+                      {!selectedScope && scopeJobs.length > 0 ? (
                         isExpanded ? (
                           <ChevronDown className="h-5 w-5 text-white/60" />
                         ) : (
                           <ChevronRight className="h-5 w-5 text-white/60" />
                         )
                       ) : null}
-                      <CardTitle className="text-white">{major.name}</CardTitle>
-                      <Badge className={STATUS_COLORS[major.status] || STATUS_COLORS.planned}>
-                        {major.status.replace("_", " ")}
+                      <CardTitle className="text-white">{scope.name}</CardTitle>
+                      <Badge className={STATUS_COLORS[scope.status] || STATUS_COLORS.planned}>
+                        {scope.status.replace("_", " ")}
                       </Badge>
                     </div>
-                    <span className="text-sm text-white/50">{subs.length} subprojects</span>
+                    <span className="text-sm text-white/50">
+                      {scopeJobs.length} job{scopeJobs.length !== 1 ? "s" : ""}
+                    </span>
                   </div>
-                  {major.description && (
-                    <CardDescription className="text-white/60">{major.description}</CardDescription>
+                  {scope.description && (
+                    <CardDescription className="text-white/60">{scope.description}</CardDescription>
                   )}
                 </CardHeader>
-                {isExpanded && subs.length > 0 && (
+                {isExpanded && scopeJobs.length > 0 && (
                   <CardContent className="space-y-2 pt-0">
-                    {subs.map((sub) => (
+                    {scopeJobs.map((job) => (
                       <div
-                        key={sub.id}
+                        key={job.id}
                         className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 p-3"
                       >
                         <div>
-                          <p className="font-medium text-white">{sub.name}</p>
+                          <p className="font-medium text-white">{job.name}</p>
                           <div className="mt-1 flex items-center gap-2">
                             <Badge
-                              className={STATUS_COLORS[sub.status] || STATUS_COLORS.planned}
+                              className={STATUS_COLORS[job.status] || STATUS_COLORS.planned}
                               variant="outline"
                             >
-                              {sub.status.replace("_", " ")}
+                              {job.status.replace("_", " ")}
                             </Badge>
-                            {sub.members?.length ? (
+                            {job.members?.length ? (
                               <span className="flex items-center gap-1 text-sm text-white/50">
                                 <Users className="h-3 w-3" />
-                                {sub.members
+                                {job.members
                                   .map((m) => PERSONA_INFO[m.userId] || m.userId)
                                   .join(", ")}
                               </span>
@@ -632,24 +664,24 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
                         {isAdmin &&
                           (() => {
                             const available = ["hans", "charl", "lucky", "irma"].filter(
-                              (id) => !sub.members?.some((m) => m.userId === id)
+                              (id) => !job.members?.some((m) => m.userId === id)
                             )
                             if (available.length === 0)
                               return <span className="text-sm text-white/40">All assigned</span>
-                            const loading = suggestMemberLoading === sub.id
+                            const loading = suggestMemberLoading === job.id
                             return (
                               <div className="flex items-center gap-2">
                                 <Button
                                   size="sm"
                                   variant="ghost"
                                   className="text-primary hover:text-primary/80 hover:bg-primary/10"
-                                  onClick={() => handleSuggestMember(sub.id, sub.name)}
+                                  onClick={() => handleSuggestMember(job.id, job.name)}
                                   disabled={loading}
                                 >
                                   <AiSuggestIcon loading={loading} size="md" />
                                 </Button>
                                 <Select
-                                  onValueChange={(v) => handleAddMember(sub.id, v, "contributor")}
+                                  onValueChange={(v) => handleAddMember(job.id, v, "contributor")}
                                 >
                                   <SelectTrigger className="w-36 border-white/10 bg-white/5">
                                     <SelectValue placeholder="Add member" />
@@ -669,9 +701,23 @@ export function ProjectsPageContent({ persona, isAdmin }: ProjectsPageContentPro
                     ))}
                   </CardContent>
                 )}
+                {isExpanded && scopeJobs.length === 0 && (
+                  <CardContent className="pt-0">
+                    <p className="rounded-lg border border-dashed border-white/10 bg-white/5 p-3 text-sm text-white/50">
+                      No jobs yet for this scope.
+                    </p>
+                  </CardContent>
+                )}
               </Card>
             )
           })}
+          {visibleScopes.length === 0 && (
+            <Card className="border-dashed border-white/10 bg-white/5">
+              <CardContent className="py-8 text-center text-white/60">
+                No Sites, Assets & Locations yet. Add a scope first, then add jobs under it.
+              </CardContent>
+            </Card>
+          )}
         </div>
       )}
     </div>

--- a/components/scope-selector.tsx
+++ b/components/scope-selector.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { MapPinned } from "lucide-react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { apiFetchSafe } from "@/lib/api-client"
+import type { Project } from "@/lib/projects"
+
+const STORAGE_KEY = "hov:selected-scope-id"
+const ALL_SCOPES = "_all"
+
+export function getStoredScopeId(): string {
+  if (typeof window === "undefined") return ALL_SCOPES
+  return window.localStorage.getItem(STORAGE_KEY) || ALL_SCOPES
+}
+
+export function ScopeSelector() {
+  const [scopes, setScopes] = useState<Project[]>([])
+  const [selectedScopeId, setSelectedScopeId] = useState(getStoredScopeId)
+
+  useEffect(() => {
+    apiFetchSafe<{ projects?: Project[] }>(
+      "/api/projects?type=major",
+      { projects: [] },
+      { label: "Scopes" }
+    ).then((data) => {
+      const loaded = data?.projects || []
+      setScopes(loaded)
+      if (typeof window === "undefined") return
+
+      const stored = getStoredScopeId()
+      if (stored !== ALL_SCOPES && !loaded.some((scope) => scope.id === stored)) {
+        window.localStorage.setItem(STORAGE_KEY, ALL_SCOPES)
+        setSelectedScopeId(ALL_SCOPES)
+      }
+    })
+  }, [])
+
+  if (scopes.length === 0) return null
+
+  const handleChange = (value: string) => {
+    setSelectedScopeId(value)
+    window.localStorage.setItem(STORAGE_KEY, value)
+    window.dispatchEvent(new CustomEvent("hov:scope-change", { detail: { scopeId: value } }))
+  }
+
+  return (
+    <div className="hidden items-center gap-2 md:flex">
+      <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+        <MapPinned className="h-3.5 w-3.5" />
+        Scope
+      </span>
+      <Select value={selectedScopeId} onValueChange={handleChange}>
+        <SelectTrigger className="h-9 w-48 border-border bg-card/80 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_SCOPES}>All scopes</SelectItem>
+          {scopes.map((scope) => (
+            <SelectItem key={scope.id} value={scope.id}>
+              {scope.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/components/scope-selector.tsx
+++ b/components/scope-selector.tsx
@@ -26,7 +26,7 @@ export function ScopeSelector() {
 
   useEffect(() => {
     apiFetchSafe<{ projects?: Project[] }>(
-      "/api/projects?type=major",
+      "/api/projects?type=scope",
       { projects: [] },
       { label: "Scopes" }
     ).then((data) => {

--- a/components/shared/tasks-page.tsx
+++ b/components/shared/tasks-page.tsx
@@ -142,9 +142,9 @@ export function TasksPage({
   useEffect(() => {
     if (!canAddTask) return
     apiFetchSafe<{ projects?: { name: string }[] }>(
-      "/api/projects",
+      "/api/projects?type=subproject",
       { projects: [] },
-      { label: "Projects" }
+      { label: "Jobs" }
     ).then((d) => setProjectOptions((d?.projects || []).map((p) => p.name)))
   }, [canAddTask])
 
@@ -157,7 +157,7 @@ export function TasksPage({
         body: {
           title: taskForm.title,
           description: taskForm.description,
-          context: `Task for project: ${taskForm.project || "general"}`,
+          context: `Task for job: ${taskForm.project || "general"}`,
         },
         label: "AI Refine",
       })
@@ -304,7 +304,7 @@ export function TasksPage({
                   />
                 </div>
                 <div>
-                  <Label>Project</Label>
+                  <Label>Job</Label>
                   <Select
                     value={taskForm.project || "_none"}
                     onValueChange={(v) =>
@@ -312,7 +312,7 @@ export function TasksPage({
                     }
                   >
                     <SelectTrigger className="mt-1 border-border bg-background">
-                      <SelectValue placeholder="Select project" />
+                      <SelectValue placeholder="Select job" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="_none">None</SelectItem>

--- a/components/shared/tasks-page.tsx
+++ b/components/shared/tasks-page.tsx
@@ -142,7 +142,7 @@ export function TasksPage({
   useEffect(() => {
     if (!canAddTask) return
     apiFetchSafe<{ projects?: { name: string }[] }>(
-      "/api/projects?type=subproject",
+      "/api/projects?type=job",
       { projects: [] },
       { label: "Jobs" }
     ).then((d) => setProjectOptions((d?.projects || []).map((p) => p.name)))

--- a/docs/05-project/work-planning-persistence-plan.md
+++ b/docs/05-project/work-planning-persistence-plan.md
@@ -1,0 +1,37 @@
+# Work Planning Persistence Plan
+
+## Current MVP
+
+The work-planning UI now treats a top-level scope as a site, asset, or location, and treats each child record as a job. A job can contain areas, grouped tasks, and material or labour allocations. For this PR the compatibility layer keeps the existing stored project types (`major` and `subproject`) while exposing the clearer `scope` and `job` language in the UI and API responses.
+
+The new job workspace stores early metadata in JSON files under `data/`:
+
+- `job-areas.json` for rooms, zones, components, and other job-local areas.
+- `job-task-groups.json` for task-to-area and task-to-group metadata while task ownership remains in the existing task service.
+- `job-allocations.json` for material and labour allocations tied to a job and optionally to an area.
+
+This is acceptable for the slice because it keeps the workflow testable without forcing a database migration before the data model is settled. It is not the long-term production persistence shape.
+
+## Durable Store Shape
+
+Move these records into the operational data store once the UI workflow has settled:
+
+| Entity | Ownership | Required fields | Notes |
+| --- | --- | --- | --- |
+| Work scope | Global dashboard planning | `id`, `name`, `category`, `status` | Category is `site`, `asset`, or `location`; retain legacy type migration from `major` to `scope`. |
+| Job | Belongs to one scope | `id`, `scopeId`, `name`, `status` | Represents work such as bathroom repair, fishpond renovation, vehicle service, or farm job. |
+| Job area | Belongs to one job | `id`, `jobId`, `name`, `kind` | Kind remains flexible: room, area, component, zone. |
+| Job task metadata | Belongs to one job and existing task | `taskId`, `jobId`, optional `areaId`, optional `groupName` | Keep canonical task fields in the existing task table/service. |
+| Job allocation | Belongs to one job | `id`, `jobId`, `type`, `name`, costing fields | `type` is material or labour; area link is optional. |
+
+## Migration Steps
+
+1. Add durable tables or Baserow tables for job areas, task metadata, and allocations.
+2. Backfill from the JSON files in an explicit one-time script that can be run in dry-run mode.
+3. Switch API route storage behind a repository module so JSON remains available only for local fallback or migration replay.
+4. Add route tests at the repository boundary and browser smoke coverage for `/dashboard/hans/projects` and `/dashboard/hans/projects/[id]`.
+5. Remove JSON writes from production mode once the durable store is live and verified.
+
+## Verification Baseline
+
+The PR includes unit coverage for project type aliases and API route coverage for job areas, allocations, and grouped task metadata. Browser verification should still be run against an authenticated environment before production rollout because the header scope selector and job workspace are navigation-heavy UI changes.

--- a/lib/nav-config.ts
+++ b/lib/nav-config.ts
@@ -64,7 +64,7 @@ const PAGE_DEFINITIONS: PageDef[] = [
     adminOnly: true,
   },
   {
-    name: "Projects",
+    name: "Work",
     href: "/dashboard",
     icon: FolderKanban,
     category: "Operations",
@@ -157,11 +157,11 @@ const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
     Marketplace: "/dashboard/hans/marketplace",
     Reports: "/dashboard/hans/reports",
     Settings: "/dashboard/hans/settings",
-    Projects: "/dashboard/hans/projects",
+    Work: "/dashboard/hans/projects",
   },
   charl: {
     "My Dashboard": "/dashboard/charl",
-    Projects: "/dashboard/charl/projects",
+    Work: "/dashboard/charl/projects",
     "My Tasks": "/dashboard/charl/tasks",
     "Time Clock": "/dashboard/charl/time",
     "Vehicle Log": "/dashboard/charl/vehicles",
@@ -171,7 +171,7 @@ const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
   },
   lucky: {
     "My Dashboard": "/dashboard/lucky",
-    Projects: "/dashboard/lucky/projects",
+    Work: "/dashboard/lucky/projects",
     "My Tasks": "/dashboard/lucky/tasks",
     "Time Clock": "/dashboard/lucky/time",
     "Vehicle Log": "/dashboard/lucky/vehicles",
@@ -182,7 +182,7 @@ const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
   },
   irma: {
     "My Dashboard": "/dashboard/irma",
-    Projects: "/dashboard/irma/projects",
+    Work: "/dashboard/irma/projects",
     "Household Tasks": "/dashboard/irma/tasks",
     "My Documents": "/dashboard/irma/documents",
     Settings: "/dashboard/irma/settings",

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -13,6 +13,8 @@ export type ProjectMemberRole = "lead" | "contributor" | "supervisor"
 
 export type ProjectKind = "scope" | "job"
 
+export type ScopeKind = "site" | "asset" | "location"
+
 export type ProjectStorageType = "major" | "subproject"
 
 export type ProjectTypeInput = ProjectKind | ProjectStorageType
@@ -28,6 +30,7 @@ export interface Project {
   name: string
   description?: string
   type: ProjectStorageType
+  scopeKind?: ScopeKind
   parentId?: string
   status: ProjectStatus
   startDate?: string

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,12 +1,21 @@
 /**
- * Project management - major projects, subprojects (work packages), and resource allocation.
- * Projects: House Revamp, Zeerust Arming, etc.
- * Subprojects: Garage, Paving, Kitchen Cupboards, Electricity-Lat, Garden Revamp, etc.
+ * Work planning model.
+ *
+ * The JSON store still uses the legacy values `major` and `subproject`.
+ * User-facing code should use `scope` and `job` through the helpers below:
+ * - scope: a Site, Asset or Location such as 32 Singlehurst, a vehicle, or a workshop
+ * - job: a Work Project under a scope, such as Repair bathroom or Service Hilux
  */
 
 export type ProjectStatus = "planned" | "in_progress" | "on_hold" | "completed"
 
 export type ProjectMemberRole = "lead" | "contributor" | "supervisor"
+
+export type ProjectKind = "scope" | "job"
+
+export type ProjectStorageType = "major" | "subproject"
+
+export type ProjectTypeInput = ProjectKind | ProjectStorageType
 
 export interface ProjectMember {
   userId: string
@@ -18,7 +27,7 @@ export interface Project {
   id: string
   name: string
   description?: string
-  type: "major" | "subproject"
+  type: ProjectStorageType
   parentId?: string
   status: ProjectStatus
   startDate?: string
@@ -27,6 +36,35 @@ export interface Project {
   members: ProjectMember[]
   createdAt: string
   updatedAt: string
+}
+
+export interface ProjectWithKind extends Project {
+  kind: ProjectKind
+}
+
+export function getProjectKind(project: Pick<Project, "type">): ProjectKind {
+  return project.type === "major" ? "scope" : "job"
+}
+
+export function isScope(project: Pick<Project, "type">): boolean {
+  return getProjectKind(project) === "scope"
+}
+
+export function isJob(project: Pick<Project, "type">): boolean {
+  return getProjectKind(project) === "job"
+}
+
+export function toStoredProjectType(type: string | null | undefined): ProjectStorageType | null {
+  if (type === "scope" || type === "major") return "major"
+  if (type === "job" || type === "subproject") return "subproject"
+  return null
+}
+
+export function withProjectKind(project: Project): ProjectWithKind {
+  return {
+    ...project,
+    kind: getProjectKind(project),
+  }
 }
 
 export const DEFAULT_MAJOR_PROJECTS = [

--- a/tests/api/job-workspace.test.ts
+++ b/tests/api/job-workspace.test.ts
@@ -170,7 +170,7 @@ describe("job task groups API", () => {
     })
     vi.doMock("@/lib/services/baserow", () => ({
       getTasks: vi.fn(async () => [
-        { id: 101, title: "Strip tiles", project: "Bathroom Repair", status: "Not Started", priority: "Medium" },
+        { id: 101, title: "Strip tiles", project: "Old Bathroom Name", status: "Not Started", priority: "Medium" },
         { id: 102, title: "Paint wall", project: "Other Job", status: "Not Started", priority: "Medium" },
       ]),
       createTask: vi.fn(),
@@ -187,5 +187,49 @@ describe("job task groups API", () => {
     expect(data.tasks).toEqual([
       expect.objectContaining({ id: 101, title: "Strip tiles", areaId: "area-1", groupName: "Prep" }),
     ])
+  })
+})
+
+describe("project suggestion approval", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it("preserves scope category when approving a scope suggestion", async () => {
+    const files = new Map<string, string>([
+      [
+        "project-suggestions.json",
+        JSON.stringify([
+          {
+            id: "sug-1",
+            name: "Zeerust Farm",
+            type: "major",
+            scopeKind: "asset",
+            suggestedBy: "lucky",
+            suggestedAt: "now",
+            status: "pending",
+          },
+        ]),
+      ],
+      ["projects.json", "[]"],
+    ])
+    vi.doMock("@/lib/workflows", () => ({ routeToInngest: vi.fn(async () => undefined) }))
+    const { PATCH } = await importWithMockedFiles<
+      typeof import("@/app/api/projects/suggestions/[id]/route")
+    >("@/app/api/projects/suggestions/[id]/route", files)
+
+    const response = await PATCH(
+      new Request("http://localhost/api/projects/suggestions/sug-1", {
+        method: "PATCH",
+        headers: authHeaders,
+        body: JSON.stringify({ status: "approved" }),
+      }),
+      { params: Promise.resolve({ id: "sug-1" }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.project).toMatchObject({ name: "Zeerust Farm", type: "major", scopeKind: "asset", kind: "scope" })
   })
 })

--- a/tests/api/job-workspace.test.ts
+++ b/tests/api/job-workspace.test.ts
@@ -16,8 +16,8 @@ async function importWithMockedFiles<T>(modulePath: string, files: FileStore = n
   vi.doMock("fs/promises", () => {
     const mockFs = {
       readFile: vi.fn(async (path: string) => {
-        const key = String(path)
-        if (!files.has(key)) throw new Error("ENOENT")
+        const key = [...files.keys()].find((fileName) => String(path).endsWith(fileName))
+        if (!key) throw new Error("ENOENT")
         return files.get(key)
       }),
       mkdir: vi.fn(async () => undefined),
@@ -37,7 +37,7 @@ describe("job areas API", () => {
   it("filters areas to the requested job", async () => {
     const files = new Map<string, string>([
       [
-        "C:\\Users\\smitj\\repos\\house-of-veritas\\data\\job-areas.json",
+        "job-areas.json",
         JSON.stringify([
           { id: "area-1", projectId: "job-1", name: "Bathroom", kind: "room", createdAt: "now", updatedAt: "now" },
           { id: "area-2", projectId: "job-2", name: "Workshop", kind: "zone", createdAt: "now", updatedAt: "now" },
@@ -85,7 +85,7 @@ describe("job allocations API", () => {
   it("filters allocations by job and optional type", async () => {
     const files = new Map<string, string>([
       [
-        "C:\\Users\\smitj\\repos\\house-of-veritas\\data\\job-allocations.json",
+        "job-allocations.json",
         JSON.stringify([
           { id: "alloc-1", projectId: "job-1", type: "material", name: "Tiles", createdAt: "now", updatedAt: "now" },
           { id: "alloc-2", projectId: "job-1", type: "labour", name: "Plumber", createdAt: "now", updatedAt: "now" },
@@ -152,14 +152,17 @@ describe("job task groups API", () => {
   it("attaches area and group metadata to existing project tasks", async () => {
     const files = new Map<string, string>([
       [
-        "C:\\Users\\smitj\\repos\\house-of-veritas\\data\\job-task-groups.json",
+        "job-task-groups.json",
         JSON.stringify([{ taskId: 101, projectId: "job-1", areaId: "area-1", groupName: "Prep", createdAt: "now", updatedAt: "now" }]),
       ],
     ])
     vi.resetModules()
     vi.doMock("fs/promises", () => {
       const mockFs = {
-        readFile: vi.fn(async (path: string) => files.get(String(path)) ?? "[]"),
+        readFile: vi.fn(async (path: string) => {
+          const key = [...files.keys()].find((fileName) => String(path).endsWith(fileName))
+          return key ? files.get(key) : "[]"
+        }),
         mkdir: vi.fn(async () => undefined),
         writeFile: vi.fn(async (path: string, data: string) => files.set(String(path), data)),
       }

--- a/tests/api/job-workspace.test.ts
+++ b/tests/api/job-workspace.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const authHeaders = {
+  "x-user-id": "hans",
+  "x-user-role": "admin",
+  "x-user-email": "smit.jurie@gmail.com",
+  "Content-Type": "application/json",
+}
+
+const routeContext = { params: Promise.resolve({ id: "job-1" }) }
+
+type FileStore = Map<string, string>
+
+async function importWithMockedFiles<T>(modulePath: string, files: FileStore = new Map()): Promise<T> {
+  vi.resetModules()
+  vi.doMock("fs/promises", () => {
+    const mockFs = {
+      readFile: vi.fn(async (path: string) => {
+        const key = String(path)
+        if (!files.has(key)) throw new Error("ENOENT")
+        return files.get(key)
+      }),
+      mkdir: vi.fn(async () => undefined),
+      writeFile: vi.fn(async (path: string, data: string) => {
+        files.set(String(path), data)
+      }),
+    }
+    return { ...mockFs, default: mockFs }
+  })
+
+  return import(modulePath) as Promise<T>
+}
+
+describe("job areas API", () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it("filters areas to the requested job", async () => {
+    const files = new Map<string, string>([
+      [
+        "C:\\Users\\smitj\\repos\\house-of-veritas\\data\\job-areas.json",
+        JSON.stringify([
+          { id: "area-1", projectId: "job-1", name: "Bathroom", kind: "room", createdAt: "now", updatedAt: "now" },
+          { id: "area-2", projectId: "job-2", name: "Workshop", kind: "zone", createdAt: "now", updatedAt: "now" },
+        ]),
+      ],
+    ])
+    const { GET } = await importWithMockedFiles<typeof import("@/app/api/projects/[id]/areas/route")>(
+      "@/app/api/projects/[id]/areas/route",
+      files
+    )
+
+    const response = await GET(new Request("http://localhost/api/projects/job-1/areas"), routeContext)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.areas).toHaveLength(1)
+    expect(data.areas[0]).toMatchObject({ id: "area-1", name: "Bathroom" })
+  })
+
+  it("creates a normalized area for the requested job", async () => {
+    const files = new Map<string, string>()
+    const { POST } = await importWithMockedFiles<typeof import("@/app/api/projects/[id]/areas/route")>(
+      "@/app/api/projects/[id]/areas/route",
+      files
+    )
+
+    const response = await POST(
+      new Request("http://localhost/api/projects/job-1/areas", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ name: "  Fishpond  ", kind: "not-a-kind", notes: "  Pump repair  " }),
+      }),
+      routeContext
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.area).toMatchObject({ projectId: "job-1", name: "Fishpond", kind: "area", notes: "Pump repair" })
+  })
+})
+
+describe("job allocations API", () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it("filters allocations by job and optional type", async () => {
+    const files = new Map<string, string>([
+      [
+        "C:\\Users\\smitj\\repos\\house-of-veritas\\data\\job-allocations.json",
+        JSON.stringify([
+          { id: "alloc-1", projectId: "job-1", type: "material", name: "Tiles", createdAt: "now", updatedAt: "now" },
+          { id: "alloc-2", projectId: "job-1", type: "labour", name: "Plumber", createdAt: "now", updatedAt: "now" },
+          { id: "alloc-3", projectId: "job-2", type: "material", name: "Paint", createdAt: "now", updatedAt: "now" },
+        ]),
+      ],
+    ])
+    const { GET } = await importWithMockedFiles<typeof import("@/app/api/projects/[id]/allocations/route")>(
+      "@/app/api/projects/[id]/allocations/route",
+      files
+    )
+
+    const response = await GET(
+      new Request("http://localhost/api/projects/job-1/allocations?type=material"),
+      routeContext
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.allocations).toEqual([expect.objectContaining({ id: "alloc-1", name: "Tiles" })])
+  })
+
+  it("keeps material and labour fields separate", async () => {
+    const files = new Map<string, string>()
+    const { POST } = await importWithMockedFiles<typeof import("@/app/api/projects/[id]/allocations/route")>(
+      "@/app/api/projects/[id]/allocations/route",
+      files
+    )
+
+    const response = await POST(
+      new Request("http://localhost/api/projects/job-1/allocations", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ name: "Electrician", type: "labour", hours: "3.5", rateCents: "45000", quantity: "99" }),
+      }),
+      routeContext
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.allocation).toMatchObject({ projectId: "job-1", type: "labour", name: "Electrician", hours: 3.5, rateCents: 45000 })
+    expect(data.allocation.quantity).toBeUndefined()
+  })
+})
+
+describe("job task groups API", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it("requires the project name when loading grouped tasks", async () => {
+    const { GET } = await importWithMockedFiles<typeof import("@/app/api/projects/[id]/task-groups/route")>(
+      "@/app/api/projects/[id]/task-groups/route"
+    )
+
+    const response = await GET(new Request("http://localhost/api/projects/job-1/task-groups"), routeContext)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe("projectName is required")
+  })
+
+  it("attaches area and group metadata to existing project tasks", async () => {
+    const files = new Map<string, string>([
+      [
+        "C:\\Users\\smitj\\repos\\house-of-veritas\\data\\job-task-groups.json",
+        JSON.stringify([{ taskId: 101, projectId: "job-1", areaId: "area-1", groupName: "Prep", createdAt: "now", updatedAt: "now" }]),
+      ],
+    ])
+    vi.resetModules()
+    vi.doMock("fs/promises", () => {
+      const mockFs = {
+        readFile: vi.fn(async (path: string) => files.get(String(path)) ?? "[]"),
+        mkdir: vi.fn(async () => undefined),
+        writeFile: vi.fn(async (path: string, data: string) => files.set(String(path), data)),
+      }
+      return { ...mockFs, default: mockFs }
+    })
+    vi.doMock("@/lib/services/baserow", () => ({
+      getTasks: vi.fn(async () => [
+        { id: 101, title: "Strip tiles", project: "Bathroom Repair", status: "Not Started", priority: "Medium" },
+        { id: 102, title: "Paint wall", project: "Other Job", status: "Not Started", priority: "Medium" },
+      ]),
+      createTask: vi.fn(),
+    }))
+    const { GET } = await import("@/app/api/projects/[id]/task-groups/route")
+
+    const response = await GET(
+      new Request("http://localhost/api/projects/job-1/task-groups?projectName=Bathroom%20Repair"),
+      routeContext
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.tasks).toEqual([
+      expect.objectContaining({ id: 101, title: "Strip tiles", areaId: "area-1", groupName: "Prep" }),
+    ])
+  })
+})

--- a/tests/lib/projects.test.ts
+++ b/tests/lib/projects.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import {
+  getProjectKind,
+  isJob,
+  isScope,
+  toStoredProjectType,
+  withProjectKind,
+  type Project,
+} from "@/lib/projects"
+
+const baseProject = {
+  id: "proj-1",
+  name: "32 Singlehurst",
+  status: "planned",
+  members: [],
+  createdAt: "2026-07-16T00:00:00.000Z",
+  updatedAt: "2026-07-16T00:00:00.000Z",
+} satisfies Omit<Project, "type">
+
+describe("project work model aliases", () => {
+  it("maps legacy stored types to scope and job kinds", () => {
+    expect(getProjectKind({ type: "major" })).toBe("scope")
+    expect(getProjectKind({ type: "subproject" })).toBe("job")
+    expect(isScope({ type: "major" })).toBe(true)
+    expect(isJob({ type: "subproject" })).toBe(true)
+  })
+
+  it("normalizes public type aliases to stored types", () => {
+    expect(toStoredProjectType("scope")).toBe("major")
+    expect(toStoredProjectType("job")).toBe("subproject")
+    expect(toStoredProjectType("major")).toBe("major")
+    expect(toStoredProjectType("subproject")).toBe("subproject")
+    expect(toStoredProjectType("unknown")).toBeNull()
+    expect(toStoredProjectType(null)).toBeNull()
+  })
+
+  it("adds kind without changing the stored type", () => {
+    const project = withProjectKind({ ...baseProject, type: "major" })
+
+    expect(project.type).toBe("major")
+    expect(project.kind).toBe("scope")
+  })
+})


### PR DESCRIPTION
## Summary

Adds the new work-planning structure discussed in the thread:

- introduces a dashboard Scope selector for Sites, Assets & Locations
- renames the Projects navigation surface to Work while preserving existing routes/access responsibilities
- normalizes the internal project model with public `scope`/`job` aliases while keeping legacy stored values compatible
- adds scope metadata and editing for site/asset/location categories
- adds job workspace detail pages
- adds job areas/rooms/components, grouped job tasks, and material/labour allocation records

## Validation

- `pnpm run lint`
- `pnpm run build`
- `pnpm exec vitest run tests/lib/projects.test.ts`

Note: `next build` still reports the pre-existing Turbopack NFT tracing warning through `app/api/files/route.ts`; this PR does not change that route.

## Follow-up Notes

The first persistence layer is intentionally JSON-backed/additive for areas, task grouping metadata, and resource allocations. A later persistence hardening pass should move those records into the canonical integration store once the operational shape settles.