### PR TITLE
fix(ai): use real project suggestions

### DIFF
--- a/app/api/ai/suggest-project-from-photo/route.ts
+++ b/app/api/ai/suggest-project-from-photo/route.ts
@@ -1,27 +1,11 @@
 import { NextResponse } from "next/server"
 import { withAuth } from "@/lib/auth/rbac"
 import { suggestProjectFromPhoto } from "@/lib/ai/azure-foundry"
-import { readFile } from "fs/promises"
-import { join } from "path"
-import type { Project } from "@/lib/projects"
-
-const PROJECTS_PATH = join(process.cwd(), "data", "projects.json")
+import { listProjects } from "@/lib/repositories/project-repository"
 
 async function loadProjectNames(): Promise<string[]> {
-  try {
-    const data = await readFile(PROJECTS_PATH, "utf-8")
-    const projects: Project[] = JSON.parse(data)
-    return (Array.isArray(projects) ? projects : []).map((p) => p.name)
-  } catch {
-    return [
-      "House Revamp",
-      "Zeerust Arming",
-      "Garage",
-      "Garden Revamp",
-      "Kitchen Cupboards",
-      "Lay Paving",
-    ]
-  }
+  const projects = await listProjects()
+  return [...new Set(projects.map((project) => project.name.trim()).filter(Boolean))]
 }
 
 export const POST = withAuth(async (request: Request) => {

--- a/app/api/ai/suggest-project/route.ts
+++ b/app/api/ai/suggest-project/route.ts
@@ -31,7 +31,7 @@ export const POST = withAuth(async (request: Request) => {
     })
 
     return NextResponse.json({
-      suggested,
+      suggested: suggested || options[0],
       options,
       aiPowered: !!suggested,
     })

--- a/app/api/ai/suggest-project/route.ts
+++ b/app/api/ai/suggest-project/route.ts
@@ -1,20 +1,11 @@
 import { NextResponse } from "next/server"
 import { withAuth } from "@/lib/auth/rbac"
 import { suggestProject } from "@/lib/ai/azure-foundry"
-import { readFile } from "fs/promises"
-import { join } from "path"
-import type { Project } from "@/lib/projects"
-
-const PROJECTS_PATH = join(process.cwd(), "data", "projects.json")
+import { listProjects } from "@/lib/repositories/project-repository"
 
 async function loadProjectNames(): Promise<string[]> {
-  try {
-    const data = await readFile(PROJECTS_PATH, "utf-8")
-    const projects: Project[] = JSON.parse(data)
-    return (Array.isArray(projects) ? projects : []).map((p) => p.name)
-  } catch {
-    return ["House Revamp", "Zeerust Arming", "Garage", "Garden Revamp", "Kitchen Cupboards"]
-  }
+  const projects = await listProjects()
+  return [...new Set(projects.map((project) => project.name.trim()).filter(Boolean))]
 }
 
 export const POST = withAuth(async (request: Request) => {
@@ -23,6 +14,15 @@ export const POST = withAuth(async (request: Request) => {
     const { taskTitle, taskDescription, expenseCategory } = body
 
     const options = await loadProjectNames()
+    if (options.length === 0) {
+      return NextResponse.json({
+        suggested: null,
+        options,
+        aiPowered: false,
+        message: "No projects configured",
+      })
+    }
+
     const suggested = await suggestProject({
       taskTitle: taskTitle || undefined,
       taskDescription: taskDescription || undefined,
@@ -31,7 +31,7 @@ export const POST = withAuth(async (request: Request) => {
     })
 
     return NextResponse.json({
-      suggested: suggested || options[0],
+      suggested,
       options,
       aiPowered: !!suggested,
     })

--- a/tests/api/ai-project-suggestions.test.ts
+++ b/tests/api/ai-project-suggestions.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const authHeaders = {
+  "x-user-id": "hans",
+  "x-user-role": "admin",
+  "x-user-email": "smit.jurie@gmail.com",
+  "Content-Type": "application/json",
+}
+
+const listProjects = vi.fn()
+const suggestProject = vi.fn()
+const suggestProjectFromPhoto = vi.fn()
+
+vi.mock("@/lib/repositories/project-repository", () => ({ listProjects }))
+vi.mock("@/lib/ai/azure-foundry", () => ({ suggestProject, suggestProjectFromPhoto }))
+
+describe("AI project suggestion routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns an empty suggestion state when no projects exist", async () => {
+    listProjects.mockResolvedValue([])
+    const { POST } = await import("@/app/api/ai/suggest-project/route")
+
+    const response = await POST(
+      new Request("http://localhost/api/ai/suggest-project", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ taskTitle: "Fix gate" }),
+      })
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      suggested: null,
+      options: [],
+      aiPowered: false,
+      message: "No projects configured",
+    })
+    expect(suggestProject).not.toHaveBeenCalled()
+  })
+
+  it("uses repository project names instead of hardcoded defaults", async () => {
+    listProjects.mockResolvedValue([
+      { id: "p1", name: "Gate Repair" },
+      { id: "p2", name: "  Gate Repair  " },
+      { id: "p3", name: "Workshop" },
+    ])
+    suggestProject.mockResolvedValue("Workshop")
+    const { POST } = await import("@/app/api/ai/suggest-project/route")
+
+    const response = await POST(
+      new Request("http://localhost/api/ai/suggest-project", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ taskTitle: "Fix drill press" }),
+      })
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.options).toEqual(["Gate Repair", "Workshop"])
+    expect(data.suggested).toBe("Workshop")
+    expect(suggestProject).toHaveBeenCalledWith(expect.objectContaining({ options: ["Gate Repair", "Workshop"] }))
+  })
+
+  it("uses repository project names for photo suggestions", async () => {
+    listProjects.mockResolvedValue([{ id: "p1", name: "Garden" }])
+    suggestProjectFromPhoto.mockResolvedValue({ name: "Garden", fromExisting: true })
+    const { POST } = await import("@/app/api/ai/suggest-project-from-photo/route")
+
+    const response = await POST(
+      new Request("http://localhost/api/ai/suggest-project-from-photo", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ imageBase64: "abc123", imageMimeType: "image/png" }),
+      })
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.options).toEqual(["Garden"])
+    expect(data.suggested).toEqual({ name: "Garden", fromExisting: true })
+    expect(suggestProjectFromPhoto).toHaveBeenCalledWith(
+      expect.objectContaining({ existingProjectNames: ["Garden"], imageMimeType: "image/png" })
+    )
+  })
+})

