### PR TITLE
Update artifact upload action

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -86,7 +86,7 @@ jobs:
         run: find .next/standalone -type f -name '*:*' -print -delete
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: nextjs-build
           path: .next/standalone

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
         run: find .next/standalone -type f -name '*:*' -print -delete
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: nextjs-build
           path: .next/standalone

--- a/.github/workflows/deployment-checklist.yml
+++ b/.github/workflows/deployment-checklist.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload Checklist Report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: deployment-checklist-report
           path: |

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -102,7 +102,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Plan Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: tfplan
           path: ${{ env.WORKING_DIR }}/tfplan


### PR DESCRIPTION
## Summary

Updates remaining `actions/upload-artifact` references from v5 to v7 after the post-merge run showed v5 still targets Node 20.

## Validation

- `pnpm exec prettier --check .github/workflows`
- `git diff --check`
- `rg` sweep for `upload-artifact@v5` / `upload-artifact@v4`

## Notes

No app runtime code changed. CI still uses Node 20 for the application build/test to match the current App Service runtime.