### PR TITLE
cleanup(terraform): drop dead runner subnet

### DIFF
--- a/docs/03-deployment/05-terraform-firewall-troubleshooting.md
+++ b/docs/03-deployment/05-terraform-firewall-troubleshooting.md
@@ -1,20 +1,21 @@
 # Terraform Firewall Troubleshooting
 
-## TL;DR – Key Vault 403 / Storage 403 (AuthorizationFailure)
+## TL;DR - Key Vault 403 / Storage 403
 
-If you see `Client address is not authorized` or `403 AuthorizationFailure` on Storage containers:
+If Terraform fails with `Client address is not authorized` or `403 AuthorizationFailure`, the runner network is not allowed by the resource firewall during state refresh.
 
-1. **One-time bootstrap:** Azure Portal → Key Vault `nl-prod-hov-kv-san` → Networking → **Allow access from all networks**
-2. Azure Portal → Storage Account `nlprodhovstsan` → Networking → **Allow access from all networks**
-3. Re-run the Terraform workflow (push or manual trigger)
-4. Terraform will apply the correct firewall rules (runner subnet, no deployer IP)
-5. Future runs work via the self-hosted runner (in the runner subnet)
+Current production posture:
+
+1. Workflows run on GitHub-hosted `ubuntu-latest` runners.
+2. Key Vault allows the container subnet plus Azure-internal runner CIDR fallback `172.128.0.0/9`.
+3. Storage allows the container/database subnets plus `deployer_ip` when a workflow passes the current runner IP.
+4. The dedicated self-hosted runner subnet was removed in 2026-05 and should not be referenced by HOV Terraform.
 
 ## Error: ForbiddenByFirewall / AuthorizationFailure
 
 When Terraform runs in GitHub Actions, you may see:
 
-```
+```text
 Error: making Read request on Azure KeyVault Secret: StatusCode=403
 Message="Client address is not authorized and caller is not a trusted service."
 Client address: 135.232.177.170
@@ -23,98 +24,58 @@ code="ForbiddenByFirewall"
 
 And for Storage:
 
