### PR TITLE
fix(test): force file fallback for job workspace routes

### DIFF
--- a/tests/api/job-workspace.test.ts
+++ b/tests/api/job-workspace.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const authHeaders = {
   "x-user-id": "hans",
@@ -8,6 +8,16 @@ const authHeaders = {
 }
 
 const routeContext = { params: Promise.resolve({ id: "job-1" }) }
+
+beforeEach(() => {
+  vi.stubEnv("MONGODB_URI", "")
+  vi.stubEnv("MONGO_URL", "")
+  vi.stubEnv("DB_NAME", "")
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 type FileStore = Map<string, string>
 


### PR DESCRIPTION
## Summary
- Force tests/api/job-workspace.test.ts into repository file-fallback mode by clearing Mongo env for this test file.
- This matches the mocked fs/promises behavior the tests assert after job workspace routes moved behind repositories.

## Why
The production deploy workflow now has Mongo-related environment available, so these tests were taking the Mongo repository path and returning empty data instead of the mocked file data. That blocked web app deployment in run 29827009650.

## Validation
- pnpm exec vitest run tests/api/job-workspace.test.ts
- pnpm exec tsc --noEmit
- pnpm run lint
