### PR TITLE
Clean build warning and parallelize CI

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -33,10 +33,10 @@ env:
   AZURE_ENV: "prod"
 
 jobs:
-  build:
-    name: "Build Application"
+  quality-checks:
+    name: "Quality Checks"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     services:
       mongodb:
         image: mongo:7
@@ -73,6 +73,40 @@ jobs:
       - name: Run Unit Tests
         run: pnpm test
 
+  build:
+    name: "Build Application"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      MONGODB_URI: mongodb://localhost:27017/house_of_veritas_test
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.30.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Build Application
         run: pnpm build
 
@@ -97,7 +131,7 @@ jobs:
     name: "Deploy Web App"
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [build]
+    needs: [quality-checks, build]
     environment: production
 
     steps:

--- a/.github/workflows/deployment-checklist.yml
+++ b/.github/workflows/deployment-checklist.yml
@@ -286,12 +286,12 @@ jobs:
           echo "✅ All required configuration files present"
 
   # ============================================
-  # Job 3: Build & Test Next.js Application
+  # Job 3: Lint Next.js Application
   # ============================================
-  build-test:
-    name: "Build & Test"
+  lint:
+    name: "Lint"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - name: Checkout Repository
@@ -314,21 +314,71 @@ jobs:
       - name: Lint Check
         run: pnpm lint
 
-      - name: Build Application
-        run: pnpm build
+  # ============================================
+  # Job 4: Unit Tests
+  # ============================================
+  unit-tests:
+    name: "Unit Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.30.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run Tests
         run: pnpm test -- --run
 
   # ============================================
-  # Job 4: E2E Tests
+  # Job 5: Production Build
+  # ============================================
+  production-build:
+    name: "Production Build"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.30.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Application
+        run: pnpm build
+
+  # ============================================
+  # Job 6: E2E Tests
   # ============================================
   e2e:
     name: "E2E Tests"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-test]
-    if: needs.build-test.result == 'success'
 
     steps:
       - name: Checkout Repository
@@ -363,13 +413,13 @@ jobs:
           AUTH_SECRET: e2e-test-secret-do-not-use-in-production
 
   # ============================================
-  # Job 5: Summary Report
+  # Job 7: Summary Report
   # ============================================
   summary:
     name: "Pipeline Summary"
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [deployment-checklist, validate-config, build-test, e2e]
+    needs: [deployment-checklist, validate-config, lint, unit-tests, production-build, e2e]
     if: always()
 
     steps:
@@ -379,10 +429,12 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Deployment Checklist | ${{ needs.deployment-checklist.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Deployment Checklist | ${{ (needs.deployment-checklist.result == 'success' && '✅ Passed') || (needs.deployment-checklist.result == 'skipped' && '⏭️ Skipped') || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Configuration Validation | ${{ needs.validate-config.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Build & Test | ${{ needs.build-test.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| E2E Tests | ${{ (needs.e2e.result == 'success' && '✅ Passed') || (needs.e2e.result == 'skipped' && '⏭️ Skipped') || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Lint | ${{ needs.lint.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Unit Tests | ${{ needs.unit-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Production Build | ${{ needs.production-build.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| E2E Tests | ${{ needs.e2e.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Infrastructure Status" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Passed: ${{ needs.deployment-checklist.outputs.passed || '0' }}" >> $GITHUB_STEP_SUMMARY

--- a/app/api/files/route.ts
+++ b/app/api/files/route.ts
@@ -13,6 +13,8 @@ const UPLOAD_CONFIG = {
   uploadDir: "/tmp/uploads", // Local fallback, Azure preferred
 }
 
+const LOCAL_UPLOAD_ROOT = "/tmp/uploads"
+
 // Azure Blob Storage configuration (optional)
 const AZURE_CONFIG = {
   connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
@@ -29,7 +31,7 @@ function isAzureConfigured(): boolean {
 // Generate unique filename
 function generateUniqueFilename(originalName: string): string {
   const ext = path.extname(originalName)
-  const baseName = path.basename(originalName, ext)
+  const baseName = path.basename(originalName, ext).replace(/[^a-zA-Z0-9._-]/g, "-") || "file"
   const timestamp = Date.now()
   const hash = crypto.randomBytes(8).toString("hex")
   return `${baseName}-${timestamp}-${hash}${ext}`
@@ -111,14 +113,14 @@ async function uploadToLocal(
   filename: string,
   category: string
 ): Promise<{ url: string; path: string }> {
-  const uploadDir = path.join(UPLOAD_CONFIG.uploadDir, category)
+  const uploadDir = `${LOCAL_UPLOAD_ROOT}/${category}`
 
   // Ensure directory exists
   if (!existsSync(uploadDir)) {
     await mkdir(uploadDir, { recursive: true })
   }
 
-  const filePath = path.join(uploadDir, filename)
+  const filePath = `${uploadDir}/${filename}`
   await writeFile(filePath, buffer)
 
   const url = `/api/files/serve?category=${encodeURIComponent(category)}&filename=${encodeURIComponent(filename)}`
@@ -256,14 +258,14 @@ export const DELETE = withAuth(async (request) => {
           { status: 400 }
         )
       }
-      if (category !== normalizeStorageSegment(category, "") || filename !== path.basename(filename)) {
+      if (
+        category !== normalizeStorageSegment(category, "") ||
+        filename.includes("/") ||
+        filename.includes("\\")
+      ) {
         return NextResponse.json({ success: false, error: "Invalid path" }, { status: 400 })
       }
-      const baseDir = path.resolve(UPLOAD_CONFIG.uploadDir, category)
-      const filePath = path.resolve(baseDir, filename)
-      if (!filePath.startsWith(baseDir + path.sep)) {
-        return NextResponse.json({ success: false, error: "Invalid path" }, { status: 400 })
-      }
+      const filePath = `${LOCAL_UPLOAD_ROOT}/${category}/${filename}`
       await unlink(filePath)
     }
 

--- a/app/api/files/serve/route.ts
+++ b/app/api/files/serve/route.ts
@@ -20,17 +20,16 @@ export const GET = withAuth(async (request) => {
     return NextResponse.json({ error: "Invalid category" }, { status: 400 })
   }
 
-  const safeName = path.basename(filename)
-  if (safeName !== filename || filename.includes("..")) {
+  if (filename.includes("/") || filename.includes("\\") || filename.includes("..")) {
     return NextResponse.json({ error: "Invalid filename" }, { status: 400 })
   }
 
-  const filePath = path.join(UPLOAD_DIR, category, safeName)
+  const filePath = `${UPLOAD_DIR}/${category}/${filename}`
   if (!existsSync(filePath)) {
     return NextResponse.json({ error: "File not found" }, { status: 404 })
   }
 
-  const ext = path.extname(safeName).toLowerCase()
+  const ext = path.extname(filename).toLowerCase()
   const mimeTypes: Record<string, string> = {
     ".jpg": "image/jpeg",
     ".jpeg": "image/jpeg",


### PR DESCRIPTION
## Summary
- remove dynamic local upload path tracing from /api/files and /api/files/serve so Turbopack no longer traces the whole repo for the route
- sanitize generated local upload filename stems and reject slash/backslash traversal in local file delete/serve paths
- split Deployment Checklist app gates into independent lint, unit test, production build, and E2E jobs for faster Renovate/dependency PR feedback
- split Deploy on Merge into parallel quality checks and build lanes before Azure deployment
- report skipped infra checks correctly for dependency-bot PR summaries

## Verification
- pnpm exec prettier --check .github/workflows/deployment-checklist.yml .github/workflows/deploy-on-merge.yml app/api/files/route.ts app/api/files/serve/route.ts
- pnpm run lint
- pnpm test
- pnpm run build

## Notes
- Final local build completed without the previous Turbopack NFT warning.