-```
+```text
 Error: retrieving Container: unexpected status 403
 AuthorizationFailure: This request is not authorized to perform this operation.
 ```
 
 ## Root Cause
 
-Key Vault and Storage Account use `default_action = "Deny"` with `ip_rules` and `virtual_network_subnet_ids`. Terraform must refresh state first (read Key Vault secrets, Storage containers) before it can apply any changes. The refresh is blocked if the runner's network is not allowed:
+Key Vault and Storage Account use `default_action = "Deny"` with `ip_rules` and `virtual_network_subnet_ids`. Terraform refreshes state before it can apply changes, so the refresh fails if the current runner network is not already allowed.
 
-1. Terraform refreshes state first
-2. The refresh is blocked by the firewall (runner's IP or subnet not in allow list)
-3. Terraform never reaches the step that would update firewall rules
+## Current Setup
 
-**Current setup:** Terraform allows the **runner subnet** via `virtual_network_subnet_ids`. Workflows run on a self-hosted runner in that subnet, so the runner's traffic is allowed. No deployer IP or GitHub Actions IP ranges are used.
+Terraform does not manage a dedicated runner subnet anymore.
 
-## Automated Solution (Current Setup)
+- Key Vault `virtual_network_subnet_ids`: container subnet.
+- Key Vault `ip_rules`: `deployer_ip` plus `172.128.0.0/9` Azure-internal fallback.
+- Storage `virtual_network_subnet_ids`: container subnet and database subnet.
+- Storage `ip_rules`: `deployer_ip` only.
 
-Terraform uses **runner subnet** (`virtual_network_subnet_ids`) for Key Vault and Storage. Workflows run on a self-hosted runner in that subnet, so no deployer IP or GitHub Actions IP ranges are needed.
+For GitHub-hosted runs, make sure the workflow discovers the current runner public IP and passes it as `deployer_ip` when Storage needs data-plane access.
 
-**Greenfield (new deployment):** Works if the self-hosted runner is online and the subnet is in the firewall from the start.
+## Brownfield Bootstrap
 
-**Brownfield (existing resources locked out):** One-time manual bootstrap:
+If both Key Vault and Storage are locked out before Terraform can refresh:
 
-1. In Azure Portal: Key Vault `nl-prod-hov-kv-san` → Networking → **Allow access from all networks**
-2. Storage Account `nlprodhovstsan` → Networking → **Allow access from all networks**
-3. Run the Terraform workflow (push to main, or manually trigger terraform-apply)
-4. Terraform will update the firewalls to use the runner subnet and set `default_action = Deny`
-5. Future runs work via the self-hosted runner—no more manual steps
+1. Azure Portal -> Key Vault `nl-prod-hov-kv` -> Networking -> temporarily allow access from all networks.
+2. Azure Portal -> Storage Account `nlprodhovst` -> Networking -> temporarily allow access from all networks.
+3. Run the Terraform workflow or a controlled manual Terraform plan/apply.
+4. Confirm the intended subnet/IP firewall rules are present.
+5. Restore `default_action = "Deny"` where required.
 
-**Note:** If you see `Client address: 172.184.x.x` (or similar 172.128–172.255), the runner is using Azure internal IPs. Terraform already adds 172.128.0.0/9 for Key Vault—but you must run the one-time bootstrap above first so Terraform can apply that change.
+## Alternative: Self-Hosted Runner in Azure VNet
 
-**Switching to self-hosted runner:** After removing `deployer_ip` from workflows, the first run may fail with Storage 403 because the old runner IP is being removed and the new runner (self-hosted) may not be in use yet. Run the one-time bootstrap above, then re-run. Once the runner subnet is in the firewall, the self-hosted runner will have access.
+A future self-hosted runner can still be used, but it should run in an existing allowed subnet such as the container subnet, or in a newly declared subnet that is deliberately added back to the Key Vault and Storage firewalls. Do not depend on `runner_subnet_id`; that Terraform output no longer exists.
 
-**Why is the job queued and not running?** Workflows use `runs-on: [self-hosted, azure-vnet-ghost]`. GitHub schedules these jobs only on self-hosted runners with the `azure-vnet-ghost` label; if no matching runner is online and idle, the job stays **queued** and does **not** fall back to GitHub-hosted runners. Check: (1) Runner is registered at HouseOfVeritas → Settings → Actions → Runners and shows Idle; (2) Runner has label `azure-vnet-ghost`; (3) Runner is installed on the phoenixvc listener VM with `GITHUB_REPO_URL` set to the HouseOfVeritas repo.
+## Other Terraform Errors
 
-**Why does terraform-plan skip fork PRs?** The plan job runs on the self-hosted runner (VNet access). To avoid running untrusted fork code in the VNet, the job is restricted to same-repo PRs only (`head.repo.full_name == repository`). Fork PRs are skipped; contributors should open branches in the main repo for plan previews.
+**InvalidIpAddressTypeForNetworkProfile:** Container groups using `subnet_ids` (VNet) must set `ip_address_type = "Private"`. Public IPs are not allowed when a network profile is set.
 
-## Alternative Options
+**Consumption Budget 400 (offerType: None):** Cost Management consumption budgets only support Enterprise Agreement, Web direct, and Microsoft Customer Agreement. Visual Studio / MSDN subscriptions can return `offerType: None`; keep `enable_consumption_budget = false` for this stack.
 
-### Option A: Add GitHub Actions IP Ranges via Script
+**"next: not found" on Azure App Service:** The deploy workflow uses Next.js standalone output. After build, `.next/static` and `public` are copied into `.next/standalone/`, the standalone `package.json` start script is set to `node server.js`, and Terraform sets `app_command_line = "node server.js"`.
 
-Add the GitHub Actions IP ranges to Key Vault and Storage so any runner can connect.
+**ApplicationGatewayDeprecatedTlsVersionUsedInSslPolicy:** The gateway module must keep a static `ssl_policy` block with `policy_name = "AppGwSslPolicy20220101"`.
 
-**Prerequisite:** Run from a machine that can already reach Key Vault and Storage (e.g. VM in your VNet, or after temporarily allowing "All networks" in the portal).
+## Production Defaults
 
-**Using the helper script:**
-
-```bash
-# From a machine with Azure CLI and network access
-cd config/scripts
-chmod +x add-github-actions-ips-to-azure.sh
-./add-github-actions-ips-to-azure.sh --dry-run   # Preview
-./add-github-actions-ips-to-azure.sh             # Apply
-```
-
-**Manual steps (Azure Portal):**
-
-1. Get the IP ranges: `curl -s https://api.github.com/meta | jq -r '.actions[]' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'`
-2. Key Vault → Networking → Firewall → Add existing IPv4 address ranges
-3. Storage Account → Networking → Firewall → Add existing IPv4 address ranges
-4. Add each CIDR (the list is large; the script automates this)
-
-### Option B: Self-Hosted Runner in Azure VNet (Recommended Long-Term)
-
-Run a self-hosted GitHub Actions runner on a VM inside your Azure VNet (e.g. in the container subnet). The subnet is already in `virtual_network_subnet_ids`, so no firewall changes are needed.
-
-- [phoenixvc-actions-runner](https://github.com/phoenixvc/phoenixvc-actions-runner) — Self-hosted runner infra (listener VM + VMSS) for phoenixvc org. Deploys into the runner subnet; use `terraform output runner_subnet_id` from HouseOfVeritas.
-
-## Other Terraform Errors (Unrelated to Firewall)
-
-**InvalidIpAddressTypeForNetworkProfile:** Container groups using `subnet_ids` (VNet) must set `ip_address_type = "Private"`. Public IPs are not allowed when a network profile is set. The compute module sets this explicitly.
-
-**Consumption Budget 400 (offerType: None):** Cost Management consumption budgets only support Enterprise Agreement, Web direct, and Microsoft Customer Agreement. Visual Studio / MSDN subscriptions (e.g. MS-AZR-0036P) return `offerType: None` and cannot use `azurerm_consumption_budget_resource_group`. Set `enable_consumption_budget = false` in the monitoring module.
-
-**"next: not found" on Azure App Service:** The deploy workflow uses Next.js standalone output. After build, `.next/static` and `public` are copied into `.next/standalone/`, the standalone `package.json` start script is set to `node server.js`, and that folder is deployed. Terraform sets `app_command_line = "node server.js"` to override the default. If you see "next: not found": 1) Run the full deploy workflow (build + deploy-infrastructure + deploy-webapp) so Terraform applies the startup command and the new artifact is deployed; 2) Re-run the workflow if it previously failed before deploy-webapp; 3) Check Azure Portal → Web App → Configuration → General Settings for "Startup Command" = `node server.js`.
-
-**"Could not find a production build in the './.next' directory":** The `.next` folder is hidden and can be excluded from artifacts/packaging. Fix: 1) `upload-artifact` must use `include-hidden-files: true` so `.next` is in the artifact; 2) deploy creates `zip -r deploy.zip .` before deploy; 3) a verification step fails the job if `.next/BUILD_ID` is missing. If the error persists, check the "Verify artifact contains .next" step in the deploy job.
-
-**ApplicationGatewayDeprecatedTlsVersionUsedInSslPolicy:** AppGwSslPolicy20150501 (TLS 1.0/1.1) is deprecated as of Aug 2025. The gateway module uses a **static** `ssl_policy` block (always present) with `policy_name = "AppGwSslPolicy20220101"` (TLS 1.2 and 1.3). Do not use a dynamic block—omitting `ssl_policy` lets Azure default to the deprecated policy. Regenerate the plan (`terraform plan -out=tfplan`) before applying. See [Azure TLS retirement](https://aka.ms/appgw-oldtlsversions).
-
----
-
-## Resource Names (Production Defaults)
-
-- Key Vault: `nl-prod-hov-kv-san`
-- Storage Account: `nlprodhovstsan`
-- Resource Group: `nl-prod-hov-rg-san`
+- Key Vault: `nl-prod-hov-kv`
+- Storage Account: `nlprodhovst`
+- Resource Group: `nl-prod-hov-rg`
 
 ## Verifying the Fix
 
-After the one-time bootstrap (or for greenfield):
-
-1. Push a change that triggers the Terraform workflow
-2. Terraform plan/apply should complete without 403 errors
-3. Firewall rules persist (runner subnet)—no ephemeral IP clearing needed
+1. Trigger the Terraform plan workflow or run a controlled plan with the deploy principal.
+2. Confirm Terraform refresh reaches Key Vault and Storage without 403s.
+3. Confirm planned firewall rules use the container/database subnet IDs and deployer IP rules, with no runner subnet references.

--- a/docs/03-deployment/07-self-hosted-runner-setup.md
+++ b/docs/03-deployment/07-self-hosted-runner-setup.md
@@ -1,150 +1,46 @@
 # Self-Hosted Runner Setup (Historical)
 
-> **Status: Historical — no longer in use as of 2026-05-14.**
-> After the transfer to `neuralliquid/house-of-veritas`, all workflows run on `ubuntu-latest`.
-> The `azure-vnet-ghost` runner was deregistered and the runner subnet allowlisting on
-> Key Vault / Storage is being kept for now (re-evaluate when next touched).
-> This page is retained for archaeology only.
+> Status: Historical. The `azure-vnet-ghost` runner was deregistered after the transfer to `neuralliquid/house-of-veritas`, and current workflows run on GitHub-hosted `ubuntu-latest` runners.
+>
+> The dedicated HOV runner subnet and `runner_subnet_id` Terraform output were removed in 2026-05. Do not use this page as current setup guidance.
 
-This describes the previous architecture: the repo lived under the **JustAGhosT** account but used a self-hosted runner hosted in **phoenixvc** Azure infrastructure. This avoided Key Vault and Storage 403 errors that can occur when using GitHub-hosted runners (`ubuntu-latest`).
+This page is retained only to explain the previous architecture.
 
----
+## Previous Architecture
 
-## Overview
+| Component             | Previous location                                                                                   |
+| --------------------- | --------------------------------------------------------------------------------------------------- |
+| HouseOfVeritas repo   | JustAGhosT personal account                                                                          |
+| Runner infrastructure | phoenixvc org ([phoenixvc-actions-runner](https://github.com/phoenixvc/phoenixvc-actions-runner))    |
+| Runner VM             | Azure VNet runner subnet in HouseOfVeritas                                                           |
+| Runner type           | Persistent repo-scoped runner named `azure-vnet-ghost`                                               |
+| Terraform             | Pre-installed on the listener VM                                                                     |
 
-| Component             | Location                                                                                          |
-| --------------------- | ------------------------------------------------------------------------------------------------- |
-| HouseOfVeritas repo   | JustAGhosT (personal account)                                                                     |
-| Runner infrastructure | phoenixvc org ([phoenixvc-actions-runner](https://github.com/phoenixvc/phoenixvc-actions-runner)) |
-| Runner VM             | Azure VNet (runner subnet in HouseOfVeritas)                                                      |
-| Runner type           | Persistent (`azure-vnet-ghost`)                                                                   |
-| Terraform             | v1.14.5 pre-installed via HashiCorp APT repo                                                      |
+The old runner avoided Key Vault and Storage firewall failures by running inside an allowlisted VNet subnet. That subnet is no longer part of the HOV Terraform contract.
 
-The persistent runner is installed on the listener VM in phoenixvc-actions-runner and registered to the JustAGhosT account. It has VNet access to Key Vault and Storage via the runner subnet firewall rules.
+## Current Guidance
 
----
+Use GitHub-hosted runners and the firewall pattern documented in [05-terraform-firewall-troubleshooting.md](05-terraform-firewall-troubleshooting.md):
 
-## Prerequisites
+- Key Vault allows the container subnet plus Azure-internal fallback CIDR rules.
+- Storage allows the container/database subnets plus the current deployer IP when needed.
+- No workflow should use `runs-on: [self-hosted, azure-vnet-ghost]`.
+- No module should expect `runner_subnet_id`.
 
-Before setting up the persistent runner:
+## If Self-Hosting Returns
 
-- [phoenixvc-actions-runner](https://github.com/phoenixvc/phoenixvc-actions-runner) Terraform applied (listener VM + VMSS exist)
-- Runner subnet added to HouseOfVeritas Key Vault and Storage firewall rules
-- SSH or Azure Bastion access to the listener VM
+A future self-hosted runner should be designed as new infrastructure. Place it in an existing allowed subnet, or add a newly declared subnet and intentionally wire that subnet into Key Vault and Storage firewall rules. Reintroducing a runner subnet requires a fresh Terraform design and import/apply plan; do not revive the old `runner_subnet_id` output.
 
----
+## Historical Troubleshooting Clues
 
-## Setting Up the Persistent Runner in JustAGhosT
+| Symptom                   | Historical cause                                               | Current action                                       |
+| ------------------------- | -------------------------------------------------------------- | ---------------------------------------------------- |
+| Job stays queued          | `azure-vnet-ghost` was offline or deregistered                 | Remove self-hosted labels; use `ubuntu-latest`       |
+| 403 on Key Vault/Storage  | Runner network was not in firewall rules                       | Check deployer IP and current firewall docs          |
+| Wrong runner label        | Mixed JustAGhosT and phoenixvc runner labels                   | Do not use old labels                                |
+| Missing runner subnet     | Dedicated runner subnet removed from HOV Terraform             | Use current subnet/IP firewall pattern               |
 
-This is a one-time setup. The runner runs on the phoenixvc listener VM but is registered to your JustAGhosT account.
+## References
 
-### Step 1: Get listener VM access
-
-From phoenixvc-actions-runner Terraform output:
-
-```bash
-cd phoenixvc-actions-runner/terraform
-terraform output -raw listener_private_ip
-```
-
-Or from Azure Portal: find the listener VM in the runner resource group → Networking.
-
-You need SSH access (Azure Bastion, VPN, or direct if the VM has a public IP).
-
-### Step 2: Create the runner in JustAGhosT
-
-**Where to find it:** "Actions" is not in your profile Settings. Use the **repository** Settings instead.
-
-1. Go to **https://github.com/JustAGhosT/HouseOfVeritas** → **Settings** → **Actions** → **Runners**
-2. Click **New self-hosted runner**
-3. Select **Linux** and **x64**
-4. Scroll to the **Configure** section (below the download commands)
-5. Copy the **registration token** from the `config.sh` command line
-
-The runner will be scoped to HouseOfVeritas only. (Personal accounts do not have account-level runners or repository access choices like organizations do.)
-
-> **Note:** For a repo-scoped runner (HouseOfVeritas), set `GITHUB_REPO_URL` when running the install script in Step 3.
-
-### Step 3: Install on the listener VM
-
-SSH to the listener VM, then:
-
-Run from the root of your workspace where the `phoenixvc-actions-runner/` repo is checked out:
-
-```bash
-# From your workstation: copy the install script to the VM
-scp phoenixvc-actions-runner/scripts/install-persistent-runner.sh azureuser@<listener-ip>:~/
-
-# SSH in
-ssh azureuser@<listener-ip>
-
-# On the listener VM: run with the token and repo URL from Step 2
-# Security: use read -rs so the token is never stored in shell history.
-read -rsp "Paste GitHub runner token (input hidden): " GITHUB_RUNNER_TOKEN && echo
-export GITHUB_REPO_URL="https://github.com/JustAGhosT/HouseOfVeritas"
-./install-persistent-runner.sh
-```
-
-The script downloads the runner, configures it for JustAGhosT, and installs it as a systemd service. The default runner name is `azure-vnet-ghost`.
-
-### Step 4: Verify
-
-1. **HouseOfVeritas** → **Settings** → **Actions** → **Runners**
-2. You should see the runner with status **Idle** or **Active**
-3. If the runner goes offline, on the listener VM: `sudo ./svc.sh status` in `/opt/gh-runner-justaghost`
-
----
-
-## Repository Access
-
-For repo-level runners (personal accounts), the runner is automatically scoped to HouseOfVeritas. No additional configuration needed.
-
----
-
-## Workflow Configuration
-
-Use the runner label in jobs that need Azure VNet access (Terraform, Key Vault, Storage):
-
-```yaml
-jobs:
-  terraform-apply:
-    runs-on: [self-hosted, azure-vnet-ghost]
-    # ...
-```
-
-HouseOfVeritas workflows that use this runner:
-
-- `terraform-apply.yml`
-- `terraform-plan.yml`
-- `terraform-destroy.yml`
-- `deploy.yml` (deploy-infrastructure job)
-
-### No deployer IP workarounds
-
-When using the self-hosted runner, you do **not** need:
-
-- `deployer_ip` or `ci_allowed_ip_ranges` Terraform variables
-- `fetch-github-actions-ips.py` or ipify steps
-- `ci_ranges.auto.tfvars`
-
-The runner subnet is already in Key Vault and Storage `virtual_network_subnet_ids`.
-
----
-
-## Troubleshooting
-
-| Issue                            | Check                                                                                                   |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `setup-terraform` AggregateError | Workflows use pre-installed Terraform on the runner VM (HashiCorp APT repo, v1.14.5). No download step. |
-| Job stays queued                 | Runner offline? `sudo ./svc.sh status` in `/opt/gh-runner-justaghost` on listener VM                    |
-| Runner not visible in repo       | HouseOfVeritas → Settings → Actions → Runners (repo Settings)                                           |
-| 403 on Key Vault/Storage         | Runner subnet must be in HouseOfVeritas Key Vault and Storage firewall rules                            |
-| Wrong runner label               | Use `[self-hosted, azure-vnet-ghost]` for JustAGhosT; `[azure-vnet]` is for phoenixvc org only          |
-| Registration token expired       | Generate a new one: HouseOfVeritas → Settings → Actions → Runners → New self-hosted runner              |
-
----
-
-## Reference
-
-- [phoenixvc-actions-runner setup](https://github.com/phoenixvc/phoenixvc-actions-runner/blob/main/docs/setup.md)
 - [05-terraform-firewall-troubleshooting.md](05-terraform-firewall-troubleshooting.md)
+- Historical phoenixvc runner repo: `phoenixvc-actions-runner`

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -52,7 +52,6 @@ module "network" {
   gateway_subnet_prefix   = var.gateway_subnet_prefix
   container_subnet_prefix = var.container_subnet_prefix
   database_subnet_prefix  = var.database_subnet_prefix
-  runner_subnet_prefix    = var.runner_subnet_prefix
 
   tags = local.common_tags
 }
@@ -68,7 +67,6 @@ module "storage" {
   network_default_action   = var.storage_network_default_action
   container_subnet_id      = module.network.container_subnet_id
   database_subnet_id       = module.network.database_subnet_id
-  runner_subnet_id         = module.network.runner_subnet_id
   deployer_ip_addresses    = local.ci_ip_rules_storage
 
   tags = local.common_tags
@@ -83,7 +81,6 @@ module "security" {
   key_vault_name                    = var.key_vault_name
   network_default_action            = var.key_vault_network_default_action
   container_subnet_id               = module.network.container_subnet_id
-  runner_subnet_id                  = module.network.runner_subnet_id
   terraform_access_policy_object_id = var.terraform_key_vault_access_policy_object_id
   deployer_ip_addresses             = local.ci_ip_rules_keyvault
   db_admin_password                 = var.db_admin_password
@@ -289,7 +286,6 @@ module "dns" {
   depends_on = [module.gateway]
 }
 
-# Runner infrastructure is in phoenixvc-actions-runner repo (deploys into runner_subnet_id)
 
 # Monitoring Module (alerts, budgets, Log Analytics)
 module "monitoring" {

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -133,8 +133,3 @@ output "function_app_hostname" {
   description = "Default hostname of the Function App"
   value       = try(module.functions[0].function_app_default_hostname, null)
 }
-
-output "runner_subnet_id" {
-  description = "ID of the runner subnet (pass to phoenixvc-actions-runner Terraform)"
-  value       = module.network.runner_subnet_id
-}

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -65,11 +65,6 @@ variable "database_subnet_prefix" {
   default     = "10.0.3.0/24"
 }
 
-variable "runner_subnet_prefix" {
-  description = "Runner subnet prefix for CI"
-  type        = string
-  default     = "10.0.4.0/28"
-}
 
 # Storage variables
 variable "storage_account_name" {

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -52,15 +52,6 @@ resource "azurerm_subnet" "database" {
   }
 }
 
-resource "azurerm_subnet" "runner" {
-  name                 = "${var.environment}-runner-subnet"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.main.name
-  address_prefixes     = [var.runner_subnet_prefix]
-
-  service_endpoints = ["Microsoft.KeyVault", "Microsoft.Storage"]
-}
-
 # Network Security Groups
 resource "azurerm_network_security_group" "gateway" {
   name                = "${var.environment}-gateway-nsg"
@@ -208,41 +199,4 @@ resource "azurerm_subnet_network_security_group_association" "containers" {
 resource "azurerm_subnet_network_security_group_association" "database" {
   subnet_id                 = azurerm_subnet.database.id
   network_security_group_id = azurerm_network_security_group.database.id
-}
-
-resource "azurerm_network_security_group" "runner" {
-  name                = "${var.environment}-runner-nsg"
-  location            = var.location
-  resource_group_name = var.resource_group_name
-
-  security_rule {
-    name                       = "AllowHTTPSOutbound"
-    priority                   = 100
-    direction                  = "Outbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "443"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
-  security_rule {
-    name                       = "DenyAllInbound"
-    priority                   = 4096
-    direction                  = "Inbound"
-    access                     = "Deny"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
-  tags = var.tags
-}
-
-resource "azurerm_subnet_network_security_group_association" "runner" {
-  subnet_id                 = azurerm_subnet.runner.id
-  network_security_group_id = azurerm_network_security_group.runner.id
 }

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -23,10 +23,6 @@ output "database_subnet_id" {
   value       = azurerm_subnet.database.id
 }
 
-output "runner_subnet_id" {
-  description = "ID of the runner subnet"
-  value       = azurerm_subnet.runner.id
-}
 
 output "gateway_nsg_id" {
   description = "ID of the gateway NSG"

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -42,11 +42,6 @@ variable "database_subnet_prefix" {
   default     = "10.0.3.0/24"
 }
 
-variable "runner_subnet_prefix" {
-  description = "Address prefix for CI runner subnet"
-  type        = string
-  default     = "10.0.4.0/28"
-}
 
 variable "tags" {
   description = "Tags to apply to resources"

--- a/terraform/modules/security/main.tf
+++ b/terraform/modules/security/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_key_vault" "main" {
     bypass                     = "AzureServices"
     default_action             = var.network_default_action
     ip_rules                   = var.deployer_ip_addresses
-    virtual_network_subnet_ids = [var.container_subnet_id, var.runner_subnet_id]
+    virtual_network_subnet_ids = [var.container_subnet_id]
   }
 
   tags = var.tags

--- a/terraform/modules/security/variables.tf
+++ b/terraform/modules/security/variables.tf
@@ -18,10 +18,6 @@ variable "container_subnet_id" {
   type        = string
 }
 
-variable "runner_subnet_id" {
-  description = "ID of the runner subnet (for CI runner access)"
-  type        = string
-}
 
 variable "db_admin_password" {
   description = "Database administrator password"

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_storage_account" "main" {
     default_action             = var.network_default_action
     bypass                     = ["AzureServices"]
     ip_rules                   = var.deployer_ip_addresses
-    virtual_network_subnet_ids = [var.container_subnet_id, var.database_subnet_id, var.runner_subnet_id]
+    virtual_network_subnet_ids = [var.container_subnet_id, var.database_subnet_id]
   }
 
   tags = var.tags

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -45,10 +45,6 @@ variable "database_subnet_id" {
   type        = string
 }
 
-variable "runner_subnet_id" {
-  description = "ID of the runner subnet (for CI runner access)"
-  type        = string
-}
 
 variable "deployer_ip_addresses" {
   description = "IP addresses allowed to manage Storage Account (e.g. CI runner)"


### PR DESCRIPTION
## Summary
- remove the dedicated runner subnet, NSG, NSG association, variables, and outputs from production Terraform
- remove runner subnet ACL wiring from Key Vault and Storage modules
- update deployment docs to reflect current GitHub-hosted runner/deployer-IP firewall posture and mark old self-hosted runner guidance as historical

## Validation
- terraform fmt -recursive
- terraform fmt -check -recursive
- terraform validate
- terraform plan -refresh=false -no-color -var-file=canonical.tfvars.example (0 add, 4 change, 3 destroy; runner subnet/NSG/association destroyed, Key Vault/Storage ACLs updated; known unrelated secret/app-settings churn remains)
- git diff --check
- rg runner_subnet terraform (no matches)