### PR TITLE
fix(terraform): enable production project datastore

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -44,14 +44,16 @@ resource "azurerm_resource_group" "main" {
 module "network" {
   source = "../../modules/network"
 
-  resource_group_name     = azurerm_resource_group.main.name
-  location                = azurerm_resource_group.main.location
-  environment             = var.environment
-  vnet_name               = var.vnet_name
-  vnet_address_space      = var.vnet_address_space
-  gateway_subnet_prefix   = var.gateway_subnet_prefix
-  container_subnet_prefix = var.container_subnet_prefix
-  database_subnet_prefix  = var.database_subnet_prefix
+  resource_group_name            = azurerm_resource_group.main.name
+  location                       = azurerm_resource_group.main.location
+  environment                    = var.environment
+  vnet_name                      = var.vnet_name
+  vnet_address_space             = var.vnet_address_space
+  gateway_subnet_prefix          = var.gateway_subnet_prefix
+  container_subnet_prefix        = var.container_subnet_prefix
+  database_subnet_prefix         = var.database_subnet_prefix
+  app_service_subnet_prefix      = var.app_service_subnet_prefix
+  private_endpoint_subnet_prefix = var.private_endpoint_subnet_prefix
 
   tags = local.common_tags
 }
@@ -120,6 +122,8 @@ module "cosmos_mongo" {
   mongo_collection_name         = var.cosmos_mongo_collection_name
   throughput                    = var.cosmos_mongo_throughput
   public_network_access_enabled = var.cosmos_public_network_access_enabled
+  private_endpoint_subnet_id    = module.network.private_endpoint_subnet_id
+  vnet_id                       = module.network.vnet_id
   enable_free_tier              = var.cosmos_enable_free_tier
 
   tags = local.common_tags
@@ -239,6 +243,7 @@ module "webapp" {
   mystira_oidc_client_secret                       = var.mystira_oidc_client_secret
   mystira_oidc_client_secret_key_vault_secret_name = var.mystira_oidc_client_secret_key_vault_secret_name
   auth_url                                         = var.auth_url
+  app_service_subnet_id                            = module.network.app_service_subnet_id
   storage_connection_string                        = module.storage.storage_account_primary_connection_string
   baserow_api_token                                = var.baserow_api_token
   baserow_database_id                              = var.baserow_database_id

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -64,6 +64,17 @@ variable "database_subnet_prefix" {
   type        = string
   default     = "10.0.3.0/24"
 }
+variable "app_service_subnet_prefix" {
+  description = "App Service integration subnet prefix"
+  type        = string
+  default     = "10.0.4.0/24"
+}
+
+variable "private_endpoint_subnet_prefix" {
+  description = "Private endpoint subnet prefix"
+  type        = string
+  default     = "10.0.5.0/24"
+}
 
 
 # Storage variables
@@ -165,7 +176,7 @@ variable "cosmos_mongo_throughput" {
 variable "cosmos_public_network_access_enabled" {
   description = "Enable public network access for Cosmos DB"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "cosmos_enable_free_tier" {
@@ -177,7 +188,7 @@ variable "cosmos_enable_free_tier" {
 variable "enable_cosmos_mongo" {
   description = "Whether to provision Cosmos DB Mongo resources"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_database" {

--- a/terraform/modules/cosmosdb-mongo/main.tf
+++ b/terraform/modules/cosmosdb-mongo/main.tf
@@ -23,6 +23,47 @@ resource "azurerm_cosmosdb_account" "main" {
   tags = var.tags
 }
 
+resource "azurerm_private_dns_zone" "mongo" {
+  count               = var.public_network_access_enabled ? 0 : 1
+  name                = var.private_dns_zone_name
+  resource_group_name = var.resource_group_name
+
+  tags = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "mongo" {
+  count                 = var.public_network_access_enabled ? 0 : 1
+  name                  = "${var.account_name}-mongo-dns-link"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.mongo[0].name
+  virtual_network_id    = var.vnet_id
+  registration_enabled  = false
+
+  tags = var.tags
+}
+
+resource "azurerm_private_endpoint" "mongo" {
+  count               = var.public_network_access_enabled ? 0 : 1
+  name                = "${var.account_name}-pe"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.private_endpoint_subnet_id
+
+  private_service_connection {
+    name                           = "${var.account_name}-mongo-psc"
+    private_connection_resource_id = azurerm_cosmosdb_account.main.id
+    is_manual_connection           = false
+    subresource_names              = ["MongoDB"]
+  }
+
+  private_dns_zone_group {
+    name                 = "mongo"
+    private_dns_zone_ids = [azurerm_private_dns_zone.mongo[0].id]
+  }
+
+  tags = var.tags
+}
+
 resource "azurerm_cosmosdb_mongo_database" "main" {
   name                = var.mongo_database_name
   resource_group_name = var.resource_group_name

--- a/terraform/modules/cosmosdb-mongo/variables.tf
+++ b/terraform/modules/cosmosdb-mongo/variables.tf
@@ -37,7 +37,25 @@ variable "throughput" {
 variable "public_network_access_enabled" {
   description = "Whether public network access is enabled. Defaults to true for backward compatibility. SECURITY NOTICE: This default will change to false in a future release. All calling modules/environments should explicitly set public_network_access_enabled = false for production security before the enforced change."
   type        = bool
-  default     = true
+  default     = false
+}
+
+variable "private_endpoint_subnet_id" {
+  description = "Subnet ID for the Cosmos DB private endpoint when public network access is disabled"
+  type        = string
+  default     = ""
+}
+
+variable "vnet_id" {
+  description = "VNet ID linked to the Cosmos DB private DNS zone when public network access is disabled"
+  type        = string
+  default     = ""
+}
+
+variable "private_dns_zone_name" {
+  description = "Private DNS zone name for Cosmos DB Mongo private endpoints"
+  type        = string
+  default     = "privatelink.mongo.cosmos.azure.com"
 }
 
 variable "enable_free_tier" {

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -52,6 +52,28 @@ resource "azurerm_subnet" "database" {
   }
 }
 
+resource "azurerm_subnet" "app_service" {
+  name                 = "${var.environment}-appservice-subnet"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.app_service_subnet_prefix]
+
+  delegation {
+    name = "app-service-delegation"
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_subnet" "private_endpoints" {
+  name                              = "${var.environment}-private-endpoint-subnet"
+  resource_group_name               = var.resource_group_name
+  virtual_network_name              = azurerm_virtual_network.main.name
+  address_prefixes                  = [var.private_endpoint_subnet_prefix]
+  private_endpoint_network_policies = "Disabled"
+}
 # Network Security Groups
 resource "azurerm_network_security_group" "gateway" {
   name                = "${var.environment}-gateway-nsg"

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -23,6 +23,15 @@ output "database_subnet_id" {
   value       = azurerm_subnet.database.id
 }
 
+output "app_service_subnet_id" {
+  description = "ID of the App Service integration subnet"
+  value       = azurerm_subnet.app_service.id
+}
+
+output "private_endpoint_subnet_id" {
+  description = "ID of the private endpoint subnet"
+  value       = azurerm_subnet.private_endpoints.id
+}
 
 output "gateway_nsg_id" {
   description = "ID of the gateway NSG"

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -9,7 +9,7 @@ variable "location" {
 }
 
 variable "environment" {
-  description = "Environment name (production, staging, etc.)"
+  description = "Environment name"
   type        = string
 }
 
@@ -42,6 +42,17 @@ variable "database_subnet_prefix" {
   default     = "10.0.3.0/24"
 }
 
+variable "app_service_subnet_prefix" {
+  description = "Address prefix for App Service regional VNet integration"
+  type        = string
+  default     = "10.0.4.0/24"
+}
+
+variable "private_endpoint_subnet_prefix" {
+  description = "Address prefix for private endpoints"
+  type        = string
+  default     = "10.0.5.0/24"
+}
 
 variable "tags" {
   description = "Tags to apply to resources"

--- a/terraform/modules/webapp/main.tf
+++ b/terraform/modules/webapp/main.tf
@@ -40,10 +40,11 @@ resource "azurerm_application_insights" "webapp" {
 }
 
 resource "azurerm_linux_web_app" "main" {
-  name                = var.web_app_name
-  resource_group_name = var.resource_group_name
-  location            = var.location
-  service_plan_id     = azurerm_service_plan.webapp.id
+  name                      = var.web_app_name
+  resource_group_name       = var.resource_group_name
+  location                  = var.location
+  service_plan_id           = azurerm_service_plan.webapp.id
+  virtual_network_subnet_id = var.app_service_subnet_id != "" ? var.app_service_subnet_id : null
 
   site_config {
     application_stack {
@@ -52,8 +53,9 @@ resource "azurerm_linux_web_app" "main" {
 
     app_command_line = "node server.js"
 
-    always_on  = true
-    ftps_state = "Disabled"
+    always_on              = true
+    ftps_state             = "Disabled"
+    vnet_route_all_enabled = var.app_service_subnet_id != ""
 
     cors {
       allowed_origins = [

--- a/terraform/modules/webapp/variables.tf
+++ b/terraform/modules/webapp/variables.tf
@@ -194,6 +194,12 @@ variable "auth_url" {
   default     = ""
 }
 
+variable "app_service_subnet_id" {
+  description = "Subnet ID for App Service regional VNet integration"
+  type        = string
+  default     = ""
+}
+
 variable "storage_connection_string" {
   description = "Azure Storage connection string"
   type        = string


### PR DESCRIPTION
## Summary
- Enable the production Cosmos Mongo module by default so PR #98 project repositories get a real production datastore.
- This fixes the post-apply state where App Insights was wired but MONGODB_URI/DB_NAME stayed empty because the GitHub apply workflow does not use local tfvars or tfvars examples.

## Validation
- terraform fmt -recursive
- terraform -chdir=terraform/environments/production validate

## Deploy Plan
After merge, rerun terraform-apply.yml from main with confirm=APPLY, then rerun the web app deploy.