### PR TITLE
docs: close out Mystira OIDC production follow-ups

### DIFF
--- a/docs/handoffs/2026-07-23-hov-mystira-oidc-prod-closeout.md
+++ b/docs/handoffs/2026-07-23-hov-mystira-oidc-prod-closeout.md
@@ -1,0 +1,37 @@
+# Handoff - HOV Mystira OIDC production closeout
+
+- **Date:** 2026-07-23
+- **Repo:** `C:\Users\smitj\repos\house-of-veritas`
+- **Branch:** `main`
+- **Baton tasks:** `4caa078e-a290-4ead-b551-9009d9469f83`, `8fa30c89-a27c-4f2a-b517-d2b651e146ab`
+- **Area:** Mystira Identity issuer, OIDC client secret, Azure Key Vault reference
+
+## Live Production Evidence
+
+Checked on 2026-07-23:
+
+- HOV production App Service `nl-prod-hov-app` has `MYSTIRA_OIDC_ISSUER=https://identity.mystira.app`.
+- HOV production App Service has `MYSTIRA_OIDC_CLIENT_ID=neuralliquid-hov-web`.
+- HOV production App Service has `MYSTIRA_OIDC_CLIENT_SECRET=@Microsoft.KeyVault(SecretUri=https://nl-prod-hov-kv.vault.azure.net/secrets/mystira-oidc-client-secret)`.
+- App Service config reference status for `MYSTIRA_OIDC_CLIENT_SECRET` is `Resolved` with `identityType=SystemAssigned`.
+- HOV production managed identity is SystemAssigned with principal ID `77a6c4b6-699b-4d4f-9c6e-d65228d3916d`.
+- Key Vault `nl-prod-hov-kv` uses access policies, not RBAC (`enableRbacAuthorization=false`).
+- Local interactive Azure user cannot list Key Vault secrets; that is expected and does not contradict the App Service reference status.
+- `https://identity.mystira.app/.well-known/openid-configuration` returns a standards-compliant OpenIddict discovery document with `/connect/authorize`, `/connect/token`, `/connect/userinfo`, `/connect/endsession`, `/connect/revoke`, `/connect/introspect`, and JWKS endpoints.
+- `https://hov.neuralliquid.ai/api/health` returns `status=healthy` with clean empty data mode.
+
+## Repo State
+
+Terraform production defaults now match the live production posture:
+
+- `mystira_oidc_issuer` defaults to `https://identity.mystira.app`.
+- `mystira_oidc_client_id` defaults to `neuralliquid-hov-web`.
+- `mystira_oidc_client_secret_key_vault_secret_name` defaults to `mystira-oidc-client-secret`.
+- `terraform/modules/webapp` emits `MYSTIRA_OIDC_CLIENT_SECRET` as an App Service Key Vault reference when the secret-name variable is set.
+- `terraform/modules/webapp` grants the web app SystemAssigned managed identity `Get` and `List` secret permissions on the HOV Key Vault.
+
+## Closeout
+
+The old Baton tasks were stale. The production issuer cutover and Key Vault secret reference are already live and resolved. No HOV runtime code change was required in this closeout pass.
+
+Residual manual check: a browser login round trip can still be used as a final smoke check when an operator account is available, but the infrastructure/configuration blockers tracked by these tasks are closed.

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -466,11 +466,10 @@ variable "custom_domain" {
 # -----------------------------------------------------------------------------
 # Auth.js v5 + Mystira OIDC (relying party: neuralliquid-hov-web)
 # -----------------------------------------------------------------------------
-# The issuer defaults to the deployed Mystira dev IdP, which is the identity
-# provider HOV currently authenticates against. When a dedicated staging/prod
-# Mystira issuer is provisioned, override MYSTIRA_OIDC_ISSUER (and supply the
-# matching client secret from Key Vault / GitHub secrets). The issuer host is
-# public config, not a secret — see .env.example.
+# The issuer defaults to the production Mystira Identity host that HOV currently
+# authenticates against. The issuer host is public config, not a secret; keep the
+# client secret in Key Vault and reference it via
+# mystira_oidc_client_secret_key_vault_secret_name.
 variable "mystira_oidc_issuer" {
   description = "Mystira OIDC issuer URL"
   type        = string
@@ -483,9 +482,9 @@ variable "mystira_oidc_client_id" {
   default     = "neuralliquid-hov-web"
 }
 
-# Supply via a GitHub Actions secret / untracked tfvars — never commit the value.
-# When empty, the app falls back to its in-code dev client secret, which matches
-# the seeded neuralliquid-hov-web client on the dev IdP above.
+# Prefer Key Vault references via mystira_oidc_client_secret_key_vault_secret_name.
+# This plaintext variable remains only as a fallback escape hatch for non-prod or
+# emergency use; never commit a real value.
 variable "mystira_oidc_client_secret" {
   description = "Mystira OIDC client secret for the House of Veritas relying party"
   type        = string
@@ -579,7 +578,7 @@ variable "ci_allowed_ip_ranges" {
   default     = []
 }
 variable "mystira_oidc_client_secret_key_vault_secret_name" {
-  description = "Name of the HOV Key Vault secret containing the Mystira OIDC client secret. Leave empty until the secret exists and issuer cutover is approved."
+  description = "Name of the HOV Key Vault secret containing the Mystira OIDC client secret. When set, the web app receives a Key Vault reference instead of a plaintext secret."
   type        = string
   default     = "mystira-oidc-client-secret"
 }


### PR DESCRIPTION
## Summary
- record live HOV production evidence for the Mystira Identity issuer and Key Vault client-secret reference
- correct stale Terraform comments around the production OIDC defaults
- document that the old Baton issuer/secret tasks were stale and are now closed out by live Azure evidence

## Validation
- terraform fmt -check terraform/environments/production/variables.tf
- git diff --check
- az webapp config appsettings list confirmed MYSTIRA_OIDC_ISSUER=https://identity.mystira.app and MYSTIRA_OIDC_CLIENT_SECRET is a Key Vault reference
- az rest configreferences confirmed MYSTIRA_OIDC_CLIENT_SECRET status=Resolved using SystemAssigned identity
- curl https://identity.mystira.app/.well-known/openid-configuration returned the OpenIddict discovery document
- curl https://hov.neuralliquid.ai/api/health returned status=healthy

## Notes
- no production apply, secret read, or secret rotation was performed
- local Azure user lacks Key Vault secret list permission; App Service configreference status was used as the proof that the secret reference resolves