### PR TITLE
Pin App Service runtime to Node 22

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install Dependencies
@@ -127,19 +127,19 @@ jobs:
 
       - name: Verify Web App Health
         run: |
-          APP_URL="https://${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}.azurewebsites.net"
+          HEALTH_URL="https://${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}.azurewebsites.net/api/health"
           healthy=false
           for i in {1..10}; do
-            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$APP_URL" || echo "000")
-            if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "302" ]; then
-              echo "Web App is healthy (HTTP $HTTP_STATUS)"
+            RESPONSE=$(curl -fsS "$HEALTH_URL" || true)
+            if echo "$RESPONSE" | grep -q '"status":"healthy"'; then
+              echo "Web App health endpoint is healthy"
               healthy=true
               break
             fi
-            echo "Waiting for Web App... (attempt $i/10, got HTTP $HTTP_STATUS)"
+            echo "Waiting for Web App health endpoint... (attempt $i/10)"
             sleep 15
           done
           if [ "$healthy" != "true" ]; then
-            echo "Web App health check failed after 10 attempts"
+            echo "Web App health endpoint failed after 10 attempts"
             exit 1
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install Dependencies
@@ -188,7 +188,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           cache: "pnpm"
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deployment-checklist.yml
+++ b/.github/workflows/deployment-checklist.yml
@@ -305,7 +305,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install Dependencies
@@ -342,7 +342,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "next build",

--- a/terraform/modules/webapp/main.tf
+++ b/terraform/modules/webapp/main.tf
@@ -52,7 +52,7 @@ resource "azurerm_linux_web_app" "main" {
 
   site_config {
     application_stack {
-      node_version = "24-lts"
+      node_version = "22-lts"
     }
 
     app_command_line = "node server.js"
@@ -71,7 +71,7 @@ resource "azurerm_linux_web_app" "main" {
   }
 
   app_settings = merge({
-    WEBSITE_NODE_DEFAULT_VERSION = "~24"
+    WEBSITE_NODE_DEFAULT_VERSION = "~22"
     HOSTNAME                     = "0.0.0.0"
     NODE_ENV                     = "production"
     NEXT_PUBLIC_APP_URL          = local.app_base_url


### PR DESCRIPTION
## Summary
- pin App Service Terraform and runtime app setting back to Node 22, the highest stack that currently starts successfully on Linux App Service
- align CI/deploy Node setup and package engines with the supported production runtime
- harden post-deploy health verification to call /api/health and require the healthy JSON payload instead of accepting Azure's default / page

## Production evidence
- Attempting the built-in Linux App Service Node 24 stack caused the site to serve Azure's default page and /api/health returned 404.
- Kudu reported: This runtime stack is not yet supported on Linux.
- Live production was restored with linuxFxVersion NODE|22-lts and WEBSITE_NODE_DEFAULT_VERSION ~22; /api/health returned 200 healthy.

## Verification
- terraform fmt -check -recursive terraform
- pnpm exec prettier --check .github/workflows/deploy-on-merge.yml .github/workflows/deploy.yml .github/workflows/deployment-checklist.yml package.json
- pnpm run lint
- pnpm test -- --run
- pnpm run build
- curl.exe -sS -i https://nl-prod-hov-app.azurewebsites.net/api/health

## Notes
- Node 24 can still be revisited via a custom container or once Azure Linux App Service fully supports the stack for this app. This PR keeps production on the currently working managed runtime.