### PR TITLE
chore(terraform): cut over HOV OIDC to prod issuer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -259,8 +259,9 @@ jobs:
         run: |
           terraform plan \
             -var="domain_name=${{ vars.DOMAIN_NAME || 'nexamesh.ai' }}" \
-            -var="mystira_oidc_issuer=${{ vars.MYSTIRA_OIDC_ISSUER || 'https://mys-dev-id-webapi.azurewebsites.net' }}" \
+            -var="mystira_oidc_issuer=${{ vars.MYSTIRA_OIDC_ISSUER || 'https://identity.mystira.app' }}" \
             -var="mystira_oidc_client_secret=${{ secrets.MYSTIRA_OIDC_CLIENT_SECRET }}" \
+            -var="mystira_oidc_client_secret_key_vault_secret_name=${{ vars.MYSTIRA_OIDC_CLIENT_SECRET_KEY_VAULT_SECRET_NAME || 'mystira-oidc-client-secret' }}" \
             -var="auth_url=${{ vars.AUTH_URL || 'https://hov.neuralliquid.ai' }}" \
             -var="db_admin_password=${{ secrets.DB_ADMIN_PASSWORD }}" \
             -var="smtp_username=${{ secrets.SMTP_USERNAME }}" \

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -463,7 +463,7 @@ variable "custom_domain" {
 variable "mystira_oidc_issuer" {
   description = "Mystira OIDC issuer URL"
   type        = string
-  default     = "https://mys-dev-id-webapi.azurewebsites.net"
+  default     = "https://identity.mystira.app"
 }
 
 variable "mystira_oidc_client_id" {
@@ -570,5 +570,5 @@ variable "ci_allowed_ip_ranges" {
 variable "mystira_oidc_client_secret_key_vault_secret_name" {
   description = "Name of the HOV Key Vault secret containing the Mystira OIDC client secret. Leave empty until the secret exists and issuer cutover is approved."
   type        = string
-  default     = ""
+  default     = "mystira-oidc-client-secret"
 }


### PR DESCRIPTION
## Summary
- switch production HOV OIDC issuer default from the dev Identity API to https://identity.mystira.app
- set the HOV OIDC client-secret Key Vault reference name to mystira-oidc-client-secret

## Secret handling
- copied existing identity-side mys-prod-identity-kv/hov-client-secret into HOV Key Vault as nl-prod-hov-kv/mystira-oidc-client-secret without printing the secret value
- temporary local HOV Key Vault secret get/list/set policy was added only for the copy, then removed
- verified the temporary local policy is absent after copy

## Live evidence
- target issuer discovery is live: https://identity.mystira.app/.well-known/openid-configuration
- HOV App Service currently has MYSTIRA_OIDC_ISSUER, MYSTIRA_OIDC_CLIENT_ID, and AUTH_URL, but no MYSTIRA_OIDC_CLIENT_SECRET until Terraform apply

## Validation
- terraform fmt -recursive
- terraform validate
- git diff --check
- terraform plan -refresh=false -no-color -var-file=canonical.tfvars.example
  - still shows the expected pending production convergence: runner subnet cleanup, hostname binding import, webapp app_settings/CORS update
  - no additional resource adds