### PR TITLE
fix(prod): wire telemetry and project datastore

### DIFF
--- a/.azure/plan.md
+++ b/.azure/plan.md
@@ -163,3 +163,36 @@ Current: execution after approval.
 2. Add deterministic Radar telemetry events and scheduled query alert definitions.
 3. Add Docket-aligned evidence/runbook notes using `https://docket.phoenixvc.tech` and the verified `/openapi.json` surface.
 4. Validate locally without deployment.
+
+---
+
+## 11. Production Remediation: Web Telemetry, Project Persistence, Clean Defaults
+
+> **Status:** Ready for Validation
+
+Added: 2026-07-20
+
+### Goal
+
+Fix three production gaps verified after the OIDC Terraform apply:
+
+- HOV web app has no Application Insights resource or App Insights app setting.
+- Project APIs write to `data/projects.json` inside the deployed app package, so project creation is not durable in Azure App Service.
+- Visible project/task defaults still include sample values even when `ALLOW_DEMO_DATA` is not enabled.
+
+### Scope
+
+| Area | Decision |
+|------|----------|
+| Web telemetry | Add Terraform-managed Application Insights for `nl-prod-hov-app` and wire `APPLICATIONINSIGHTS_CONNECTION_STRING` / role name into App Service settings. |
+| Node instrumentation | Initialize Azure Monitor from `instrumentation.ts` when the connection string exists. |
+| Project persistence | Use the existing production `AZURE_STORAGE_CONNECTION_STRING` to store project JSON in Blob Storage, with local file fallback for dev/tests. |
+| Dummy data | Remove visible project/task seed defaults from production paths; keep explicit demo data behind `ALLOW_DEMO_DATA=true`. |
+| Deployment | Prepare and validate in PR first; production apply/deploy remains a separate controlled action after merge. |
+
+### Validation
+
+- Run `pnpm run lint`.
+- Run focused API tests for projects/tasks.
+- Run `pnpm run build`.
+- Run `terraform fmt -recursive` and `terraform -chdir=terraform/environments/production validate`.

--- a/app/api/projects/[id]/allocations/route.ts
+++ b/app/api/projects/[id]/allocations/route.ts
@@ -1,43 +1,12 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
-import { readFile, writeFile, mkdir } from "fs/promises"
-import { join } from "path"
+import {
+  createJobAllocation,
+  listJobAllocations,
+  type JobAllocation,
+  type JobAllocationType,
+} from "@/lib/repositories/job-workspace-repository"
 import { logger } from "@/lib/logger"
