### PR TITLE
chore(terraform): codify hov custom hostname binding

### DIFF
--- a/terraform/environments/production/imports.tf
+++ b/terraform/environments/production/imports.tf
@@ -1,0 +1,4 @@
+import {
+  to = module.webapp.azurerm_app_service_custom_hostname_binding.root[0]
+  id = "/subscriptions/bb4e3882-2079-4bab-8974-611bc0b8bb58/resourceGroups/nl-prod-hov-rg/providers/Microsoft.Web/sites/nl-prod-hov-app/hostNameBindings/hov.neuralliquid.ai"
+}

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -230,6 +230,7 @@ module "webapp" {
   location                           = azurerm_resource_group.main.location
   web_app_name                       = var.web_app_name
   domain_name                        = var.domain_name
+  custom_domain                      = var.custom_domain
   key_vault_id                       = module.security.key_vault_id
   jwt_secret                         = random_password.jwt_secret.result
   mystira_oidc_issuer                = var.mystira_oidc_issuer

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -446,6 +446,11 @@ variable "domain_name" {
   type        = string
   default     = "nexamesh.ai"
 }
+variable "custom_domain" {
+  description = "Canonical custom hostname bound to the HOV web app. DNS is owned by neuralliquid-org."
+  type        = string
+  default     = "hov.neuralliquid.ai"
+}
 
 # -----------------------------------------------------------------------------
 # Auth.js v5 + Mystira OIDC (relying party: neuralliquid-hov-web)

--- a/terraform/modules/webapp/main.tf
+++ b/terraform/modules/webapp/main.tf
@@ -126,4 +126,8 @@ resource "azurerm_app_service_custom_hostname_binding" "root" {
   hostname            = var.custom_domain
   app_service_name    = azurerm_linux_web_app.main.name
   resource_group_name = var.resource_group_name
+
+  lifecycle {
+    ignore_changes = [ssl_state, thumbprint]
+  }
 }

--- a/terraform/modules/webapp/main.tf
+++ b/terraform/modules/webapp/main.tf
@@ -1,4 +1,6 @@
 locals {
+  app_base_url = var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${var.domain_name}"
+
   # Auth.js v5 + Mystira OIDC runtime settings. Each OIDC key is emitted ONLY
   # when a value is supplied, so an unset variable leaves the setting absent and
   # the app falls back to its in-code dev default (see auth.config.ts) rather
@@ -45,7 +47,7 @@ resource "azurerm_linux_web_app" "main" {
 
     cors {
       allowed_origins = [
-        "https://${var.domain_name}",
+        local.app_base_url,
         "https://docs.${var.domain_name}",
         "https://ops.${var.domain_name}",
       ]
@@ -56,7 +58,7 @@ resource "azurerm_linux_web_app" "main" {
     WEBSITE_NODE_DEFAULT_VERSION = "~20"
     HOSTNAME                     = "0.0.0.0"
     NODE_ENV                     = "production"
-    NEXT_PUBLIC_APP_URL          = "https://${var.domain_name}"
+    NEXT_PUBLIC_APP_URL          = local.app_base_url
 
     BASEROW_URL             = "https://ops.${var.domain_name}"
     BASEROW_TOKEN           = var.baserow_api_token


### PR DESCRIPTION
## Summary
- wire the production web app custom_domain to hov.neuralliquid.ai
- add a Terraform import block for the existing App Service hostname binding
- keep SSL fields ignored on the hostname binding so Azure's existing managed certificate/SNI binding is not replaced

## Live evidence
- 
euralliquid-org DNS Terraform plan is clean (No changes) and already owns hov + suid.hov
- Azure DNS: hov.neuralliquid.ai CNAME -> 
l-prod-hov-app.azurewebsites.net, TTL 300
- Azure DNS: suid.hov.neuralliquid.ai TXT exists, TTL 3600
- App Service hostname binding exists with sslState=SniEnabled, thumbprint 6521E63EDA292F5EB039766A84CF7D0A4F6E1FA5

## Validation
- terraform fmt -recursive
- terraform fmt -check -recursive
- terraform validate
- terraform plan -refresh=false -no-color -var-file=canonical.tfvars.example
  - prepares 1 import for the custom hostname binding
  - 0 adds for this change
  - does not replace the managed certificate or certificate binding
  - still shows the already-merged runner-subnet cleanup pending apply plus known secret/app-settings noise