### PR TITLE
fix(terraform): resume production datastore apply

### DIFF
--- a/terraform/modules/cosmosdb-mongo/main.tf
+++ b/terraform/modules/cosmosdb-mongo/main.tf
@@ -77,4 +77,9 @@ resource "azurerm_cosmosdb_mongo_collection" "main" {
   account_name        = azurerm_cosmosdb_account.main.name
   database_name       = azurerm_cosmosdb_mongo_database.main.name
   throughput          = var.throughput
+
+  index {
+    keys   = ["_id"]
+    unique = true
+  }
 }

--- a/terraform/modules/webapp/main.tf
+++ b/terraform/modules/webapp/main.tf
@@ -36,6 +36,10 @@ resource "azurerm_application_insights" "webapp" {
   location            = var.location
   application_type    = "web"
 
+  lifecycle {
+    ignore_changes = [workspace_id]
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
## Summary
- Add the required _id index block to the Cosmos Mongo collection.
- Ignore Azure-populated App Insights workspace_id drift so Terraform does not try to remove it after the first apply.

## Why
The production apply after PR #99 partially created Cosmos/private networking, then failed with:
- index with '_id' key is required on zurerm_cosmosdb_mongo_collection.main
- workspace_id can not be removed after set on zurerm_application_insights.webapp

## Validation
- 	erraform fmt -recursive
- 	erraform -chdir=terraform/environments/production validate

## After Merge
Rerun 	erraform-apply.yml from main with confirm=APPLY, then rerun/deploy the web app.