### PR TITLE
fix(projects): harden datastore API writes

### DIFF
--- a/app/api/files/route.ts
+++ b/app/api/files/route.ts
@@ -54,6 +54,12 @@ function validateFile(file: File): { valid: boolean; error?: string } {
   return { valid: true }
 }
 
+function normalizeStorageSegment(value: string | null | undefined, fallback: string): string {
+  const segment = value?.trim()
+  if (!segment) return fallback
+  return segment.replace(/[^a-zA-Z0-9._-]/g, "-")
+}
+
 // Upload to Azure Blob Storage
 async function uploadToAzure(
   buffer: Buffer,
@@ -126,7 +132,7 @@ export const POST = withAuth(async (request) => {
   try {
     const formData = await request.formData()
     const file = formData.get("file") as File
-    const category = (formData.get("category") as string) || "general"
+    const category = normalizeStorageSegment(formData.get("category") as string | null, "general")
     const assetId = formData.get("assetId") as string
     const userId = formData.get("userId") as string
 
@@ -249,6 +255,9 @@ export const DELETE = withAuth(async (request) => {
           { success: false, error: "category and filename required for local delete" },
           { status: 400 }
         )
+      }
+      if (category !== normalizeStorageSegment(category, "") || filename !== path.basename(filename)) {
+        return NextResponse.json({ success: false, error: "Invalid path" }, { status: 400 })
       }
       const baseDir = path.resolve(UPLOAD_CONFIG.uploadDir, category)
       const filePath = path.resolve(baseDir, filename)

--- a/app/api/projects/[id]/allocations/route.ts
+++ b/app/api/projects/[id]/allocations/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto"
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import {
@@ -53,7 +54,7 @@ export const POST = withRole("admin", "operator", "employee")(async (request, co
     const costCents = numberFromBody(body.costCents)
     const now = new Date().toISOString()
     const allocation: JobAllocation = {
-      id: `alloc-${Date.now()}`,
+      id: `alloc-${randomUUID()}`,
       projectId,
       type,
       name,

--- a/app/api/projects/[id]/areas/route.ts
+++ b/app/api/projects/[id]/areas/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto"
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import {
@@ -41,7 +42,7 @@ export const POST = withRole("admin", "operator", "employee")(async (request, co
 
     const now = new Date().toISOString()
     const area: JobArea = {
-      id: `area-${Date.now()}`,
+      id: `area-${randomUUID()}`,
       projectId,
       name,
       kind: normalizeKind(body.kind),

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
-import { toStoredProjectType, withProjectKind } from "@/lib/projects"
+import { toStoredProjectType, withProjectKind, type Project } from "@/lib/projects"
 import { deleteProject, findProjectById, replaceProject } from "@/lib/repositories/project-repository"
 import { logger } from "@/lib/logger"
 import { routeToInngest } from "@/lib/workflows"
@@ -29,18 +29,38 @@ export const PATCH = withRole("admin")(async (request, context) => {
     if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 })
 
     const prevStatus = project.status
-    const storedType = toStoredProjectType(body.type)
-    const updates = { ...body }
-    if (body.type !== undefined) {
-      if (storedType) updates.type = storedType
-      else delete updates.type
+    const updates: Partial<Project> = {}
+
+    if (body.name !== undefined) {
+      const name = typeof body.name === "string" ? body.name.trim() : ""
+      if (!name) return NextResponse.json({ error: "name must be a non-empty string" }, { status: 400 })
+      updates.name = name
     }
+
+    if (body.type !== undefined) {
+      const storedType = toStoredProjectType(body.type)
+      if (!storedType) return NextResponse.json({ error: "type must be scope or job" }, { status: 400 })
+      updates.type = storedType
+      updates.scopeKind = storedType === "major" ? body.scopeKind || project.scopeKind || "site" : undefined
+      updates.parentId = storedType === "subproject" ? body.parentId ?? project.parentId : undefined
+    } else {
+      if (body.scopeKind !== undefined) updates.scopeKind = body.scopeKind
+      if (body.parentId !== undefined) updates.parentId = body.parentId
+    }
+
+    if (body.description !== undefined) {
+      updates.description = typeof body.description === "string" && body.description.trim() ? body.description.trim() : undefined
+    }
+    if (body.status !== undefined) updates.status = body.status
+    if (body.startDate !== undefined) updates.startDate = body.startDate
+    if (body.endDate !== undefined) updates.endDate = body.endDate
+    if (body.budget !== undefined) updates.budget = body.budget
+    if (body.members !== undefined) updates.members = Array.isArray(body.members) ? body.members : project.members
 
     const updatedProject = {
       ...project,
       ...updates,
       id: project.id,
-      members: body.members ?? project.members,
       updatedAt: new Date().toISOString(),
     }
     await replaceProject(updatedProject)

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,9 +1,9 @@
+import { randomUUID } from "crypto"
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import { toStoredProjectType, withProjectKind, type Project } from "@/lib/projects"
 import { logger } from "@/lib/logger"
 import { createProject, listProjects } from "@/lib/repositories/project-repository"
-
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -42,18 +42,23 @@ export const POST = withRole("admin")(async (request: Request) => {
     const body = await request.json()
     const { name, description, type, scopeKind, parentId, status, startDate, endDate, budget, members } = body
 
-    if (!name || !type) {
+    const projectName = typeof name === "string" ? name.trim() : ""
+    if (!projectName || !type) {
       return NextResponse.json({ error: "name and type are required" }, { status: 400 })
     }
 
-    const id = `proj-${Date.now()}`
+    const storedType = toStoredProjectType(type)
+    if (!storedType) {
+      return NextResponse.json({ error: "type must be scope or job" }, { status: 400 })
+    }
+
+    const id = `proj-${randomUUID()}`
     const now = new Date().toISOString()
-    const storedType = toStoredProjectType(type) ?? "subproject"
 
     const project: Project = {
       id,
-      name,
-      description: description || undefined,
+      name: projectName,
+      description: typeof description === "string" && description.trim() ? description.trim() : undefined,
       type: storedType,
       scopeKind: storedType === "major" ? scopeKind || "site" : undefined,
       parentId: storedType === "subproject" ? parentId : undefined,

--- a/app/api/projects/suggestions/[id]/route.ts
+++ b/app/api/projects/suggestions/[id]/route.ts
@@ -1,10 +1,11 @@
+import { randomUUID } from "crypto"
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import { withProjectKind, type Project, type ProjectMember } from "@/lib/projects"
 import { createProject } from "@/lib/repositories/project-repository"
 import {
   listProjectSuggestions,
-  saveProjectSuggestions,
+  replaceProjectSuggestion,
 } from "@/lib/repositories/project-suggestion-repository"
 import { logger } from "@/lib/logger"
 import { routeToInngest } from "@/lib/workflows"
@@ -34,17 +35,16 @@ export const PATCH = withRole("admin")(async (request, context) => {
     }
 
     const now = new Date().toISOString()
-    suggestions[idx] = {
+    const reviewedSuggestion = {
       ...suggestion,
       status,
       reviewedBy: auth,
       reviewedAt: now,
     }
-    await saveProjectSuggestions(suggestions)
 
     if (status === "approved") {
       const project: Project = {
-        id: `proj-${Date.now()}`,
+        id: `proj-${randomUUID()}`,
         name: suggestion.name,
         description: suggestion.description,
         type: suggestion.type,
@@ -56,6 +56,8 @@ export const PATCH = withRole("admin")(async (request, context) => {
         updatedAt: now,
       }
       await createProject(project)
+      await replaceProjectSuggestion(reviewedSuggestion)
+      suggestions[idx] = reviewedSuggestion
 
       await routeToInngest({
         name: "house-of-veritas/project.suggestion.approved",
@@ -71,6 +73,8 @@ export const PATCH = withRole("admin")(async (request, context) => {
       return NextResponse.json({ suggestion: suggestions[idx], project: withProjectKind(project) })
     }
 
+    await replaceProjectSuggestion(reviewedSuggestion)
+    suggestions[idx] = reviewedSuggestion
     return NextResponse.json({ suggestion: suggestions[idx] })
   } catch (err) {
     logger.error("Failed to update suggestion", {

--- a/app/api/projects/suggestions/route.ts
+++ b/app/api/projects/suggestions/route.ts
@@ -1,9 +1,10 @@
+import { randomUUID } from "crypto"
 import { NextResponse } from "next/server"
 import { withAuth } from "@/lib/auth/rbac"
 import { toStoredProjectType } from "@/lib/projects"
 import {
+  createProjectSuggestion,
   listProjectSuggestions,
-  saveProjectSuggestions,
   type ProjectSuggestion,
 } from "@/lib/repositories/project-suggestion-repository"
 import { logger } from "@/lib/logger"
@@ -33,9 +34,12 @@ export const POST = withAuth(async (request: Request) => {
       return NextResponse.json({ error: "name is required" }, { status: 400 })
     }
 
-    const suggestions = await listProjectSuggestions()
-    const id = `sug-${Date.now()}`
-    const storedType = toStoredProjectType(type) ?? "subproject"
+    const id = `sug-${randomUUID()}`
+    const storedType = toStoredProjectType(type)
+    if (!storedType) {
+      return NextResponse.json({ error: "type must be scope or job" }, { status: 400 })
+    }
+
     const suggestion: ProjectSuggestion = {
       id,
       name: name.trim(),
@@ -47,8 +51,7 @@ export const POST = withAuth(async (request: Request) => {
       suggestedAt: new Date().toISOString(),
       status: "pending",
     }
-    suggestions.push(suggestion)
-    await saveProjectSuggestions(suggestions)
+    await createProjectSuggestion(suggestion)
     return NextResponse.json({ suggestion })
   } catch (err) {
     logger.error("Failed to create suggestion", {

--- a/lib/db/mongodb.ts
+++ b/lib/db/mongodb.ts
@@ -1,25 +1,41 @@
 import { MongoClient, Db, Collection, ObjectId } from "mongodb"
 import { logger } from "@/lib/logger"
 
-// MongoDB connection
-const MONGO_URL = process.env.MONGODB_URI || process.env.MONGO_URL || "mongodb://localhost:27017"
-const DB_NAME = process.env.DB_NAME || "house_of_veritas"
-
 let client: MongoClient | null = null
 let db: Db | null = null
+let activeConnectionKey: string | null = null
+
+function getMongoUrl(): string {
+  return process.env.MONGODB_URI || process.env.MONGO_URL || "mongodb://localhost:27017"
+}
+
+function getDatabaseName(): string {
+  return process.env.DB_NAME || "house_of_veritas"
+}
 
 export function isMongoConfigured(): boolean {
   return !!(process.env.MONGODB_URI || process.env.MONGO_URL)
 }
 
 export async function getDatabase(): Promise<Db> {
-  if (db) return db
+  const mongoUrl = getMongoUrl()
+  const databaseName = getDatabaseName()
+  const connectionKey = `${mongoUrl}|${databaseName}`
+  if (db && activeConnectionKey === connectionKey) return db
+
+  if (client) {
+    await client.close()
+    client = null
+    db = null
+    activeConnectionKey = null
+  }
 
   try {
-    client = new MongoClient(MONGO_URL)
+    client = new MongoClient(mongoUrl)
     await client.connect()
-    db = client.db(DB_NAME)
-    logger.info(`MongoDB connected to ${DB_NAME}`)
+    db = client.db(databaseName)
+    activeConnectionKey = connectionKey
+    logger.info(`MongoDB connected to ${databaseName}`)
     return db
   } catch (error) {
     logger.error("MongoDB connection error", {
@@ -42,17 +58,23 @@ export async function closeConnection(): Promise<void> {
     await client.close()
     client = null
     db = null
+    activeConnectionKey = null
   }
+}
+
+export function withoutMongoId<T extends { _id?: unknown }>(doc: T): Omit<T, "_id"> {
+  const { _id, ...rest } = doc
+  return rest
 }
 
 // Helper to convert MongoDB _id to string id
 export function sanitizeDocument<T extends { _id?: ObjectId }>(
   doc: T
 ): Omit<T, "_id"> & { id: string } {
-  const { _id, ...rest } = doc
+  const rest = withoutMongoId(doc)
   return {
     ...rest,
-    id: _id?.toString() || "",
+    id: "id" in rest && typeof rest.id === "string" && rest.id ? rest.id : doc._id?.toString() || "",
   } as Omit<T, "_id"> & { id: string }
 }
 

--- a/lib/repositories/job-workspace-repository.ts
+++ b/lib/repositories/job-workspace-repository.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile, mkdir } from "fs/promises"
 import { dirname, join } from "path"
 import type { Filter } from "mongodb"
-import { getCollection, isMongoConfigured } from "@/lib/db/mongodb"
+import { getCollection, isMongoConfigured, withoutMongoId } from "@/lib/db/mongodb"
 import type { Task } from "@/lib/services/baserow"
 
 export type JobAreaKind = "room" | "area" | "component" | "zone"
@@ -42,6 +42,10 @@ export interface JobTaskMetadata {
   createdAt: string
   updatedAt: string
 }
+
+type JobAreaDocument = JobArea & { _id?: unknown }
+type JobAllocationDocument = JobAllocation & { _id?: unknown }
+type JobTaskMetadataDocument = JobTaskMetadata & { _id?: unknown }
 
 export interface GroupedJobTask extends Task {
   areaId?: string
@@ -85,8 +89,9 @@ export async function listJobAreas(projectId: string): Promise<JobArea[]> {
     return areas.filter((area) => area.projectId === projectId)
   }
 
-  const collection = await getCollection<JobArea>(AREAS_COLLECTION)
-  return collection.find({ projectId } as Filter<JobArea>).sort({ createdAt: 1 }).toArray()
+  const collection = await getCollection<JobAreaDocument>(AREAS_COLLECTION)
+  const areas = await collection.find({ projectId } as Filter<JobAreaDocument>).sort({ createdAt: 1 }).toArray()
+  return areas.map(withoutMongoId)
 }
 
 export async function createJobArea(area: JobArea): Promise<JobArea> {
@@ -98,7 +103,7 @@ export async function createJobArea(area: JobArea): Promise<JobArea> {
     return area
   }
 
-  const collection = await getCollection<JobArea>(AREAS_COLLECTION)
+  const collection = await getCollection<JobAreaDocument>(AREAS_COLLECTION)
   await collection.insertOne(area)
   return area
 }
@@ -110,9 +115,10 @@ export async function listJobAllocations(projectId: string, type?: JobAllocation
     return allocations.filter((allocation) => allocation.projectId === projectId && (!type || allocation.type === type))
   }
 
-  const query: Filter<JobAllocation> = type ? { projectId, type } : { projectId }
-  const collection = await getCollection<JobAllocation>(ALLOCATIONS_COLLECTION)
-  return collection.find(query).sort({ createdAt: 1 }).toArray()
+  const query: Filter<JobAllocationDocument> = type ? { projectId, type } : { projectId }
+  const collection = await getCollection<JobAllocationDocument>(ALLOCATIONS_COLLECTION)
+  const allocations = await collection.find(query).sort({ createdAt: 1 }).toArray()
+  return allocations.map(withoutMongoId)
 }
 
 export async function createJobAllocation(allocation: JobAllocation): Promise<JobAllocation> {
@@ -124,7 +130,7 @@ export async function createJobAllocation(allocation: JobAllocation): Promise<Jo
     return allocation
   }
 
-  const collection = await getCollection<JobAllocation>(ALLOCATIONS_COLLECTION)
+  const collection = await getCollection<JobAllocationDocument>(ALLOCATIONS_COLLECTION)
   await collection.insertOne(allocation)
   return allocation
 }
@@ -136,8 +142,9 @@ export async function listJobTaskMetadata(projectId: string): Promise<JobTaskMet
     return metadata.filter((item) => item.projectId === projectId)
   }
 
-  const collection = await getCollection<JobTaskMetadata>(TASK_METADATA_COLLECTION)
-  return collection.find({ projectId } as Filter<JobTaskMetadata>).sort({ createdAt: 1 }).toArray()
+  const collection = await getCollection<JobTaskMetadataDocument>(TASK_METADATA_COLLECTION)
+  const metadata = await collection.find({ projectId } as Filter<JobTaskMetadataDocument>).sort({ createdAt: 1 }).toArray()
+  return metadata.map(withoutMongoId)
 }
 
 export async function createJobTaskMetadata(metadata: JobTaskMetadata): Promise<JobTaskMetadata> {
@@ -149,7 +156,7 @@ export async function createJobTaskMetadata(metadata: JobTaskMetadata): Promise<
     return metadata
   }
 
-  const collection = await getCollection<JobTaskMetadata>(TASK_METADATA_COLLECTION)
+  const collection = await getCollection<JobTaskMetadataDocument>(TASK_METADATA_COLLECTION)
   await collection.insertOne(metadata)
   return metadata
 }

--- a/lib/repositories/project-repository.ts
+++ b/lib/repositories/project-repository.ts
@@ -1,13 +1,13 @@
 import { readFile, writeFile, mkdir } from "fs/promises"
 import { dirname, join } from "path"
 import type { Filter } from "mongodb"
-import { getCollection, isMongoConfigured } from "@/lib/db/mongodb"
+import { getCollection, isMongoConfigured, withoutMongoId } from "@/lib/db/mongodb"
 import type { Project } from "@/lib/projects"
 
 const PROJECTS_FILE = join(process.cwd(), "data", "projects.json")
 const PROJECTS_COLLECTION = "projects"
 
-type ProjectDocument = Project
+type ProjectDocument = Project & { _id?: unknown }
 
 function requireProductionStore(): void {
   if (process.env.NODE_ENV === "production" && process.env.CI !== "true" && !isMongoConfigured()) {
@@ -35,7 +35,8 @@ export async function listProjects(): Promise<Project[]> {
   if (!isMongoConfigured()) return readFileProjects()
 
   const collection = await getCollection<ProjectDocument>(PROJECTS_COLLECTION)
-  return collection.find({}).sort({ createdAt: 1 }).toArray()
+  const projects = await collection.find({}).sort({ createdAt: 1 }).toArray()
+  return projects.map(withoutMongoId)
 }
 
 export async function findProjectById(id: string): Promise<Project | null> {
@@ -46,7 +47,8 @@ export async function findProjectById(id: string): Promise<Project | null> {
   }
 
   const collection = await getCollection<ProjectDocument>(PROJECTS_COLLECTION)
-  return collection.findOne({ id } as Filter<ProjectDocument>)
+  const project = await collection.findOne({ id } as Filter<ProjectDocument>)
+  return project ? withoutMongoId(project) : null
 }
 
 export async function createProject(project: Project): Promise<Project> {
@@ -75,8 +77,9 @@ export async function replaceProject(project: Project): Promise<Project | null> 
   }
 
   const collection = await getCollection<ProjectDocument>(PROJECTS_COLLECTION)
-  const result = await collection.replaceOne({ id: project.id } as Filter<ProjectDocument>, project)
-  return result.matchedCount > 0 ? project : null
+  const document = withoutMongoId(project as ProjectDocument)
+  const result = await collection.replaceOne({ id: project.id } as Filter<ProjectDocument>, document)
+  return result.matchedCount > 0 ? document : null
 }
 
 export async function deleteProject(id: string): Promise<boolean> {

--- a/lib/repositories/project-suggestion-repository.ts
+++ b/lib/repositories/project-suggestion-repository.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, mkdir } from "fs/promises"
 import { dirname, join } from "path"
-import { getCollection, isMongoConfigured } from "@/lib/db/mongodb"
+import type { Filter } from "mongodb"
+import { getCollection, isMongoConfigured, withoutMongoId } from "@/lib/db/mongodb"
 import type { ProjectStorageType, ScopeKind } from "@/lib/projects"
 
 const SUGGESTIONS_FILE = join(process.cwd(), "data", "project-suggestions.json")
@@ -19,6 +20,8 @@ export interface ProjectSuggestion {
   reviewedBy?: string
   reviewedAt?: string
 }
+
+type ProjectSuggestionDocument = ProjectSuggestion & { _id?: unknown }
 
 function requireProductionStore(): void {
   if (process.env.NODE_ENV === "production" && process.env.CI !== "true" && !isMongoConfigured()) {
@@ -45,8 +48,40 @@ export async function listProjectSuggestions(): Promise<ProjectSuggestion[]> {
   requireProductionStore()
   if (!isMongoConfigured()) return readFileSuggestions()
 
-  const collection = await getCollection<ProjectSuggestion>(SUGGESTIONS_COLLECTION)
-  return collection.find({}).sort({ suggestedAt: 1 }).toArray()
+  const collection = await getCollection<ProjectSuggestionDocument>(SUGGESTIONS_COLLECTION)
+  const suggestions = await collection.find({}).sort({ suggestedAt: 1 }).toArray()
+  return suggestions.map(withoutMongoId)
+}
+
+export async function createProjectSuggestion(suggestion: ProjectSuggestion): Promise<ProjectSuggestion> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const suggestions = await readFileSuggestions()
+    suggestions.push(suggestion)
+    await writeFileSuggestions(suggestions)
+    return suggestion
+  }
+
+  const collection = await getCollection<ProjectSuggestionDocument>(SUGGESTIONS_COLLECTION)
+  await collection.insertOne(suggestion)
+  return suggestion
+}
+
+export async function replaceProjectSuggestion(suggestion: ProjectSuggestion): Promise<ProjectSuggestion | null> {
+  requireProductionStore()
+  if (!isMongoConfigured()) {
+    const suggestions = await readFileSuggestions()
+    const index = suggestions.findIndex((item) => item.id === suggestion.id)
+    if (index === -1) return null
+    suggestions[index] = suggestion
+    await writeFileSuggestions(suggestions)
+    return suggestion
+  }
+
+  const collection = await getCollection<ProjectSuggestionDocument>(SUGGESTIONS_COLLECTION)
+  const document = withoutMongoId(suggestion as ProjectSuggestionDocument)
+  const result = await collection.replaceOne({ id: suggestion.id } as Filter<ProjectSuggestionDocument>, document)
+  return result.matchedCount > 0 ? document : null
 }
 
 export async function saveProjectSuggestions(suggestions: ProjectSuggestion[]): Promise<void> {
@@ -56,7 +91,7 @@ export async function saveProjectSuggestions(suggestions: ProjectSuggestion[]): 
     return
   }
 
-  const collection = await getCollection<ProjectSuggestion>(SUGGESTIONS_COLLECTION)
+  const collection = await getCollection<ProjectSuggestionDocument>(SUGGESTIONS_COLLECTION)
   await collection.deleteMany({})
   if (suggestions.length > 0) await collection.insertMany(suggestions)
 }

--- a/tests/api/job-workspace.test.ts
+++ b/tests/api/job-workspace.test.ts
@@ -243,3 +243,65 @@ describe("project suggestion approval", () => {
     expect(data.project).toMatchObject({ name: "Zeerust Farm", type: "major", scopeKind: "asset", kind: "scope" })
   })
 })
+
+describe("project API validation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it("rejects invalid project types instead of coercing them to jobs", async () => {
+    const { POST } = await importWithMockedFiles<typeof import("@/app/api/projects/route")>(
+      "@/app/api/projects/route",
+      new Map([["projects.json", "[]"]])
+    )
+
+    const response = await POST(
+      new Request("http://localhost/api/projects", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ name: "New Work", type: "other" }),
+      })
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe("type must be scope or job")
+  })
+
+  it("rejects invalid project type patches", async () => {
+    const files = new Map<string, string>([
+      [
+        "projects.json",
+        JSON.stringify([
+          {
+            id: "proj-1",
+            name: "Bathroom Repair",
+            type: "subproject",
+            status: "planned",
+            members: [],
+            createdAt: "now",
+            updatedAt: "now",
+          },
+        ]),
+      ],
+    ])
+    const { PATCH } = await importWithMockedFiles<typeof import("@/app/api/projects/[id]/route")>(
+      "@/app/api/projects/[id]/route",
+      files
+    )
+
+    const response = await PATCH(
+      new Request("http://localhost/api/projects/proj-1", {
+        method: "PATCH",
+        headers: authHeaders,
+        body: JSON.stringify({ type: "other" }),
+      }),
+      { params: Promise.resolve({ id: "proj-1" }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe("type must be scope or job")
+  })
+})

--- a/tests/lib/mongodb.test.ts
+++ b/tests/lib/mongodb.test.ts
@@ -1,0 +1,18 @@
+import { ObjectId } from "mongodb"
+import { describe, expect, it } from "vitest"
+import { sanitizeDocument, withoutMongoId } from "@/lib/db/mongodb"
+
+describe("MongoDB document helpers", () => {
+  it("removes Mongo internals from API documents", () => {
+    expect(withoutMongoId({ _id: new ObjectId(), id: "project-1", name: "Project" })).toEqual({
+      id: "project-1",
+      name: "Project",
+    })
+  })
+
+  it("preserves an application id when sanitizing documents", () => {
+    const sanitized = sanitizeDocument({ _id: new ObjectId(), id: "domain-id", name: "Domain object" })
+
+    expect(sanitized.id).toBe("domain-id")
+  })
+})


### PR DESCRIPTION
## Summary
- strip Mongo _id fields from project, suggestion, and job workspace API data
- reject invalid project/suggestion types instead of silently coercing them
- use UUID-backed IDs for project, suggestion, area, and allocation creates
- make suggestion creation/review use targeted repository writes instead of full collection rewrites
- normalize local file upload/delete path segments

## Validation
- pnpm exec vitest run tests/api/job-workspace.test.ts tests/lib/projects.test.ts tests/lib/mongodb.test.ts
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

Note: pnpm run build still reports the existing Turbopack NFT warning for pp/api/files/route.ts; build exits 0.