### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -27,15 +27,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -51,15 +51,15 @@ jobs:
       MONGODB_URI: mongodb://localhost:27017/house_of_veritas_test
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.30.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -86,7 +86,7 @@ jobs:
         run: find .next/standalone -type f -name '*:*' -print -delete
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nextjs-build
           path: .next/standalone
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: nextjs-build
 
@@ -115,7 +115,7 @@ jobs:
         run: zip -r deploy.zip . -x "*.git*"
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,15 +53,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9.0"
 
@@ -69,7 +69,7 @@ jobs:
         run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -116,15 +116,15 @@ jobs:
       MONGODB_URI: mongodb://localhost:27017/house_of_veritas_test
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.30.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -151,7 +151,7 @@ jobs:
         run: find .next/standalone -type f -name '*:*' -print -delete
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nextjs-build
           path: .next/standalone
@@ -180,13 +180,13 @@ jobs:
       MONGODB_URI: mongodb://localhost:27017/house_of_veritas_test
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.30.3
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -214,10 +214,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9.0"
 
@@ -233,7 +233,7 @@ jobs:
           terraform version
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -304,7 +304,7 @@ jobs:
 
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: nextjs-build
 
@@ -317,7 +317,7 @@ jobs:
         run: zip -r deploy.zip . -x "*.git*"
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -359,10 +359,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -419,10 +419,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -479,10 +479,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -514,15 +514,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9.0"
 
@@ -530,7 +530,7 @@ jobs:
         run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/deployment-checklist.yml
+++ b/.github/workflows/deployment-checklist.yml
@@ -42,15 +42,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9.0"
 
@@ -60,7 +60,7 @@ jobs:
           az --version
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload Checklist Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: deployment-checklist-report
           path: |
@@ -107,7 +107,7 @@ jobs:
 
       - name: Comment PR with Checklist Results
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -160,7 +160,7 @@ jobs:
 
       - name: Create Issue for Failed Checks (Scheduled Run)
         if: github.event_name == 'schedule' && steps.checklist.outputs.failed != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -218,10 +218,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -292,15 +292,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.30.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -329,15 +329,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.30.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -12,9 +12,9 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: 'Type APPLY to confirm. Any other value aborts.'
+        description: "Type APPLY to confirm. Any other value aborts."
         required: true
-        default: ''
+        default: ""
 
 permissions:
   contents: write
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9.0"
 
@@ -51,7 +51,7 @@ jobs:
           terraform version
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -25,10 +25,10 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9.0"
 
@@ -44,7 +44,7 @@ jobs:
           terraform version
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9.0"
 
@@ -44,7 +44,7 @@ jobs:
           terraform version
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -102,7 +102,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Plan Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: tfplan
           path: ${{ env.WORKING_DIR }}/tfplan
@@ -119,7 +119,7 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with Plan
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: github.event_name == 'pull_request'
         env:
           PLAN: "${{ steps.show-plan.outputs.plan }}"

--- a/config/scripts/deployment-checklist.py
+++ b/config/scripts/deployment-checklist.py
@@ -88,6 +88,10 @@ class DeploymentChecker:
         self.env = os.environ.get("AZURE_ENV", "prod")
         self.enable_operational_services = os.environ.get("ENABLE_OPERATIONAL_SERVICES", "false").lower() == "true"
         self.enable_application_gateway = os.environ.get("ENABLE_APPLICATION_GATEWAY", "false").lower() == "true"
+        self.is_ci = (
+            os.environ.get("CI", "false").lower() == "true"
+            or os.environ.get("GITHUB_ACTIONS") == "true"
+        )
 
         # Naming convention: nl-{env}-hov-{resourcetype}
         self.expected_resources = {
@@ -269,6 +273,17 @@ class DeploymentChecker:
         
         # Check for .terraform directory (initialized)
         if not (terraform_dir / ".terraform").exists():
+            if self.is_ci:
+                return CheckResult(
+                    name="Terraform State",
+                    status=Status.SKIP,
+                    message="Terraform local state directory is not expected in CI",
+                    details=(
+                        "Terraform plan/apply workflows initialize their own backend "
+                        "before running Terraform commands"
+                    )
+                )
+
             return CheckResult(
                 name="Terraform State",
                 status=Status.WARN,
@@ -422,12 +437,13 @@ class DeploymentChecker:
             )
         
         # Check for required secrets
-        required_secrets = [
-            "postgres-admin-password",
-            "docuseal-secret-key",
-            "baserow-secret-key",
-            "smtp-password"
-        ]
+        required_secrets = ["smtp-password"]
+        if self.enable_operational_services:
+            required_secrets.extend([
+                "postgres-admin-password",
+                "docuseal-secret-key",
+                "baserow-secret-key",
+            ])
         
         success, output, error = self.run_command([
             "az", "keyvault", "secret", "list",
@@ -661,6 +677,14 @@ class DeploymentChecker:
         template_file = self.repo_root / ".env.example"
         
         if not env_file.exists():
+            if self.is_ci:
+                return CheckResult(
+                    name="Environment File",
+                    status=Status.PASS,
+                    message="CI/CD uses GitHub secrets instead of .env.local",
+                    details=".env.local is intentionally absent from CI checkouts"
+                )
+
             return CheckResult(
                 name="Environment File",
                 status=Status.WARN,
@@ -907,7 +931,14 @@ class DeploymentChecker:
             },
             {
                 "name": "Initialize Terraform",
-                "complete": (self.repo_root / "terraform" / "environments" / "production" / ".terraform").exists(),
+                "complete": self.is_ci
+                or (
+                    self.repo_root
+                    / "terraform"
+                    / "environments"
+                    / "production"
+                    / ".terraform"
+                ).exists(),
                 "command": "cd /app/terraform/environments/production && terraform init"
             },
             {


### PR DESCRIPTION
## Summary

Updates GitHub Actions workflow dependencies to Node 24-backed major versions so CI/deploy runs stop emitting Node 20 deprecation warnings.

Also makes the deployment checklist classify clean-default CI expectations correctly:
- `.terraform` is skipped in CI because Terraform plan/apply jobs initialize their own backend.
- `.env.local` is treated as intentionally absent in CI because GitHub secrets are the source of truth.
- Operational-service Key Vault secrets are required only when `ENABLE_OPERATIONAL_SERVICES=true`.

## Validation

- `pnpm exec prettier --check .github/workflows`
- `python -m py_compile config/scripts/deployment-checklist.py`
- `git diff --check`
- `rg` stale-pin sweep for the prior Node 20-era action refs
- GitHub PR checks: Build & Test, E2E Tests, Infrastructure Verification, Pipeline Summary, Terraform Plan, Validate Configuration

## Notes

No app runtime code changed.