-
-const ALLOCATIONS_PATH = join(process.cwd(), "data", "job-allocations.json")
-
-export type JobAllocationType = "material" | "labour"
-
-export interface JobAllocation {
-  id: string
-  projectId: string
-  type: JobAllocationType
-  name: string
-  areaId?: string
-  quantity?: number
-  unit?: string
-  hours?: number
-  rateCents?: number
-  costCents?: number
-  notes?: string
-  createdAt: string
-  updatedAt: string
-}
-
-async function loadAllocations(): Promise<JobAllocation[]> {
-  try {
-    const data = await readFile(ALLOCATIONS_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveAllocations(allocations: JobAllocation[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(ALLOCATIONS_PATH, JSON.stringify(allocations, null, 2), "utf-8")
-}
 
 function normalizeType(value: unknown): JobAllocationType {
   return value === "labour" ? "labour" : "material"
@@ -52,13 +21,11 @@ function numberFromBody(value: unknown): number | undefined {
 export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params
   const { searchParams } = new URL(request.url)
-  const type = searchParams.get("type")
+  const requestedType = searchParams.get("type")
+  const type = requestedType === "material" || requestedType === "labour" ? requestedType : undefined
 
   try {
-    let allocations = (await loadAllocations()).filter((allocation) => allocation.projectId === id)
-    if (type === "material" || type === "labour") {
-      allocations = allocations.filter((allocation) => allocation.type === type)
-    }
+    const allocations = await listJobAllocations(id, type)
     return NextResponse.json({ allocations })
   } catch (error) {
     logger.error("Failed to load job allocations", {
@@ -101,9 +68,7 @@ export const POST = withRole("admin", "operator", "employee")(async (request, co
       updatedAt: now,
     }
 
-    const allocations = await loadAllocations()
-    allocations.push(allocation)
-    await saveAllocations(allocations)
+    await createJobAllocation(allocation)
     return NextResponse.json({ allocation })
   } catch (error) {
     logger.error("Failed to create job allocation", {

--- a/app/api/projects/[id]/areas/route.ts
+++ b/app/api/projects/[id]/areas/route.ts
@@ -1,37 +1,12 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
-import { readFile, writeFile, mkdir } from "fs/promises"
-import { join } from "path"
+import {
+  createJobArea,
+  listJobAreas,
+  type JobArea,
+  type JobAreaKind,
+} from "@/lib/repositories/job-workspace-repository"
 import { logger } from "@/lib/logger"
-
-const AREAS_PATH = join(process.cwd(), "data", "job-areas.json")
-
-export type JobAreaKind = "room" | "area" | "component" | "zone"
-
-export interface JobArea {
-  id: string
-  projectId: string
-  name: string
-  kind: JobAreaKind
-  notes?: string
-  createdAt: string
-  updatedAt: string
-}
-
-async function loadAreas(): Promise<JobArea[]> {
-  try {
-    const data = await readFile(AREAS_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveAreas(areas: JobArea[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(AREAS_PATH, JSON.stringify(areas, null, 2), "utf-8")
-}
 
 function normalizeKind(value: unknown): JobAreaKind {
   if (value === "room" || value === "area" || value === "component" || value === "zone") {
@@ -43,8 +18,8 @@ function normalizeKind(value: unknown): JobAreaKind {
 export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params
   try {
-    const areas = await loadAreas()
-    return NextResponse.json({ areas: areas.filter((area) => area.projectId === id) })
+    const areas = await listJobAreas(id)
+    return NextResponse.json({ areas })
   } catch (error) {
     logger.error("Failed to load job areas", {
       error: error instanceof Error ? error.message : String(error),
@@ -64,7 +39,6 @@ export const POST = withRole("admin", "operator", "employee")(async (request, co
     const name = typeof body.name === "string" ? body.name.trim() : ""
     if (!name) return NextResponse.json({ error: "name is required" }, { status: 400 })
 
-    const areas = await loadAreas()
     const now = new Date().toISOString()
     const area: JobArea = {
       id: `area-${Date.now()}`,
@@ -75,8 +49,7 @@ export const POST = withRole("admin", "operator", "employee")(async (request, co
       createdAt: now,
       updatedAt: now,
     }
-    areas.push(area)
-    await saveAreas(areas)
+    await createJobArea(area)
     return NextResponse.json({ area })
   } catch (error) {
     logger.error("Failed to create job area", {

--- a/app/api/projects/[id]/members/route.ts
+++ b/app/api/projects/[id]/members/route.ts
@@ -1,26 +1,8 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
-import { readFile, writeFile, mkdir } from "fs/promises"
-import { join } from "path"
-import type { Project, ProjectMember } from "@/lib/projects"
+import type { ProjectMember } from "@/lib/projects"
+import { findProjectById, replaceProject } from "@/lib/repositories/project-repository"
 import { logger } from "@/lib/logger"
-
-const PROJECTS_PATH = join(process.cwd(), "data", "projects.json")
-
-async function loadProjects(): Promise<Project[]> {
-  try {
-    const data = await readFile(PROJECTS_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveProjects(projects: Project[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(PROJECTS_PATH, JSON.stringify(projects, null, 2), "utf-8")
-}
 
 export const POST = withRole("admin")(async (request, context) => {
   const params = await context.params
@@ -34,12 +16,11 @@ export const POST = withRole("admin")(async (request, context) => {
       return NextResponse.json({ error: "userId and role are required" }, { status: 400 })
     }
 
-    const projects = await loadProjects()
-    const idx = projects.findIndex((p) => p.id === id)
-    if (idx === -1) return NextResponse.json({ error: "Project not found" }, { status: 404 })
+    const project = await findProjectById(id)
+    if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 })
 
-    const members = projects[idx].members || []
-    if (members.some((m) => m.userId === userId)) {
+    const members = project.members || []
+    if (members.some((member) => member.userId === userId)) {
       return NextResponse.json({ error: "Member already assigned" }, { status: 400 })
     }
 
@@ -48,14 +29,13 @@ export const POST = withRole("admin")(async (request, context) => {
       role: role === "lead" ? "lead" : role === "supervisor" ? "supervisor" : "contributor",
       allocationPercent: allocationPercent ?? undefined,
     }
-    members.push(member)
-    projects[idx] = {
-      ...projects[idx],
-      members,
+    const updatedProject = {
+      ...project,
+      members: [...members, member],
       updatedAt: new Date().toISOString(),
     }
-    await saveProjects(projects)
-    return NextResponse.json({ member, project: projects[idx] })
+    await replaceProject(updatedProject)
+    return NextResponse.json({ member, project: updatedProject })
   } catch (err) {
     logger.error("Failed to add member", {
       error: err instanceof Error ? err.message : String(err),
@@ -76,18 +56,16 @@ export const DELETE = withRole("admin")(async (request, context) => {
   }
 
   try {
-    const projects = await loadProjects()
-    const idx = projects.findIndex((p) => p.id === id)
-    if (idx === -1) return NextResponse.json({ error: "Project not found" }, { status: 404 })
+    const project = await findProjectById(id)
+    if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 })
 
-    const members = (projects[idx].members || []).filter((m) => m.userId !== userId)
-    projects[idx] = {
-      ...projects[idx],
-      members,
+    const updatedProject = {
+      ...project,
+      members: (project.members || []).filter((member) => member.userId !== userId),
       updatedAt: new Date().toISOString(),
     }
-    await saveProjects(projects)
-    return NextResponse.json({ success: true, project: projects[idx] })
+    await replaceProject(updatedProject)
+    return NextResponse.json({ success: true, project: updatedProject })
   } catch (err) {
     logger.error("Failed to remove member", {
       error: err instanceof Error ? err.message : String(err),

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,33 +1,14 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
-import { readFile, writeFile, mkdir } from "fs/promises"
-import { join } from "path"
-import { toStoredProjectType, withProjectKind, type Project } from "@/lib/projects"
+import { toStoredProjectType, withProjectKind } from "@/lib/projects"
+import { deleteProject, findProjectById, replaceProject } from "@/lib/repositories/project-repository"
 import { logger } from "@/lib/logger"
 import { routeToInngest } from "@/lib/workflows"
-
-const PROJECTS_PATH = join(process.cwd(), "data", "projects.json")
-
-async function loadProjects(): Promise<Project[]> {
-  try {
-    const data = await readFile(PROJECTS_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveProjects(projects: Project[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(PROJECTS_PATH, JSON.stringify(projects, null, 2), "utf-8")
-}
 
 export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params
   try {
-    const projects = await loadProjects()
-    const project = projects.find((p) => p.id === id)
+    const project = await findProjectById(id)
     if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 })
     return NextResponse.json({ project: withProjectKind(project) })
   } catch (err) {
@@ -44,39 +25,38 @@ export const PATCH = withRole("admin")(async (request, context) => {
   if (!id) return NextResponse.json({ error: "Project ID required" }, { status: 400 })
   try {
     const body = await request.json()
-    const projects = await loadProjects()
-    const idx = projects.findIndex((p) => p.id === id)
-    if (idx === -1) return NextResponse.json({ error: "Project not found" }, { status: 404 })
+    const project = await findProjectById(id)
+    if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 })
 
-    const p = projects[idx]
-    const prevStatus = p.status
+    const prevStatus = project.status
     const storedType = toStoredProjectType(body.type)
     const updates = { ...body }
     if (body.type !== undefined) {
       if (storedType) updates.type = storedType
       else delete updates.type
     }
-    projects[idx] = {
-      ...p,
+
+    const updatedProject = {
+      ...project,
       ...updates,
-      id: p.id,
-      members: body.members ?? p.members,
+      id: project.id,
+      members: body.members ?? project.members,
       updatedAt: new Date().toISOString(),
     }
-    await saveProjects(projects)
+    await replaceProject(updatedProject)
 
     if (body.status === "in_progress" && prevStatus !== "in_progress") {
       await routeToInngest({
         name: "house-of-veritas/project.started",
         data: {
-          projectId: p.id,
-          name: p.name,
-          type: p.type,
+          projectId: project.id,
+          name: project.name,
+          type: project.type,
         },
       })
     }
 
-    return NextResponse.json({ project: withProjectKind(projects[idx]) })
+    return NextResponse.json({ project: withProjectKind(updatedProject) })
   } catch (err) {
     logger.error("Failed to update project", {
       error: err instanceof Error ? err.message : String(err),
@@ -90,12 +70,8 @@ export const DELETE = withRole("admin")(async (_request, context) => {
   const id = params?.id
   if (!id) return NextResponse.json({ error: "Project ID required" }, { status: 400 })
   try {
-    const projects = await loadProjects()
-    const filtered = projects.filter((p) => p.id !== id)
-    if (filtered.length === projects.length) {
-      return NextResponse.json({ error: "Project not found" }, { status: 404 })
-    }
-    await saveProjects(filtered)
+    const deleted = await deleteProject(id)
+    if (!deleted) return NextResponse.json({ error: "Project not found" }, { status: 404 })
     return NextResponse.json({ success: true })
   } catch (err) {
     logger.error("Failed to delete project", {

--- a/app/api/projects/[id]/task-groups/route.ts
+++ b/app/api/projects/[id]/task-groups/route.ts
@@ -1,44 +1,17 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import { getTasks, createTask, type Task } from "@/lib/services/baserow"
-import { readFile, writeFile, mkdir } from "fs/promises"
-import { join } from "path"
+import {
+  createJobTaskMetadata,
+  listJobTaskMetadata,
+  type GroupedJobTask,
+  type JobTaskMetadata,
+} from "@/lib/repositories/job-workspace-repository"
 import { logger } from "@/lib/logger"
 
-const META_PATH = join(process.cwd(), "data", "job-task-groups.json")
-
-export interface JobTaskMetadata {
-  taskId: number
-  projectId: string
-  areaId?: string
-  groupName?: string
-  createdAt: string
-  updatedAt: string
-}
-
-export interface GroupedJobTask extends Task {
-  areaId?: string
-  groupName?: string
-}
-
-async function loadMetadata(): Promise<JobTaskMetadata[]> {
-  try {
-    const data = await readFile(META_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveMetadata(metadata: JobTaskMetadata[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(META_PATH, JSON.stringify(metadata, null, 2), "utf-8")
-}
-
-function attachMetadata(tasks: Task[], metadata: JobTaskMetadata[], projectId: string): GroupedJobTask[] {
+function attachMetadata(tasks: Task[], metadata: JobTaskMetadata[]): GroupedJobTask[] {
   return tasks.map((task) => {
-    const match = metadata.find((item) => item.projectId === projectId && item.taskId === task.id)
+    const match = metadata.find((item) => item.taskId === task.id)
     return {
       ...task,
       areaId: match?.areaId,
@@ -55,13 +28,11 @@ export async function GET(request: Request, context: { params: Promise<{ id: str
   if (!projectName) return NextResponse.json({ error: "projectName is required" }, { status: 400 })
 
   try {
-    const [tasks, metadata] = await Promise.all([getTasks({ status: undefined }), loadMetadata()])
-    const projectMetadata = metadata.filter((item) => item.projectId === id)
+    const [tasks, metadata] = await Promise.all([getTasks({ status: undefined }), listJobTaskMetadata(id)])
     const projectTasks = tasks.filter(
-      (task) =>
-        task.project === projectName || projectMetadata.some((item) => item.taskId === task.id)
+      (task) => task.project === projectName || metadata.some((item) => item.taskId === task.id)
     )
-    return NextResponse.json({ tasks: attachMetadata(projectTasks, metadata, id) })
+    return NextResponse.json({ tasks: attachMetadata(projectTasks, metadata) })
   } catch (error) {
     logger.error("Failed to load grouped job tasks", {
       error: error instanceof Error ? error.message : String(error),
@@ -95,7 +66,6 @@ export const POST = withRole("admin", "operator", "employee")(async (request, co
 
     if (!task) return NextResponse.json({ error: "Failed to create task" }, { status: 500 })
 
-    const metadata = await loadMetadata()
     const now = new Date().toISOString()
     const taskMeta: JobTaskMetadata = {
       taskId: task.id,
@@ -105,8 +75,7 @@ export const POST = withRole("admin", "operator", "employee")(async (request, co
       createdAt: now,
       updatedAt: now,
     }
-    metadata.push(taskMeta)
-    await saveMetadata(metadata)
+    await createJobTaskMetadata(taskMeta)
 
     return NextResponse.json({ task: { ...task, areaId: taskMeta.areaId, groupName: taskMeta.groupName } })
   } catch (error) {

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,26 +1,9 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
-import { readFile, writeFile, mkdir } from "fs/promises"
-import { join } from "path"
 import { toStoredProjectType, withProjectKind, type Project } from "@/lib/projects"
 import { logger } from "@/lib/logger"
+import { createProject, listProjects } from "@/lib/repositories/project-repository"
 
-const PROJECTS_PATH = join(process.cwd(), "data", "projects.json")
-
-async function loadProjects(): Promise<Project[]> {
-  try {
-    const data = await readFile(PROJECTS_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveProjects(projects: Project[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(PROJECTS_PATH, JSON.stringify(projects, null, 2), "utf-8")
-}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -29,7 +12,7 @@ export async function GET(request: Request) {
   const member = searchParams.get("member")
 
   try {
-    let projects = await loadProjects()
+    let projects = await listProjects()
     if (parentId) projects = projects.filter((p) => p.parentId === parentId)
     if (type) projects = projects.filter((p) => p.type === type)
     if (member) projects = projects.filter((p) => p.members?.some((m) => m.userId === member))
@@ -63,7 +46,6 @@ export const POST = withRole("admin")(async (request: Request) => {
       return NextResponse.json({ error: "name and type are required" }, { status: 400 })
     }
 
-    const projects = await loadProjects()
     const id = `proj-${Date.now()}`
     const now = new Date().toISOString()
     const storedType = toStoredProjectType(type) ?? "subproject"
@@ -84,8 +66,7 @@ export const POST = withRole("admin")(async (request: Request) => {
       updatedAt: now,
     }
 
-    projects.push(project)
-    await saveProjects(projects)
+    await createProject(project)
 
     return NextResponse.json({ project: withProjectKind(project) })
   } catch (err) {

--- a/app/api/projects/suggestions/[id]/route.ts
+++ b/app/api/projects/suggestions/[id]/route.ts
@@ -1,44 +1,13 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
-import { readFile, writeFile, mkdir } from "fs/promises"
-import { join } from "path"
 import { withProjectKind, type Project, type ProjectMember } from "@/lib/projects"
-import type { ProjectSuggestion } from "../route"
+import { createProject } from "@/lib/repositories/project-repository"
+import {
+  listProjectSuggestions,
+  saveProjectSuggestions,
+} from "@/lib/repositories/project-suggestion-repository"
 import { logger } from "@/lib/logger"
 import { routeToInngest } from "@/lib/workflows"
-
-const SUGGESTIONS_PATH = join(process.cwd(), "data", "project-suggestions.json")
-const PROJECTS_PATH = join(process.cwd(), "data", "projects.json")
-
-async function loadSuggestions(): Promise<ProjectSuggestion[]> {
-  try {
-    const data = await readFile(SUGGESTIONS_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveSuggestions(suggestions: ProjectSuggestion[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(SUGGESTIONS_PATH, JSON.stringify(suggestions, null, 2), "utf-8")
-}
-
-async function loadProjects(): Promise<Project[]> {
-  try {
-    const data = await readFile(PROJECTS_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveProjects(projects: Project[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(PROJECTS_PATH, JSON.stringify(projects, null, 2), "utf-8")
-}
 
 export const PATCH = withRole("admin")(async (request, context) => {
   const params = await context.params
@@ -55,7 +24,7 @@ export const PATCH = withRole("admin")(async (request, context) => {
       return NextResponse.json({ error: "status must be approved or rejected" }, { status: 400 })
     }
 
-    const suggestions = await loadSuggestions()
+    const suggestions = await listProjectSuggestions()
     const idx = suggestions.findIndex((s) => s.id === id)
     if (idx === -1) return NextResponse.json({ error: "Suggestion not found" }, { status: 404 })
 
@@ -71,10 +40,9 @@ export const PATCH = withRole("admin")(async (request, context) => {
       reviewedBy: auth,
       reviewedAt: now,
     }
-    await saveSuggestions(suggestions)
+    await saveProjectSuggestions(suggestions)
 
     if (status === "approved") {
-      const projects = await loadProjects()
       const project: Project = {
         id: `proj-${Date.now()}`,
         name: suggestion.name,
@@ -87,8 +55,7 @@ export const PATCH = withRole("admin")(async (request, context) => {
         createdAt: now,
         updatedAt: now,
       }
-      projects.push(project)
-      await saveProjects(projects)
+      await createProject(project)
 
       await routeToInngest({
         name: "house-of-veritas/project.suggestion.approved",

--- a/app/api/projects/suggestions/route.ts
+++ b/app/api/projects/suggestions/route.ts
@@ -1,60 +1,16 @@
 import { NextResponse } from "next/server"
-import { withAuth, withRole } from "@/lib/auth/rbac"
-import { readFile, writeFile, mkdir } from "fs/promises"
-import { join } from "path"
-import { toStoredProjectType, type Project, type ProjectStorageType, type ScopeKind } from "@/lib/projects"
+import { withAuth } from "@/lib/auth/rbac"
+import { toStoredProjectType } from "@/lib/projects"
+import {
+  listProjectSuggestions,
+  saveProjectSuggestions,
+  type ProjectSuggestion,
+} from "@/lib/repositories/project-suggestion-repository"
 import { logger } from "@/lib/logger"
-
-const SUGGESTIONS_PATH = join(process.cwd(), "data", "project-suggestions.json")
-const PROJECTS_PATH = join(process.cwd(), "data", "projects.json")
-
-export interface ProjectSuggestion {
-  id: string
-  name: string
-  description?: string
-  type: ProjectStorageType
-  scopeKind?: ScopeKind
-  parentId?: string
-  suggestedBy: string
-  suggestedAt: string
-  status: "pending" | "approved" | "rejected"
-  reviewedBy?: string
-  reviewedAt?: string
-}
-
-async function loadSuggestions(): Promise<ProjectSuggestion[]> {
-  try {
-    const data = await readFile(SUGGESTIONS_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveSuggestions(suggestions: ProjectSuggestion[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(SUGGESTIONS_PATH, JSON.stringify(suggestions, null, 2), "utf-8")
-}
-
-async function loadProjects(): Promise<Project[]> {
-  try {
-    const data = await readFile(PROJECTS_PATH, "utf-8")
-    const parsed = JSON.parse(data)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-async function saveProjects(projects: Project[]): Promise<void> {
-  await mkdir(join(process.cwd(), "data"), { recursive: true })
-  await writeFile(PROJECTS_PATH, JSON.stringify(projects, null, 2), "utf-8")
-}
 
 export const GET = withAuth(async (request: Request) => {
   try {
-    const suggestions = await loadSuggestions()
+    const suggestions = await listProjectSuggestions()
     const { searchParams } = new URL(request.url)
     const status = searchParams.get("status")
     const filtered = status ? suggestions.filter((s) => s.status === status) : suggestions
@@ -77,7 +33,7 @@ export const POST = withAuth(async (request: Request) => {
       return NextResponse.json({ error: "name is required" }, { status: 400 })
     }
 
-    const suggestions = await loadSuggestions()
+    const suggestions = await listProjectSuggestions()
     const id = `sug-${Date.now()}`
     const storedType = toStoredProjectType(type) ?? "subproject"
     const suggestion: ProjectSuggestion = {
@@ -92,7 +48,7 @@ export const POST = withAuth(async (request: Request) => {
       status: "pending",
     }
     suggestions.push(suggestion)
-    await saveSuggestions(suggestions)
+    await saveProjectSuggestions(suggestions)
     return NextResponse.json({ suggestion })
   } catch (err) {
     logger.error("Failed to create suggestion", {

--- a/components/job-detail-page-content.tsx
+++ b/components/job-detail-page-content.tsx
@@ -20,9 +20,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { apiFetch } from "@/lib/api-client"
 import { logger } from "@/lib/logger"
 import type { Project } from "@/lib/projects"
-import type { JobArea, JobAreaKind } from "@/app/api/projects/[id]/areas/route"
-import type { GroupedJobTask } from "@/app/api/projects/[id]/task-groups/route"
-import type { JobAllocation } from "@/app/api/projects/[id]/allocations/route"
+import type { JobArea, JobAreaKind } from "@/lib/repositories/job-workspace-repository"
+import type { GroupedJobTask } from "@/lib/repositories/job-workspace-repository"
+import type { JobAllocation } from "@/lib/repositories/job-workspace-repository"
 
 const STATUS_COLORS: Record<string, string> = {
   planned: "bg-muted text-muted-foreground",

--- a/components/projects-page-content.tsx
+++ b/components/projects-page-content.tsx
@@ -40,7 +40,7 @@ import {
 import { AiSuggestIcon } from "@/components/ui/ai-suggest-icon"
 import { getStoredScopeId } from "@/components/scope-selector"
 import type { Project, ScopeKind } from "@/lib/projects"
-import type { ProjectSuggestion } from "@/app/api/projects/suggestions/route"
+import type { ProjectSuggestion } from "@/lib/repositories/project-suggestion-repository"
 import { logger } from "@/lib/logger"
 import { apiFetch } from "@/lib/api-client"
 import Image from "next/image"

--- a/docs/handoffs/2026-07-20-prod-telemetry-project-store.md
+++ b/docs/handoffs/2026-07-20-prod-telemetry-project-store.md
@@ -1,0 +1,62 @@
+# Handoff - Production telemetry and project datastore remediation
+
+- **Date:** 2026-07-20
+- **Branch:** `codex/blob-backed-project-store`
+- **PR:** #98 - `fix(prod): wire telemetry and project datastore`
+- **Status:** Ready to merge after CI; deployment still requires controlled Terraform apply and web app deploy after merge.
+- **Area:** Next.js API routes, project persistence, Azure App Service telemetry, Terraform production config
+
+## Problem
+
+Live production checks after the OIDC cutover showed three gaps:
+
+1. `nl-prod-hov-app` had no web App Insights resource or `APPLICATIONINSIGHTS_CONNECTION_STRING` app setting.
+2. Project creation used `data/projects.json` under the deployed app package. That is not a real production datastore and can fail or lose data in Azure App Service.
+3. The app reported `dataMode: empty`, but hardcoded project/job sample defaults still existed in source.
+
+## What PR #98 Changes
+
+- Adds `@azure/monitor-opentelemetry` and initializes Azure Monitor from `instrumentation.ts` when `APPLICATIONINSIGHTS_CONNECTION_STRING` is present.
+- Adds `azurerm_application_insights.webapp` in `terraform/modules/webapp/main.tf`.
+- Wires `APPLICATIONINSIGHTS_CONNECTION_STRING`, `APPINSIGHTS_INSTRUMENTATIONKEY`, and `APPLICATIONINSIGHTS_ROLE_NAME` into the web app settings.
+- Adds `lib/repositories/project-repository.ts` for project list/create persistence.
+- Changes `app/api/projects/route.ts` to use the repository for list/create instead of directly reading/writing `data/projects.json`.
+- Changes `lib/projects.ts` member project lookup to use the repository path.
+- Adds `isMongoConfigured()` in `lib/db/mongodb.ts`.
+- Enables the existing Cosmos Mongo module in `terraform/environments/production/canonical.tfvars.example` so production gets `MONGODB_URI` after apply.
+- Removes unused hardcoded defaults `House Revamp`, `Zeerust Arming`, and related default subprojects from `lib/projects.ts`.
+
+## Validation Before PR
+
+- `pnpm exec tsc --noEmit` - passed
+- `pnpm run lint` - passed
+- `pnpm exec vitest run tests/api/tasks.test.ts tests/api/job-workspace.test.ts` - passed, 10 tests
+- `pnpm run build` - passed; pre-existing Turbopack NFT warning from `app/api/files/route.ts`
+- `terraform fmt -recursive` - passed
+- `terraform -chdir=terraform/environments/production validate` - passed
+- PR #98 CI initially green with no actionable inline bot comments before this handoff commit
+
+## Deployment Needed After Merge
+
+Run both steps after PR #98 is merged:
+
+1. Controlled infrastructure apply:
+   - Workflow: `terraform-apply.yml`
+   - Ref: `main`
+   - Input: `confirm=APPLY`
+   - Expected effect: create Cosmos Mongo resources, create web App Insights, set `MONGODB_URI`, `DB_NAME`, and App Insights settings on `nl-prod-hov-app`.
+2. Web app deployment:
+   - If merge touches app/lib/package/instrumentation paths, `deploy-on-merge.yml` should run automatically.
+   - If it does not run or fails, manually dispatch the full deploy or rerun the deploy-on-merge workflow so the repository and telemetry code are live.
+
+## Post-Deploy Checks
+
+- `az webapp config appsettings list` should show non-empty `MONGODB_URI`, `DB_NAME`, and `APPLICATIONINSIGHTS_CONNECTION_STRING` for `nl-prod-hov-app`.
+- `az resource list --resource-group nl-prod-hov-rg --query "[?type=='microsoft.insights/components']"` should show the HOV web App Insights component.
+- `https://hov.neuralliquid.ai/api/health` should remain `healthy` and `dataMode: empty` unless explicit demo flags are set.
+- Create a project through the UI while signed in as admin and confirm it persists after refresh/restart.
+- Confirm visible project/job dropdowns no longer show the old hardcoded project defaults unless real records exist.
+
+## Residual Risk
+
+Only `/api/projects` list/create and member project lookup are moved to the repository in this PR. Secondary project routes for detail edits, members, suggestions, areas, allocations, and task groups still contain local JSON helpers and should be moved to repositories in a follow-up if those workflows are used in production.

--- a/docs/handoffs/2026-07-20-prod-telemetry-project-store.md
+++ b/docs/handoffs/2026-07-20-prod-telemetry-project-store.md
@@ -59,4 +59,4 @@ Run both steps after PR #98 is merged:
 
 ## Residual Risk
 
-Only `/api/projects` list/create and member project lookup are moved to the repository in this PR. Secondary project routes for detail edits, members, suggestions, areas, allocations, and task groups still contain local JSON helpers and should be moved to repositories in a follow-up if those workflows are used in production.
+Core project workflows now use repositories consistently: list/create, detail edit/delete, member changes, member lookup, and suggestion approval. Project-adjacent metadata routes for areas, allocations, and task groups still contain local JSON helpers and should be moved to durable repositories if those workflows are used in production.

--- a/docs/handoffs/2026-07-20-prod-telemetry-project-store.md
+++ b/docs/handoffs/2026-07-20-prod-telemetry-project-store.md
@@ -19,8 +19,8 @@ Live production checks after the OIDC cutover showed three gaps:
 - Adds `@azure/monitor-opentelemetry` and initializes Azure Monitor from `instrumentation.ts` when `APPLICATIONINSIGHTS_CONNECTION_STRING` is present.
 - Adds `azurerm_application_insights.webapp` in `terraform/modules/webapp/main.tf`.
 - Wires `APPLICATIONINSIGHTS_CONNECTION_STRING`, `APPINSIGHTS_INSTRUMENTATIONKEY`, and `APPLICATIONINSIGHTS_ROLE_NAME` into the web app settings.
-- Adds `lib/repositories/project-repository.ts` for project list/create persistence.
-- Changes `app/api/projects/route.ts` to use the repository for list/create instead of directly reading/writing `data/projects.json`.
+- Adds repository-backed persistence for core projects, project suggestions, and job workspace metadata (areas, allocations, task grouping).
+- Changes project routes to use repositories instead of directly reading/writing `data/projects.json`, `project-suggestions.json`, and job workspace JSON files.
 - Changes `lib/projects.ts` member project lookup to use the repository path.
 - Adds `isMongoConfigured()` in `lib/db/mongodb.ts`.
 - Enables the existing Cosmos Mongo module in `terraform/environments/production/canonical.tfvars.example` so production gets `MONGODB_URI` after apply.
@@ -59,4 +59,4 @@ Run both steps after PR #98 is merged:
 
 ## Residual Risk
 
-Core project workflows now use repositories consistently: list/create, detail edit/delete, member changes, member lookup, and suggestion approval. Project-adjacent metadata routes for areas, allocations, and task groups still contain local JSON helpers and should be moved to durable repositories if those workflows are used in production.
+Project, project suggestion, and job workspace metadata routes now go through repositories with Mongo required in real production. Local file fallback remains only for local/test/CI when `MONGODB_URI` is absent.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,10 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
+      const azureMonitor = await import("@azure/monitor-opentelemetry")
+      azureMonitor.useAzureMonitor()
+    }
+
     const { logger } = await import("@/lib/logger")
     logger.info("Next.js server starting")
   }

--- a/lib/db/mongodb.ts
+++ b/lib/db/mongodb.ts
@@ -8,6 +8,10 @@ const DB_NAME = process.env.DB_NAME || "house_of_veritas"
 let client: MongoClient | null = null
 let db: Db | null = null
 
+export function isMongoConfigured(): boolean {
+  return !!(process.env.MONGODB_URI || process.env.MONGO_URL)
+}
+
 export async function getDatabase(): Promise<Db> {
   if (db) return db
 
@@ -25,7 +29,7 @@ export async function getDatabase(): Promise<Db> {
   }
 }
 
-export async function getCollection<T extends { _id?: ObjectId }>(
+export async function getCollection<T extends object>(
   name: string
 ): Promise<Collection<T>> {
   const database = await getDatabase()

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -70,48 +70,7 @@ export function withProjectKind(project: Project): ProjectWithKind {
   }
 }
 
-export const DEFAULT_MAJOR_PROJECTS = [
-  {
-    id: "house-revamp",
-    name: "House Revamp",
-    description: "Full house renovation and improvements",
-  },
-  {
-    id: "zeerust-arming",
-    name: "Zeerust Arming",
-    description: "Security and arming at Zeerust property",
-  },
-]
-
 export async function getProjectNamesForMember(userId: string): Promise<string[]> {
-  try {
-    const { readFile } = await import("fs/promises")
-    const { join } = await import("path")
-    const data = await readFile(join(process.cwd(), "data", "projects.json"), "utf-8")
-    const projects: Project[] = JSON.parse(data)
-    if (!Array.isArray(projects)) return []
-    return projects.filter((p) => p.members?.some((m) => m.userId === userId)).map((p) => p.name)
-  } catch {
-    return []
-  }
-}
-
-export const DEFAULT_SUBPROJECTS: Record<string, { name: string; parentId: string }[]> = {
-  "house-revamp": [
-    { name: "Garage", parentId: "house-revamp" },
-    { name: "Lay Paving", parentId: "house-revamp" },
-    { name: "Paint Flat", parentId: "house-revamp" },
-    { name: "Paint Roof", parentId: "house-revamp" },
-    { name: "Kitchen Cupboards", parentId: "house-revamp" },
-    { name: "Electricity - Flat", parentId: "house-revamp" },
-    { name: "Electricity - House", parentId: "house-revamp" },
-    { name: "Garden Revamp", parentId: "house-revamp" },
-    { name: "Paint House Internal", parentId: "house-revamp" },
-    { name: "Paint House External", parentId: "house-revamp" },
-  ],
-  "zeerust-arming": [
-    { name: "Perimeter Fencing", parentId: "zeerust-arming" },
-    { name: "Alarm System", parentId: "zeerust-arming" },
-    { name: "CCTV", parentId: "zeerust-arming" },
-  ],
+  const { getProjectNamesForMemberFromStore } = await import("@/lib/repositories/project-repository")
+  return getProjectNamesForMemberFromStore(userId)
 }

--- a/lib/repositories/job-workspace-repository.ts
+++ b/lib/repositories/job-workspace-repository.ts
@@ -1,0 +1,155 @@
+import { readFile, writeFile, mkdir } from "fs/promises"
+import { dirname, join } from "path"
+import type { Filter } from "mongodb"
+import { getCollection, isMongoConfigured } from "@/lib/db/mongodb"
+import type { Task } from "@/lib/services/baserow"
+
+export type JobAreaKind = "room" | "area" | "component" | "zone"
+
+export interface JobArea {
+  id: string
+  projectId: string
+  name: string
+  kind: JobAreaKind
+  notes?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type JobAllocationType = "material" | "labour"
+
+export interface JobAllocation {
+  id: string
+  projectId: string
+  type: JobAllocationType
+  name: string
+  areaId?: string
+  quantity?: number
+  unit?: string
+  hours?: number
+  rateCents?: number
+  costCents?: number
+  notes?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface JobTaskMetadata {
+  taskId: number
+  projectId: string
+  areaId?: string
+  groupName?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface GroupedJobTask extends Task {
+  areaId?: string
+  groupName?: string
+}
+
+const DATA_DIR = join(process.cwd(), "data")
+const AREAS_FILE = join(DATA_DIR, "job-areas.json")
+const ALLOCATIONS_FILE = join(DATA_DIR, "job-allocations.json")
+const TASK_METADATA_FILE = join(DATA_DIR, "job-task-groups.json")
+
+const AREAS_COLLECTION = "job_areas"
+const ALLOCATIONS_COLLECTION = "job_allocations"
+const TASK_METADATA_COLLECTION = "job_task_metadata"
+
+function requireProductionStore(): void {
+  if (process.env.NODE_ENV === "production" && process.env.CI !== "true" && !isMongoConfigured()) {
+    throw new Error("Job workspace datastore is not configured. Set MONGODB_URI for production.")
+  }
+}
+
+async function readJsonArray<T>(path: string): Promise<T[]> {
+  try {
+    const data = await readFile(path, "utf-8")
+    const parsed = JSON.parse(data)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+async function writeJsonArray<T>(path: string, items: T[]): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, JSON.stringify(items, null, 2), "utf-8")
+}
+
+export async function listJobAreas(projectId: string): Promise<JobArea[]> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const areas = await readJsonArray<JobArea>(AREAS_FILE)
+    return areas.filter((area) => area.projectId === projectId)
+  }
+
+  const collection = await getCollection<JobArea>(AREAS_COLLECTION)
+  return collection.find({ projectId } as Filter<JobArea>).sort({ createdAt: 1 }).toArray()
+}
+
+export async function createJobArea(area: JobArea): Promise<JobArea> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const areas = await readJsonArray<JobArea>(AREAS_FILE)
+    areas.push(area)
+    await writeJsonArray(AREAS_FILE, areas)
+    return area
+  }
+
+  const collection = await getCollection<JobArea>(AREAS_COLLECTION)
+  await collection.insertOne(area)
+  return area
+}
+
+export async function listJobAllocations(projectId: string, type?: JobAllocationType): Promise<JobAllocation[]> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const allocations = await readJsonArray<JobAllocation>(ALLOCATIONS_FILE)
+    return allocations.filter((allocation) => allocation.projectId === projectId && (!type || allocation.type === type))
+  }
+
+  const query: Filter<JobAllocation> = type ? { projectId, type } : { projectId }
+  const collection = await getCollection<JobAllocation>(ALLOCATIONS_COLLECTION)
+  return collection.find(query).sort({ createdAt: 1 }).toArray()
+}
+
+export async function createJobAllocation(allocation: JobAllocation): Promise<JobAllocation> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const allocations = await readJsonArray<JobAllocation>(ALLOCATIONS_FILE)
+    allocations.push(allocation)
+    await writeJsonArray(ALLOCATIONS_FILE, allocations)
+    return allocation
+  }
+
+  const collection = await getCollection<JobAllocation>(ALLOCATIONS_COLLECTION)
+  await collection.insertOne(allocation)
+  return allocation
+}
+
+export async function listJobTaskMetadata(projectId: string): Promise<JobTaskMetadata[]> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const metadata = await readJsonArray<JobTaskMetadata>(TASK_METADATA_FILE)
+    return metadata.filter((item) => item.projectId === projectId)
+  }
+
+  const collection = await getCollection<JobTaskMetadata>(TASK_METADATA_COLLECTION)
+  return collection.find({ projectId } as Filter<JobTaskMetadata>).sort({ createdAt: 1 }).toArray()
+}
+
+export async function createJobTaskMetadata(metadata: JobTaskMetadata): Promise<JobTaskMetadata> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const items = await readJsonArray<JobTaskMetadata>(TASK_METADATA_FILE)
+    items.push(metadata)
+    await writeJsonArray(TASK_METADATA_FILE, items)
+    return metadata
+  }
+
+  const collection = await getCollection<JobTaskMetadata>(TASK_METADATA_COLLECTION)
+  await collection.insertOne(metadata)
+  return metadata
+}

--- a/lib/repositories/project-repository.ts
+++ b/lib/repositories/project-repository.ts
@@ -10,7 +10,7 @@ const PROJECTS_COLLECTION = "projects"
 type ProjectDocument = Project
 
 function requireProductionStore(): void {
-  if (process.env.NODE_ENV === "production" && !isMongoConfigured()) {
+  if (process.env.NODE_ENV === "production" && process.env.CI !== "true" && !isMongoConfigured()) {
     throw new Error("Project datastore is not configured. Set MONGODB_URI for production.")
   }
 }
@@ -30,17 +30,23 @@ async function writeFileProjects(projects: Project[]): Promise<void> {
   await writeFile(PROJECTS_FILE, JSON.stringify(projects, null, 2), "utf-8")
 }
 
-function toProject(doc: ProjectDocument): Project {
-  return doc
-}
-
 export async function listProjects(): Promise<Project[]> {
   requireProductionStore()
   if (!isMongoConfigured()) return readFileProjects()
 
   const collection = await getCollection<ProjectDocument>(PROJECTS_COLLECTION)
-  const docs = await collection.find({}).sort({ createdAt: 1 }).toArray()
-  return docs.map(toProject)
+  return collection.find({}).sort({ createdAt: 1 }).toArray()
+}
+
+export async function findProjectById(id: string): Promise<Project | null> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const projects = await readFileProjects()
+    return projects.find((project) => project.id === id) ?? null
+  }
+
+  const collection = await getCollection<ProjectDocument>(PROJECTS_COLLECTION)
+  return collection.findOne({ id } as Filter<ProjectDocument>)
 }
 
 export async function createProject(project: Project): Promise<Project> {
@@ -57,8 +63,38 @@ export async function createProject(project: Project): Promise<Project> {
   return project
 }
 
+export async function replaceProject(project: Project): Promise<Project | null> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const projects = await readFileProjects()
+    const index = projects.findIndex((item) => item.id === project.id)
+    if (index === -1) return null
+    projects[index] = project
+    await writeFileProjects(projects)
+    return project
+  }
+
+  const collection = await getCollection<ProjectDocument>(PROJECTS_COLLECTION)
+  const result = await collection.replaceOne({ id: project.id } as Filter<ProjectDocument>, project)
+  return result.matchedCount > 0 ? project : null
+}
+
+export async function deleteProject(id: string): Promise<boolean> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const projects = await readFileProjects()
+    const filtered = projects.filter((project) => project.id !== id)
+    if (filtered.length === projects.length) return false
+    await writeFileProjects(filtered)
+    return true
+  }
+
+  const collection = await getCollection<ProjectDocument>(PROJECTS_COLLECTION)
+  const result = await collection.deleteOne({ id } as Filter<ProjectDocument>)
+  return result.deletedCount === 1
+}
+
 export async function getProjectNamesForMemberFromStore(userId: string): Promise<string[]> {
   const projects = await listProjects()
   return projects.filter((project) => project.members?.some((member) => member.userId === userId)).map((project) => project.name)
 }
-

--- a/lib/repositories/project-repository.ts
+++ b/lib/repositories/project-repository.ts
@@ -1,0 +1,64 @@
+import { readFile, writeFile, mkdir } from "fs/promises"
+import { dirname, join } from "path"
+import type { Filter } from "mongodb"
+import { getCollection, isMongoConfigured } from "@/lib/db/mongodb"
+import type { Project } from "@/lib/projects"
+
+const PROJECTS_FILE = join(process.cwd(), "data", "projects.json")
+const PROJECTS_COLLECTION = "projects"
+
+type ProjectDocument = Project
+
+function requireProductionStore(): void {
+  if (process.env.NODE_ENV === "production" && !isMongoConfigured()) {
+    throw new Error("Project datastore is not configured. Set MONGODB_URI for production.")
+  }
+}
+
+async function readFileProjects(): Promise<Project[]> {
+  try {
+    const data = await readFile(PROJECTS_FILE, "utf-8")
+    const parsed = JSON.parse(data)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+async function writeFileProjects(projects: Project[]): Promise<void> {
+  await mkdir(dirname(PROJECTS_FILE), { recursive: true })
+  await writeFile(PROJECTS_FILE, JSON.stringify(projects, null, 2), "utf-8")
+}
+
+function toProject(doc: ProjectDocument): Project {
+  return doc
+}
+
+export async function listProjects(): Promise<Project[]> {
+  requireProductionStore()
+  if (!isMongoConfigured()) return readFileProjects()
+
+  const collection = await getCollection<ProjectDocument>(PROJECTS_COLLECTION)
+  const docs = await collection.find({}).sort({ createdAt: 1 }).toArray()
+  return docs.map(toProject)
+}
+
+export async function createProject(project: Project): Promise<Project> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const projects = await readFileProjects()
+    projects.push(project)
+    await writeFileProjects(projects)
+    return project
+  }
+
+  const collection = await getCollection<ProjectDocument>(PROJECTS_COLLECTION)
+  await collection.insertOne(project)
+  return project
+}
+
+export async function getProjectNamesForMemberFromStore(userId: string): Promise<string[]> {
+  const projects = await listProjects()
+  return projects.filter((project) => project.members?.some((member) => member.userId === userId)).map((project) => project.name)
+}
+

--- a/lib/repositories/project-suggestion-repository.ts
+++ b/lib/repositories/project-suggestion-repository.ts
@@ -1,0 +1,62 @@
+import { readFile, writeFile, mkdir } from "fs/promises"
+import { dirname, join } from "path"
+import { getCollection, isMongoConfigured } from "@/lib/db/mongodb"
+import type { ProjectStorageType, ScopeKind } from "@/lib/projects"
+
+const SUGGESTIONS_FILE = join(process.cwd(), "data", "project-suggestions.json")
+const SUGGESTIONS_COLLECTION = "project_suggestions"
+
+export interface ProjectSuggestion {
+  id: string
+  name: string
+  description?: string
+  type: ProjectStorageType
+  scopeKind?: ScopeKind
+  parentId?: string
+  suggestedBy: string
+  suggestedAt: string
+  status: "pending" | "approved" | "rejected"
+  reviewedBy?: string
+  reviewedAt?: string
+}
+
+function requireProductionStore(): void {
+  if (process.env.NODE_ENV === "production" && process.env.CI !== "true" && !isMongoConfigured()) {
+    throw new Error("Project suggestion datastore is not configured. Set MONGODB_URI for production.")
+  }
+}
+
+async function readFileSuggestions(): Promise<ProjectSuggestion[]> {
+  try {
+    const data = await readFile(SUGGESTIONS_FILE, "utf-8")
+    const parsed = JSON.parse(data)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+async function writeFileSuggestions(suggestions: ProjectSuggestion[]): Promise<void> {
+  await mkdir(dirname(SUGGESTIONS_FILE), { recursive: true })
+  await writeFile(SUGGESTIONS_FILE, JSON.stringify(suggestions, null, 2), "utf-8")
+}
+
+export async function listProjectSuggestions(): Promise<ProjectSuggestion[]> {
+  requireProductionStore()
+  if (!isMongoConfigured()) return readFileSuggestions()
+
+  const collection = await getCollection<ProjectSuggestion>(SUGGESTIONS_COLLECTION)
+  return collection.find({}).sort({ suggestedAt: 1 }).toArray()
+}
+
+export async function saveProjectSuggestions(suggestions: ProjectSuggestion[]): Promise<void> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    await writeFileSuggestions(suggestions)
+    return
+  }
+
+  const collection = await getCollection<ProjectSuggestion>(SUGGESTIONS_COLLECTION)
+  await collection.deleteMany({})
+  if (suggestions.length > 0) await collection.insertMany(suggestions)
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@azure/communication-email": "^1.1.0",
+    "@azure/monitor-opentelemetry": "^1.18.2",
     "@azure/storage-blob": "^12.31.0",
     "@emotion/is-prop-valid": "latest",
     "@hookform/resolvers": "^3.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@azure/communication-email':
         specifier: ^1.1.0
         version: 1.1.0
+      '@azure/monitor-opentelemetry':
+        specifier: ^1.18.2
+        version: 1.18.2
       '@azure/storage-blob':
         specifier: ^12.31.0
         version: 12.31.0
@@ -130,7 +133,7 @@ importers:
         version: 2.3.8
       inngest:
         specifier: ^3.54.0
-        version: 3.54.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(zod@3.25.76)
+        version: 3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(zod@3.25.76)
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -356,6 +359,18 @@ packages:
     resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
     engines: {node: '>=20.0.0'}
 
+  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.43':
+    resolution: {integrity: sha512-551lMY6gSf7TO+j15nmQ23+nG9fExb664TH9RDs9zUul1xHt3NUtfsZe90nNhOzMEeg+I1f7zn955dvH5o6yjA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/monitor-opentelemetry@1.18.2':
+    resolution: {integrity: sha512-Alk3qvFew2HAq+PEe/TPlbIOMOX+VivEDF8U7JfBpkqYVACdw5Ae5TbhS5SnXvREnmO/FmkfGqf8ILgOD77Row==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/opentelemetry-instrumentation-azure-sdk@1.1.0-beta.1':
+    resolution: {integrity: sha512-FJCHWlMA//XMs5rxf1z/mN0gaWPbJhlAVw5l4IxKhEtZX2bgNERlqbdBWXNjjkok+nTh0UcKqV5G0rrCupo+4A==}
+    engines: {node: '>=20.0.0'}
+
   '@azure/storage-blob@12.31.0':
     resolution: {integrity: sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==}
     engines: {node: '>=20.0.0'}
@@ -453,6 +468,10 @@ packages:
 
   '@bufbuild/protobuf@2.12.0':
     resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
+
+  '@colors/colors@1.6.0':
+    resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
+    engines: {node: '>=0.1.90'}
 
   '@cspell/cspell-bundled-dicts@9.6.4':
     resolution: {integrity: sha512-OIiPQuB7XQ6rnUv4KaCwHr9vNwbh6VZ4GfgQjcThT0oz0hkL6E5Ar3tq54K9jyqE9ylcHqpRuXUgnKgio6Hlig==}
@@ -1126,6 +1145,9 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@microsoft/applicationinsights-web-snippet@1.2.3':
+    resolution: {integrity: sha512-59ex4x1/PabGQIg+o0GKG5olqAJYBvMOiXec/9HCD3hK2y36YMWT0ivq5mequvtS5+21kco3SOnMB6QyScLPIA==}
+
   '@mongodb-js/saslprep@1.4.6':
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
 
@@ -1213,8 +1235,16 @@ packages:
     resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.211.0':
+    resolution: {integrity: sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.217.0':
     resolution: {integrity: sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.219.0':
+    resolution: {integrity: sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
@@ -1234,8 +1264,26 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
+  '@opentelemetry/configuration@0.219.0':
+    resolution: {integrity: sha512-wXZUYv4ngu43nA4WEhuXNacm46LW+17LRM8nKyIhBzroRA24PBYjMnakwzR/w777nFUB5xlgsYTTeuXxumZM1Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@opentelemetry/context-async-hooks@2.7.1':
     resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/context-async-hooks@2.8.0':
+    resolution: {integrity: sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/context-async-hooks@2.9.0':
+    resolution: {integrity: sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -1246,8 +1294,26 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/core@2.8.0':
+    resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/exporter-logs-otlp-grpc@0.217.0':
     resolution: {integrity: sha512-vC5S0Dc+noxD86CVtNu1+awCHPA5Kewi1Sg23ps+9lh4YifwsKXh3pe4XTNEKtUJiAcjpJ5dqStGakLbrSE+YQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.219.0':
+    resolution: {integrity: sha512-7SvzDCIclHWAcCwZ1MTOLcwn4BVNPGI3QxS/DJraPNe1TTL+4TvUBq5zeQV8tsnYvtDN7wKW2qocVmaCP2l7sQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1258,8 +1324,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-logs-otlp-http@0.219.0':
+    resolution: {integrity: sha512-mhl2HL6GmZI8b8PwPfqMws/5ovJfbRTxwc9Y5agVVHiQ+e5SL1btsFr/kJDgt7YCexDtsUn5HAreHQO9szFS0A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-logs-otlp-proto@0.217.0':
     resolution: {integrity: sha512-Se0GG/ZO24mQTlQj7zprR4pNI0nKe4lPDPBsuJmi6508b9TlZEuUd3EfyuHk6oJxzL7fGyDFYAbxNigQvRP2ZQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.219.0':
+    resolution: {integrity: sha512-Ayw4Gf71PS9jhBVaYywa4WsajnqfDehMkTdVH3TSAVHqPcsAv/AhH/wTNRYNt99szeYr6Gbd/D6RjZD77wAxHg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1270,8 +1348,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.219.0':
+    resolution: {integrity: sha512-6LaaSrPxK5L55bXevWajvOMxGOpNm0n12tG53TeZaUeNzXwLPg6d2KCC1zAlGsojan+xRG71mA4Qqs9K2VVrKQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-metrics-otlp-http@0.217.0':
     resolution: {integrity: sha512-1zkMzzhiNJdVmLxuwkltqWGw4fOOam47bqRxmuQNjyKJe/9NmY5cIrZ4kiQV7sVGxoOgT0ZvGUfLcjvtpC/b9Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.219.0':
+    resolution: {integrity: sha512-6CaDRbMVHZSDWzNXwrR8y/H4B/Z1eMNnkHiPQlTx3Ojz2OHY4X/aff/UC4P/3pHUQSuTfi3oh2UsPPZppw+Vrg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1282,8 +1372,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-metrics-otlp-proto@0.219.0':
+    resolution: {integrity: sha512-DUS7XyIiEnoeccQUvuKy0G2/YqeKhpN8FVIrGbrLNIVMj10yeIFLRzRv0tibCI2kXXvlTTABVexGAk78wHk2ug==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-prometheus@0.217.0':
     resolution: {integrity: sha512-U9MCXxJu0sBCh5aEkylYRR4xVIL8D1CW6dGwvYXbfFr0qveSorfD0XJchCAWoW6QfAAIcY/yxjf4Dj8OgkHBPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.219.0':
+    resolution: {integrity: sha512-TxOnJ85eWJY5JyOJsNMXiRTYlkDcOv0u3KbXEzWCc+tUS9sjL/BC6BcdxZ0B9r2OFVqsrZFXUzSD2sZUy42Ucw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1294,8 +1396,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-trace-otlp-grpc@0.219.0':
+    resolution: {integrity: sha512-BkDNv1UD6BscW19MxbAxVmSYSSFuyeqR6buV2/HTYqA7GrR0EbTFzqG6h86T3PtXmpdbsWjMGLDdjG2rikG27Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-trace-otlp-http@0.217.0':
     resolution: {integrity: sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.219.0':
+    resolution: {integrity: sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1306,8 +1420,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-trace-otlp-proto@0.219.0':
+    resolution: {integrity: sha512-lF/LUBfhOFmxJa+SQsLN7ziV4MHa2pyKgOM6JNehSOfU+npjM4gwm9oIKEJrzrWcexMcqydiyoFy0XCb1Ql3wQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-zipkin@2.7.1':
     resolution: {integrity: sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/exporter-zipkin@2.8.0':
+    resolution: {integrity: sha512-Mj84UkEa17BK2o903VTXW3wM8CrSZexGs4tRGVZVIMM9ni1T6TuGx5IrRfoWKAbshx42D5/kc7YV+axypLPYyA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
@@ -1404,6 +1530,12 @@ packages:
 
   '@opentelemetry/instrumentation-http@0.217.0':
     resolution: {integrity: sha512-B88Y7k5A9a60pHUboFoeJlgVwXq2T0rsZKj6dTwzSMKSOsNXR4Jz5ovwprVn3kHLAZrkyLEjQtBJ34DYHs1U4Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.219.0':
+    resolution: {integrity: sha512-nNt1fqpyah/OKjNHdEOu8xLwISppRU2qJuF8aR+fCcftVwdFkPgtworBLA+TI1HU2iF508jcQBF2gerWczJAXg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1558,8 +1690,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation@0.211.0':
+    resolution: {integrity: sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation@0.217.0':
     resolution: {integrity: sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.219.0':
+    resolution: {integrity: sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1570,8 +1714,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.219.0':
+    resolution: {integrity: sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-grpc-exporter-base@0.217.0':
     resolution: {integrity: sha512-7RTAdZuOsCDnsyqTCG4+bDzrfnsWdzkRs7z0AVi/V3tEQx0oKeyc+OuRWYxnRsmaJXgxcmB8vb/lfxn58Dj6Ag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.219.0':
+    resolution: {integrity: sha512-iIk/s8QQu39zpTrRRmsW/Eg3SE2+Hg8tLWepr2FLRgmwUpNd0IpCTLJEHJ77hpt4hgIS8MAh44UYI4xQPZwWlw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1582,14 +1738,32 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-transformer@0.219.0':
+    resolution: {integrity: sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/propagator-b3@2.7.1':
     resolution: {integrity: sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/propagator-b3@2.8.0':
+    resolution: {integrity: sha512-SazlvuSKi5533rPHTW2TwBwdMakhjZST4SYs0YauuvfGDkT13KbG1gJS75hV0uWVeevhtVP9sAIlaZLTHdSbMg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/propagator-jaeger@2.7.1':
     resolution: {integrity: sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.8.0':
+    resolution: {integrity: sha512-Xnz9zZvvQzUw+9DrOn0MomR7BxFCkA2pcfXBQuHC28ndJpSbjLs7knzYb05kw5SyCjSsEWombkZMgGcJSk8JVg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -1634,8 +1808,26 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
+  '@opentelemetry/resources@2.8.0':
+    resolution: {integrity: sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.9.0':
+    resolution: {integrity: sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/sdk-logs@0.217.0':
     resolution: {integrity: sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.219.0':
+    resolution: {integrity: sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
@@ -1646,8 +1838,26 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
+  '@opentelemetry/sdk-metrics@2.8.0':
+    resolution: {integrity: sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.9.0':
+    resolution: {integrity: sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
   '@opentelemetry/sdk-node@0.217.0':
     resolution: {integrity: sha512-K/60pSv42+NQiZKy1pAH18nYDkxltsDV4O3SJ233J0E9raU1ksyL9gsKuS8p30bYBb4AMPCfDuutHQaHYpcv0Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.219.0':
+    resolution: {integrity: sha512-NWLpWLEb8gV3+JBHYoIrktbM385wyHpRJoh3J/4Q52d4PR+AlPMNGJT3DzBUrDSUEVbKAXoHR+EDAPxtiNcj8g==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -1658,11 +1868,47 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
+  '@opentelemetry/sdk-trace-base@2.8.0':
+    resolution: {integrity: sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.9.0':
+    resolution: {integrity: sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-node@2.7.1':
     resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.8.0':
+    resolution: {integrity: sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.9.0':
+    resolution: {integrity: sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-web@2.9.0':
+    resolution: {integrity: sha512-LS4XlzOK3e6YYdt84m15AmRR04121rKipmifi4XFZToH1h75f7F2bzHLbB1NMgIEYJ0jSKYm4VsK5mws/5kfTQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.9.0':
+    resolution: {integrity: sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
@@ -1673,6 +1919,10 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
+
+  '@opentelemetry/winston-transport@0.27.0':
+    resolution: {integrity: sha512-Imeoqm9CqxSJRo6INwtOn1Kx2XXYZzkyrH6q2teIDJ7ZypKx7DRf23l5ylQZ3vYibkcCLIANbzpeMqCNPp4CEw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
@@ -2705,6 +2955,9 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
+  '@types/triple-beam@1.3.5':
+    resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -3680,6 +3933,9 @@ packages:
       picomatch:
         optional: true
 
+  fecha@4.2.3:
+    resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -3925,6 +4181,9 @@ packages:
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
+  import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
 
   import-in-the-middle@3.0.1:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
@@ -4356,6 +4615,10 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  logform@2.7.0:
+    resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
+    engines: {node: '>= 12.0.0'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -4919,6 +5182,10 @@ packages:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
@@ -5025,6 +5292,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -5168,6 +5439,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@5.2.0:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
     engines: {node: '>=6'}
@@ -5277,6 +5551,10 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  triple-beam@1.4.1:
+    resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
+    engines: {node: '>= 14.0.0'}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -5375,6 +5653,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
@@ -5516,6 +5797,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  winston-transport@4.9.0:
+    resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
+    engines: {node: '>= 12.0.0'}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -5718,6 +6003,71 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.43':
+    dependencies:
+      '@azure-rest/core-client': 2.6.0
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-util': 1.13.1
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/monitor-opentelemetry@1.18.2':
+    dependencies:
+      '@azure-rest/core-client': 2.6.0
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/logger': 1.3.0
+      '@azure/monitor-opentelemetry-exporter': 1.0.0-beta.43
+      '@azure/opentelemetry-instrumentation-azure-sdk': 1.1.0-beta.1
+      '@microsoft/applicationinsights-web-snippet': 1.2.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-bunyan': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.70.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.63.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.69.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.65.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-winston': 0.61.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-azure': 0.25.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/winston-transport': 0.27.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/opentelemetry-instrumentation-azure-sdk@1.1.0-beta.1':
+    dependencies:
+      '@azure/core-tracing': 1.3.1
+      '@azure/logger': 1.3.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.9.0(@opentelemetry/api@1.9.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@azure/storage-blob@12.31.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
@@ -5867,6 +6217,8 @@ snapshots:
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@bufbuild/protobuf@2.12.0': {}
+
+  '@colors/colors@1.6.0': {}
 
   '@cspell/cspell-bundled-dicts@9.6.4':
     dependencies:
@@ -6409,6 +6761,8 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@microsoft/applicationinsights-web-snippet@1.2.3': {}
+
   '@mongodb-js/saslprep@1.4.6':
     dependencies:
       sparse-bitfield: 3.0.3
@@ -6470,16 +6824,24 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.211.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api-logs@0.217.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.219.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/auto-instrumentations-node@0.75.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))':
+  '@opentelemetry/auto-instrumentations-node@0.75.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-amqplib': 0.64.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-aws-lambda': 0.69.0(@opentelemetry/api@1.9.1)
@@ -6537,11 +6899,35 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       yaml: 2.8.4
 
+  '@opentelemetry/configuration@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      yaml: 2.8.4
+
   '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/context-async-hooks@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -6556,6 +6942,16 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-logs-otlp-grpc@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-logs-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -6564,6 +6960,15 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-logs-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -6575,6 +6980,17 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -6588,6 +7004,18 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-metrics-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -6596,6 +7024,15 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-metrics-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -6607,12 +7044,30 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-metrics-otlp-proto@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-prometheus@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-prometheus@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
@@ -6626,6 +7081,17 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-trace-otlp-grpc@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -6634,6 +7100,15 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -6644,12 +7119,29 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-zipkin@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-zipkin@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/instrumentation-amqplib@0.64.0(@opentelemetry/api@1.9.1)':
@@ -6786,6 +7278,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-http@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-ioredis@0.65.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -6908,7 +7410,7 @@ snapshots:
   '@opentelemetry/instrumentation-pg@0.69.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
@@ -7001,10 +7503,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.211.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
       import-in-the-middle: 3.0.1
       require-in-the-middle: 8.0.1
     transitivePeerDependencies:
@@ -7016,6 +7536,12 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/otlp-exporter-base@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/otlp-grpc-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
@@ -7023,6 +7549,14 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-transformer@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7035,15 +7569,35 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       protobufjs: 8.0.1
 
+  '@opentelemetry/otlp-transformer@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/propagator-b3@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/propagator-jaeger@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/redis-common@0.38.3': {}
 
@@ -7063,8 +7617,8 @@ snapshots:
   '@opentelemetry/resource-detector-azure@0.25.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/resource-detector-container@0.8.8(@opentelemetry/api@1.9.1)':
@@ -7088,6 +7642,18 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
+  '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@opentelemetry/sdk-logs@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -7096,11 +7662,31 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
+  '@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-node@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7133,11 +7719,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/sdk-node@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/configuration': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1)':
@@ -7147,12 +7780,44 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-node@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-web@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@opentelemetry/semantic-conventions@1.40.0': {}
 
   '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/winston-transport@0.27.0':
+    dependencies:
+      '@opentelemetry/api-logs': 0.217.0
+      winston-transport: 4.9.0
 
   '@panva/hkdf@1.2.1': {}
 
@@ -8156,6 +8821,8 @@ snapshots:
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 22.19.11
+
+  '@types/triple-beam@1.3.5': {}
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -9367,6 +10034,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fecha@4.2.3: {}
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -9622,6 +10291,13 @@ snapshots:
       cjs-module-lexer: 1.4.3
       module-details-from-path: 1.0.4
 
+  import-in-the-middle@2.0.6:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   import-in-the-middle@3.0.1:
     dependencies:
       acorn: 8.16.0
@@ -9639,13 +10315,13 @@ snapshots:
 
   ini@4.1.1: {}
 
-  inngest@3.54.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(zod@3.25.76):
+  inngest@3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@bufbuild/protobuf': 2.12.0
       '@inngest/ai': 0.1.7
       '@jpwilliams/waitgroup': 2.1.1
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/auto-instrumentations-node': 0.75.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))
+      '@opentelemetry/auto-instrumentations-node': 0.75.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
@@ -10025,6 +10701,15 @@ snapshots:
   lodash.once@4.1.1: {}
 
   lodash@4.18.1: {}
+
+  logform@2.7.0:
+    dependencies:
+      '@colors/colors': 1.6.0
+      '@types/triple-beam': 1.3.5
+      fecha: 4.2.3
+      ms: 2.1.3
+      safe-stable-stringify: 2.5.0
+      triple-beam: 1.4.1
 
   long@5.3.2: {}
 
@@ -10499,6 +11184,12 @@ snapshots:
 
   react@19.2.0: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   recharts-scale@0.4.5:
     dependencies:
       decimal.js-light: 2.5.1
@@ -10657,6 +11348,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safe-stable-stringify@2.5.0: {}
 
   scheduler@0.27.0: {}
 
@@ -10851,6 +11544,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@5.2.0:
     dependencies:
       ansi-regex: 4.1.1
@@ -10935,6 +11632,8 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  triple-beam@1.4.1: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -11077,6 +11776,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:
       react: 19.2.0
+
+  util-deprecate@1.0.2: {}
 
   utrie@1.0.2:
     dependencies:
@@ -11224,6 +11925,12 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  winston-transport@4.9.0:
+    dependencies:
+      logform: 2.7.0
+      readable-stream: 3.6.2
+      triple-beam: 1.4.1
 
   word-wrap@1.2.5: {}
 

--- a/terraform/environments/production/canonical.tfvars.example
+++ b/terraform/environments/production/canonical.tfvars.example
@@ -33,7 +33,7 @@ functions_storage_account_name   = "nlprodhovfuncst"
 cosmos_enable_free_tier = true
 
 # Cost-control switches for the initial canonical stack.
-enable_cosmos_mongo          = false
+enable_cosmos_mongo          = true
 enable_database              = false
 enable_operational_services  = false
 enable_application_gateway   = false

--- a/terraform/modules/webapp/main.tf
+++ b/terraform/modules/webapp/main.tf
@@ -30,6 +30,15 @@ resource "azurerm_service_plan" "webapp" {
   tags = var.tags
 }
 
+resource "azurerm_application_insights" "webapp" {
+  name                = "${var.web_app_name}-insights"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  application_type    = "web"
+
+  tags = var.tags
+}
+
 resource "azurerm_linux_web_app" "main" {
   name                = var.web_app_name
   resource_group_name = var.resource_group_name
@@ -99,9 +108,12 @@ resource "azurerm_linux_web_app" "main" {
     AUTH_SECRET = var.jwt_secret
     JWT_SECRET  = var.jwt_secret
 
-    AZURE_STORAGE_CONNECTION_STRING = var.storage_connection_string
-    DOCUMENT_INTELLIGENCE_ENDPOINT  = var.document_intelligence_endpoint
-    DOCUMENT_INTELLIGENCE_KEY       = var.document_intelligence_key
+    AZURE_STORAGE_CONNECTION_STRING       = var.storage_connection_string
+    DOCUMENT_INTELLIGENCE_ENDPOINT        = var.document_intelligence_endpoint
+    DOCUMENT_INTELLIGENCE_KEY             = var.document_intelligence_key
+    APPLICATIONINSIGHTS_CONNECTION_STRING = azurerm_application_insights.webapp.connection_string
+    APPINSIGHTS_INSTRUMENTATIONKEY        = azurerm_application_insights.webapp.instrumentation_key
+    APPLICATIONINSIGHTS_ROLE_NAME         = var.web_app_name
   }, local.auth_app_settings, var.extra_app_settings)
 
   identity {


### PR DESCRIPTION
## Summary
- Add web App Insights wiring for the Next.js App Service through Terraform and initialize Azure Monitor telemetry when the connection string exists.
- Move the core project list/create API behind a repository that requires Mongo/Cosmos in production and keeps JSON file fallback only for non-production dev/tests.
- Remove unused hardcoded default project/job seeds from the shared project model.
- Enable the existing Cosmos Mongo module in canonical production tfvars so MONGODB_URI is populated after controlled Terraform apply.

## Live findings addressed
- 
l-prod-hov-rg had no HOV App Insights component and 
l-prod-hov-app had no App Insights app setting.
- MONGODB_URI was empty in production, while /api/projects wrote to data/projects.json.
- Health was dataMode: empty, but hardcoded project defaults still existed in source.

## Validation
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm exec vitest run tests/api/tasks.test.ts tests/api/job-workspace.test.ts
- pnpm run build (passes; pre-existing Turbopack NFT warning from pp/api/files/route.ts)
- 	erraform fmt -recursive
- 	erraform -chdir=terraform/environments/production validate

## Deployment note
After merge, production needs both:
1. controlled 	erraform-apply.yml to create Cosmos/App Insights and set app settings;
2. web app deploy so the repository/instrumentation code is running.