--- a/tests/api/ai-project-suggestions.test.ts
+++ b/tests/api/ai-project-suggestions.test.ts
@@ -66,6 +66,26 @@ describe("AI project suggestion routes", () => {
     expect(suggestProject).toHaveBeenCalledWith(expect.objectContaining({ options: ["Gate Repair", "Workshop"] }))
   })
 
+  it("falls back to the first real project option when AI is unavailable", async () => {
+    listProjects.mockResolvedValue([{ id: "p1", name: "Gate Repair" }, { id: "p2", name: "Workshop" }])
+    suggestProject.mockResolvedValue(null)
+    const { POST } = await import("@/app/api/ai/suggest-project/route")
+
+    const response = await POST(
+      new Request("http://localhost/api/ai/suggest-project", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ taskTitle: "Fix drill press" }),
+      })
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.options).toEqual(["Gate Repair", "Workshop"])
+    expect(data.suggested).toBe("Gate Repair")
+    expect(data.aiPowered).toBe(false)
+  })
+
   it("uses repository project names for photo suggestions", async () => {
     listProjects.mockResolvedValue([{ id: "p1", name: "Garden" }])
     suggestProjectFromPhoto.mockResolvedValue({ name: "Garden", fromExisting: true })


### PR DESCRIPTION
## Summary
- remove hardcoded AI project suggestion fallbacks like House Revamp and Zeerust Arming
- load project suggestion options from the project repository so production uses the configured datastore
- return an explicit empty suggestion state when no projects exist
- add route tests for empty state, repository-backed options, and photo suggestions

## Validation
- pnpm exec vitest run tests/api/ai-project-suggestions.test.ts tests/api/job-workspace.test.ts tests/lib/mongodb.test.ts
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

Note: pnpm run build still exits 0 with the existing Turbopack NFT warning for pp/api/files/route.ts.