### PR TITLE
feat: add mobile inventory photo capture

### DIFF
--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -51,6 +51,26 @@ function findInventoryItemByName(inventory: InventoryItem[], name: string): numb
   return -1
 }
 
+function optionalText(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  return trimmed.slice(0, maxLength)
+}
+
+function optionalPhotoUrl(value: unknown): string | undefined {
+  const photoUrl = optionalText(value, 2048)
+  if (!photoUrl) return undefined
+  if (
+    photoUrl.startsWith("/api/uploads/") ||
+    photoUrl.startsWith("/api/files/serve?") ||
+    photoUrl.startsWith("https://")
+  ) {
+    return photoUrl
+  }
+  return undefined
+}
+
 // GET - List inventory with filters
 export const GET = withRole(
   "admin",
@@ -127,7 +147,8 @@ export const GET = withRole(
 export const POST = withRole(
   "admin",
   "operator",
-  "employee"
+  "employee",
+  "resident"
 )(async (request: Request) => {
   const inventory = getInventory()
   try {
@@ -220,6 +241,9 @@ export const POST = withRole(
       location,
       supplier,
       unitCost,
+      label,
+      photoUrl,
+      photoFileId,
     } = body
 
     if (!name || !category || !unit || !location) {
@@ -231,19 +255,26 @@ export const POST = withRole(
 
     const newItem: InventoryItem = {
       id: `inv_${Date.now()}`,
-      name,
+      name: optionalText(name, 120) ?? name,
       category,
-      unit,
+      unit: optionalText(unit, 40) ?? unit,
       currentStock: currentStock || 0,
       minStock: minStock || 1,
       maxStock: maxStock || 10,
       reorderPoint: reorderPoint || minStock || 1,
       lastRestocked: new Date().toISOString().split("T")[0],
       averageConsumption: 0,
-      location,
-      supplier,
+      location: optionalText(location, 120) ?? location,
+      supplier: optionalText(supplier, 120),
       unitCost: unitCost || 0,
       totalValue: (currentStock || 0) * (unitCost || 0),
+      label: optionalText(label, 120),
+      photoUrl: optionalPhotoUrl(photoUrl),
+      photoFileId: optionalText(photoFileId, 120),
+      photoUploadedAt: optionalPhotoUrl(photoUrl) ? new Date().toISOString() : undefined,
+      capturedBy: optionalPhotoUrl(photoUrl)
+        ? optionalText(request.headers.get("x-user-id"), 80)
+        : undefined,
       consumptionHistory: [],
     }
 

--- a/app/dashboard/charl/page.tsx
+++ b/app/dashboard/charl/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import DashboardLayout from "@/components/dashboard-layout"
+import { InventoryPhotoCapture } from "@/components/inventory-photo-capture"
 import { logger } from "@/lib/logger"
 import { apiFetchSafe } from "@/lib/api-client"
 import {
@@ -146,7 +147,9 @@ export default function CharlDashboard() {
           <div className="flex items-center gap-3">
             <div className="mr-4 hidden text-right md:block">
               <p className="text-sm text-amber-200/60">Clocked in at</p>
-              <p className="font-medium text-amber-100">{isClockRunning ? "Manual session" : "Not clocked in"}</p>
+              <p className="font-medium text-amber-100">
+                {isClockRunning ? "Manual session" : "Not clocked in"}
+              </p>
             </div>
             <button
               onClick={() => setIsClockRunning(!isClockRunning)}
@@ -188,6 +191,8 @@ export default function CharlDashboard() {
           <Settings className="h-4 w-4" /> Magicman
         </span>
       </div>
+
+      <InventoryPhotoCapture persona="charl" tone="amber" />
 
       {/* Stats Row */}
       <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
@@ -249,7 +254,10 @@ export default function CharlDashboard() {
             </div>
           </div>
           <div className="h-64">
-            <EmptyPanel title="No weekly task history" action="Assigned and completed task history will appear after live task records exist." />
+            <EmptyPanel
+              title="No weekly task history"
+              action="Assigned and completed task history will appear after live task records exist."
+            />
           </div>
         </div>
 
@@ -261,7 +269,10 @@ export default function CharlDashboard() {
           <h3 className="mb-2 font-semibold text-amber-100">Skills Distribution</h3>
           <p className="mb-4 text-sm text-amber-200/50">Task types this month</p>
           <div className="h-48">
-            <EmptyPanel title="No task-type data" action="Skill distribution will appear once tasks are categorized." />
+            <EmptyPanel
+              title="No task-type data"
+              action="Skill distribution will appear once tasks are categorized."
+            />
           </div>
         </div>
       </div>
@@ -286,7 +297,10 @@ export default function CharlDashboard() {
             </span>
           </div>
           <div className="max-h-96 space-y-3 overflow-y-auto p-4">
-            <EmptyPanel title="No assigned tasks" action="Live task assignments will appear here." />
+            <EmptyPanel
+              title="No assigned tasks"
+              action="Live task assignments will appear here."
+            />
           </div>
         </div>
 
@@ -305,7 +319,10 @@ export default function CharlDashboard() {
             </div>
           </div>
           <div className="p-4">
-            <EmptyPanel title="No workshop asset data" action="Equipment checkouts will appear after asset records are connected." />
+            <EmptyPanel
+              title="No workshop asset data"
+              action="Equipment checkouts will appear after asset records are connected."
+            />
           </div>
         </div>
 
@@ -327,7 +344,10 @@ export default function CharlDashboard() {
             </span>
           </div>
           <div className="p-6">
-            <EmptyPanel title="Vehicles are coming soon" action="Trip logging, mileage, fuel, and compliance checks are not active yet." />
+            <EmptyPanel
+              title="Vehicles are coming soon"
+              action="Trip logging, mileage, fuel, and compliance checks are not active yet."
+            />
           </div>
         </div>
       </div>

--- a/app/dashboard/hans/page.tsx
+++ b/app/dashboard/hans/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import DashboardLayout from "@/components/dashboard-layout"
+import { InventoryPhotoCapture } from "@/components/inventory-photo-capture"
 import { WidgetErrorBoundary } from "@/components/widget-error-boundary"
 import { apiFetchSafe } from "@/lib/api-client"
 import {
@@ -21,7 +22,18 @@ import {
 } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
-import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
 
 interface DashboardStats {
   dataSource?: "empty" | "demo" | "live"
@@ -240,7 +252,13 @@ export default function DashboardPage() {
   ].filter((item) => item.value > 0)
   const budgetData =
     budget.allocated > 0 || budget.spent > 0
-      ? [{ month: currentTime.toLocaleString("en-ZA", { month: "short" }), allocated: budget.allocated, spent: budget.spent }]
+      ? [
+          {
+            month: currentTime.toLocaleString("en-ZA", { month: "short" }),
+            allocated: budget.allocated,
+            spent: budget.spent,
+          },
+        ]
       : []
   const hasTaskStatus = taskStatusData.length > 0
   const hasBudgetData = budgetData.length > 0
@@ -267,6 +285,13 @@ export default function DashboardPage() {
         </span>
       </div>
 
+      <InventoryPhotoCapture
+        persona="hans"
+        tone="blue"
+        defaultCategory="other"
+        defaultLocation="House"
+      />
+
       {/* Stats Grid */}
       <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
         <WidgetErrorBoundary>
@@ -280,12 +305,7 @@ export default function DashboardPage() {
           />
         </WidgetErrorBoundary>
         <WidgetErrorBoundary>
-          <StatCard
-            title="Active Employees"
-            value={users.active}
-            icon={Users}
-            color="green"
-          />
+          <StatCard title="Active Employees" value={users.active} icon={Users} color="green" />
         </WidgetErrorBoundary>
         <WidgetErrorBoundary>
           <StatCard
@@ -345,12 +365,20 @@ export default function DashboardPage() {
                       tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`}
                     />
                     <Tooltip content={<CustomTooltip />} />
-                    <Bar dataKey="allocated" fill="#3b82f6" radius={[4, 4, 0, 0]} name="Allocated" />
+                    <Bar
+                      dataKey="allocated"
+                      fill="#3b82f6"
+                      radius={[4, 4, 0, 0]}
+                      name="Allocated"
+                    />
                     <Bar dataKey="spent" fill="#10b981" radius={[4, 4, 0, 0]} name="Spent" />
                   </BarChart>
                 </ResponsiveContainer>
               ) : (
-                <EmptyPanel title="No budget data yet" action="Approved expenses and configured budgets will appear here." />
+                <EmptyPanel
+                  title="No budget data yet"
+                  action="Approved expenses and configured budgets will appear here."
+                />
               )}
             </div>
           </div>
@@ -385,7 +413,10 @@ export default function DashboardPage() {
                   </PieChart>
                 </ResponsiveContainer>
               ) : (
-                <EmptyPanel title="No tasks yet" action="Create or sync tasks to populate this overview." />
+                <EmptyPanel
+                  title="No tasks yet"
+                  action="Create or sync tasks to populate this overview."
+                />
               )}
             </div>
             {hasTaskStatus && (
@@ -423,7 +454,10 @@ export default function DashboardPage() {
               </div>
             </div>
             <div className="h-64">
-              <EmptyPanel title="No employee performance data yet" action="Task completion by assignee will appear after live task records exist." />
+              <EmptyPanel
+                title="No employee performance data yet"
+                action="Task completion by assignee will appear after live task records exist."
+              />
             </div>
           </div>
         </WidgetErrorBoundary>
@@ -445,7 +479,10 @@ export default function DashboardPage() {
               </div>
             </div>
             <div className="h-64">
-              <EmptyPanel title="No compliance trend yet" action="Signed document history will populate this chart after live records exist." />
+              <EmptyPanel
+                title="No compliance trend yet"
+                action="Signed document history will populate this chart after live records exist."
+              />
             </div>
           </div>
         </WidgetErrorBoundary>
@@ -469,7 +506,10 @@ export default function DashboardPage() {
               </span>
             </div>
             <div className="max-h-96 space-y-3 overflow-y-auto p-4">
-              <EmptyPanel title="No pending approvals" action="Submitted expenses or approval workflows will appear here." />
+              <EmptyPanel
+                title="No pending approvals"
+                action="Submitted expenses or approval workflows will appear here."
+              />
             </div>
             <div className="border-t border-blue-500/20 p-4">
               <button
@@ -500,7 +540,10 @@ export default function DashboardPage() {
                 <AlertTriangle className="h-5 w-5 text-amber-400" />
               </div>
               <div className="space-y-3 p-4">
-                <EmptyPanel title="No expiring documents" action="Connected document records will appear here." />
+                <EmptyPanel
+                  title="No expiring documents"
+                  action="Connected document records will appear here."
+                />
               </div>
             </div>
           </WidgetErrorBoundary>
@@ -515,7 +558,10 @@ export default function DashboardPage() {
                 <h3 className="font-semibold text-blue-100">Recent Activity</h3>
               </div>
               <div className="divide-y divide-blue-500/10 p-4">
-                <EmptyPanel title="No recent activity" action="Live events will appear here after work is recorded." />
+                <EmptyPanel
+                  title="No recent activity"
+                  action="Live events will appear here after work is recorded."
+                />
               </div>
             </div>
           </WidgetErrorBoundary>
@@ -533,7 +579,9 @@ export default function DashboardPage() {
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-blue-200/60">Data mode</span>
-                  <span className="text-sm font-medium text-blue-100">{stats?.dataSource ?? "empty"}</span>
+                  <span className="text-sm font-medium text-blue-100">
+                    {stats?.dataSource ?? "empty"}
+                  </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-blue-200/60">Tasks tracked</span>

--- a/app/dashboard/irma/page.tsx
+++ b/app/dashboard/irma/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import DashboardLayout from "@/components/dashboard-layout"
+import { InventoryPhotoCapture } from "@/components/inventory-photo-capture"
 import { logger } from "@/lib/logger"
 import { apiFetch } from "@/lib/api-client"
 import {
@@ -189,6 +190,13 @@ export default function IrmaDashboard() {
         </span>
       </div>
 
+      <InventoryPhotoCapture
+        persona="irma"
+        tone="purple"
+        defaultCategory="household"
+        defaultLocation="House"
+      />
+
       {/* Quick Stats */}
       <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
         <div
@@ -236,7 +244,7 @@ export default function IrmaDashboard() {
         >
           <div className="mb-2 flex items-center gap-3">
             <UtensilsCrossed className="h-5 w-5 text-purple-400" />
-          <p className="text-sm text-purple-200/60">Meals Planned</p>
+            <p className="text-sm text-purple-200/60">Meals Planned</p>
           </div>
           <p className="text-2xl font-bold text-purple-100">0</p>
           <p className="text-sm text-purple-200/50">No meal records</p>
@@ -261,7 +269,10 @@ export default function IrmaDashboard() {
             </div>
           </div>
           <div className="h-64">
-            <EmptyPanel title="No weekly task history" action="Completed and assigned task history will appear after live records exist." />
+            <EmptyPanel
+              title="No weekly task history"
+              action="Completed and assigned task history will appear after live records exist."
+            />
           </div>
         </div>
 
@@ -273,7 +284,10 @@ export default function IrmaDashboard() {
           <h3 className="mb-2 font-semibold text-purple-100">Task Distribution</h3>
           <p className="mb-4 text-sm text-purple-200/50">By category this month</p>
           <div className="h-48">
-            <EmptyPanel title="No task distribution" action="Task categories will appear once live household tasks are categorized." />
+            <EmptyPanel
+              title="No task distribution"
+              action="Task categories will appear once live household tasks are categorized."
+            />
           </div>
         </div>
       </div>
@@ -369,7 +383,10 @@ export default function IrmaDashboard() {
             </button>
           </div>
           <div className="p-4">
-            <EmptyPanel title="No meals planned" action="Meal plans will appear here after records are connected." />
+            <EmptyPanel
+              title="No meals planned"
+              action="Meal plans will appear here after records are connected."
+            />
           </div>
         </div>
 
@@ -442,7 +459,10 @@ export default function IrmaDashboard() {
             </div>
           </div>
           <div className="p-6">
-            <EmptyPanel title="No weekly schedule" action="Household roster entries will appear after schedule data exists." />
+            <EmptyPanel
+              title="No weekly schedule"
+              action="Household roster entries will appear after schedule data exists."
+            />
           </div>
         </div>
       </div>

--- a/app/dashboard/lucky/page.tsx
+++ b/app/dashboard/lucky/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import DashboardLayout from "@/components/dashboard-layout"
+import { InventoryPhotoCapture } from "@/components/inventory-photo-capture"
 import { logger } from "@/lib/logger"
 import { apiFetchSafe } from "@/lib/api-client"
 import {
@@ -192,7 +193,9 @@ export default function LuckyDashboard() {
           <div className="flex items-center gap-3">
             <div className="mr-4 hidden text-right md:block">
               <p className="text-sm text-green-200/60">Clocked in at</p>
-              <p className="font-medium text-green-100">{isClockRunning ? "Manual session" : "Not clocked in"}</p>
+              <p className="font-medium text-green-100">
+                {isClockRunning ? "Manual session" : "Not clocked in"}
+              </p>
             </div>
             <button
               onClick={() => setIsClockRunning(!isClockRunning)}
@@ -240,6 +243,13 @@ export default function LuckyDashboard() {
         </div>
       </div>
 
+      <InventoryPhotoCapture
+        persona="lucky"
+        tone="green"
+        defaultCategory="garden_supplies"
+        defaultLocation="Yard"
+      />
+
       {/* Stats Row */}
       <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
         <div
@@ -263,7 +273,9 @@ export default function LuckyDashboard() {
           data-testid="stat-expenses"
         >
           <p className="text-sm text-green-200/60">Monthly Expenses</p>
-          <p className="text-2xl font-bold text-green-100">R{expenses.thisMonth.toLocaleString()}</p>
+          <p className="text-2xl font-bold text-green-100">
+            R{expenses.thisMonth.toLocaleString()}
+          </p>
           <p className="text-sm text-amber-400">{expenses.pending} pending approval</p>
         </div>
         <div
@@ -294,7 +306,10 @@ export default function LuckyDashboard() {
             </div>
           </div>
           <div className="h-64">
-            <EmptyPanel title="No weekly hours" action="Clock records will populate this chart after time tracking is connected." />
+            <EmptyPanel
+              title="No weekly hours"
+              action="Clock records will populate this chart after time tracking is connected."
+            />
           </div>
         </div>
 
@@ -306,7 +321,10 @@ export default function LuckyDashboard() {
           <h3 className="mb-2 font-semibold text-green-100">Task Types</h3>
           <p className="mb-4 text-sm text-green-200/50">This month&apos;s work</p>
           <div className="h-48">
-            <EmptyPanel title="No task-type data" action="Task categories will appear once live work records exist." />
+            <EmptyPanel
+              title="No task-type data"
+              action="Task categories will appear once live work records exist."
+            />
           </div>
         </div>
       </div>
@@ -328,7 +346,10 @@ export default function LuckyDashboard() {
             </div>
           </div>
           <div className="space-y-3 p-4">
-            <EmptyPanel title="No assigned tasks" action="Live garden and maintenance tasks will appear here." />
+            <EmptyPanel
+              title="No assigned tasks"
+              action="Live garden and maintenance tasks will appear here."
+            />
           </div>
         </div>
 
@@ -354,7 +375,10 @@ export default function LuckyDashboard() {
             </button>
           </div>
           <div className="space-y-3 p-4">
-            <EmptyPanel title="No expenses submitted" action="Expense submissions will appear here after live records exist." />
+            <EmptyPanel
+              title="No expenses submitted"
+              action="Expense submissions will appear here after live records exist."
+            />
           </div>
           <div className="border-t border-green-500/20 p-4">
             <button
@@ -389,7 +413,10 @@ export default function LuckyDashboard() {
             </div>
           </div>
           <div className="h-48">
-            <EmptyPanel title="No monthly expense trend" action="Approved and pending expenses will appear after submissions exist." />
+            <EmptyPanel
+              title="No monthly expense trend"
+              action="Approved and pending expenses will appear after submissions exist."
+            />
           </div>
         </div>
 
@@ -411,7 +438,10 @@ export default function LuckyDashboard() {
             </span>
           </div>
           <div className="p-4">
-            <EmptyPanel title="Vehicles are coming soon" action="Trip logging, mileage, fuel, and compliance checks are not active yet." />
+            <EmptyPanel
+              title="Vehicles are coming soon"
+              action="Trip logging, mileage, fuel, and compliance checks are not active yet."
+            />
           </div>
         </div>
       </div>

--- a/components/inventory-photo-capture.tsx
+++ b/components/inventory-photo-capture.tsx
@@ -1,0 +1,317 @@
+"use client"
+
+import { apiFetch } from "@/lib/api-client"
+import { useAuth } from "@/lib/auth-context"
+import { logger } from "@/lib/logger"
+import { AlertCircle, Camera, CheckCircle2, Tag, Upload } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+
+const INVENTORY_CATEGORIES = [
+  { value: "workshop_consumables", label: "Workshop" },
+  { value: "building_materials", label: "Building" },
+  { value: "fuel", label: "Fuel" },
+  { value: "garden_supplies", label: "Garden" },
+  { value: "cleaning_supplies", label: "Cleaning" },
+  { value: "household", label: "Household" },
+  { value: "other", label: "Other" },
+] as const
+
+const QUICK_LOCATIONS = [
+  "Workshop Store",
+  "Tool Wall",
+  "Fuel Store",
+  "Yard",
+  "Container",
+  "House",
+] as const
+
+type InventoryTone = "blue" | "amber" | "green" | "purple"
+
+const toneClasses: Record<
+  InventoryTone,
+  {
+    border: string
+    panel: string
+    soft: string
+    text: string
+    muted: string
+    button: string
+    focus: string
+  }
+> = {
+  blue: {
+    border: "border-blue-500/25",
+    panel: "bg-blue-950/45",
+    soft: "bg-blue-500/20",
+    text: "text-blue-100",
+    muted: "text-blue-200/55",
+    button: "border-blue-400/40 bg-blue-500 text-white hover:bg-blue-400",
+    focus: "focus:border-blue-300",
+  },
+  amber: {
+    border: "border-amber-500/25",
+    panel: "bg-amber-950/45",
+    soft: "bg-amber-500/20",
+    text: "text-amber-100",
+    muted: "text-amber-200/55",
+    button: "border-amber-400/40 bg-amber-500 text-black hover:bg-amber-400",
+    focus: "focus:border-amber-300",
+  },
+  green: {
+    border: "border-green-500/25",
+    panel: "bg-green-950/45",
+    soft: "bg-green-500/20",
+    text: "text-green-100",
+    muted: "text-green-200/55",
+    button: "border-green-400/40 bg-green-500 text-black hover:bg-green-400",
+    focus: "focus:border-green-300",
+  },
+  purple: {
+    border: "border-purple-500/25",
+    panel: "bg-purple-950/45",
+    soft: "bg-purple-500/20",
+    text: "text-purple-100",
+    muted: "text-purple-200/55",
+    button: "border-purple-400/40 bg-purple-500 text-white hover:bg-purple-400",
+    focus: "focus:border-purple-300",
+  },
+}
+
+interface InventoryPhotoCaptureProps {
+  persona: "hans" | "charl" | "lucky" | "irma"
+  tone: InventoryTone
+  defaultCategory?: string
+  defaultLocation?: string
+}
+
+export function InventoryPhotoCapture({
+  persona,
+  tone,
+  defaultCategory = "workshop_consumables",
+  defaultLocation = "Workshop Store",
+}: InventoryPhotoCaptureProps) {
+  const { user } = useAuth()
+  const styles = toneClasses[tone]
+  const [label, setLabel] = useState("")
+  const [category, setCategory] = useState(defaultCategory)
+  const [location, setLocation] = useState(defaultLocation)
+  const [photo, setPhoto] = useState<File | null>(null)
+  const [preview, setPreview] = useState<string | null>(null)
+  const previewRef = useRef<string | null>(null)
+  const [status, setStatus] = useState<{
+    type: "idle" | "saving" | "success" | "error"
+    message: string
+  }>({ type: "idle", message: "" })
+
+  function clearPreview() {
+    if (previewRef.current) {
+      URL.revokeObjectURL(previewRef.current)
+      previewRef.current = null
+    }
+    setPreview(null)
+  }
+
+  function selectPhoto(nextPhoto: File | null) {
+    clearPreview()
+    setPhoto(nextPhoto)
+    if (nextPhoto) {
+      const nextPreview = URL.createObjectURL(nextPhoto)
+      previewRef.current = nextPreview
+      setPreview(nextPreview)
+    }
+    setStatus({ type: "idle", message: "" })
+  }
+
+  useEffect(() => () => clearPreview(), [])
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const trimmedLabel = label.trim()
+    if (!trimmedLabel) {
+      setStatus({ type: "error", message: "Add a label before saving." })
+      return
+    }
+    if (!photo) {
+      setStatus({ type: "error", message: "Take or choose a photo first." })
+      return
+    }
+
+    const userId = user?.id ?? persona
+    setStatus({ type: "saving", message: "Uploading photo..." })
+
+    try {
+      const formData = new FormData()
+      formData.append("file", photo)
+      formData.append("userId", userId)
+      formData.append("category", "image")
+      formData.append("resourceType", "inventory")
+
+      const upload = await apiFetch<{
+        success: boolean
+        file: { id: string; url: string }
+      }>("/api/uploads", {
+        method: "POST",
+        body: formData,
+        label: "InventoryPhotoUpload",
+      })
+
+      setStatus({ type: "saving", message: "Saving label..." })
+
+      await apiFetch("/api/inventory", {
+        method: "POST",
+        body: {
+          name: trimmedLabel,
+          label: trimmedLabel,
+          category,
+          unit: "units",
+          currentStock: 1,
+          minStock: 1,
+          maxStock: 1,
+          reorderPoint: 1,
+          location,
+          unitCost: 0,
+          photoUrl: upload.file.url,
+          photoFileId: upload.file.id,
+        },
+        label: "InventoryPhotoLabel",
+      })
+
+      setLabel("")
+      setPhoto(null)
+      clearPreview()
+      setStatus({ type: "success", message: "Saved to inventory." })
+    } catch (error) {
+      logger.error("Failed to save inventory photo label", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      setStatus({ type: "error", message: "Could not save. Try again." })
+    }
+  }
+
+  return (
+    <section
+      className={`mb-6 overflow-hidden rounded-xl border ${styles.border} ${styles.panel} backdrop-blur-sm sm:mb-8`}
+      data-testid="inventory-photo-capture"
+    >
+      <div className={`border-b ${styles.border} p-4 sm:p-5`}>
+        <div className="flex items-center gap-3">
+          <div
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border ${styles.border} ${styles.soft}`}
+          >
+            <Camera className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <h3 className={`font-semibold ${styles.text}`}>Inventory Capture</h3>
+            <p className={`text-sm ${styles.muted}`}>Photo, label, save.</p>
+          </div>
+        </div>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="grid gap-3 p-3 sm:gap-4 sm:p-4 md:grid-cols-[minmax(180px,240px)_1fr]"
+      >
+        <label
+          className={`group flex aspect-4/3 min-h-44 cursor-pointer items-center justify-center overflow-hidden rounded-lg border border-dashed ${styles.border} bg-black/20 text-center transition-colors hover:bg-white/5`}
+        >
+          {preview ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={preview} alt="Inventory preview" className="h-full w-full object-cover" />
+          ) : (
+            <span className={`flex flex-col items-center gap-2 px-4 text-sm ${styles.muted}`}>
+              <Upload className="h-8 w-8" />
+              Take photo
+            </span>
+          )}
+          <input
+            type="file"
+            accept="image/*"
+            capture="environment"
+            className="sr-only"
+            data-testid="inventory-photo-input"
+            onChange={(event) => selectPhoto(event.target.files?.[0] ?? null)}
+          />
+        </label>
+
+        <div className="grid content-start gap-3">
+          <label className="grid gap-1.5">
+            <span className={`flex items-center gap-2 text-sm font-medium ${styles.text}`}>
+              <Tag className="h-4 w-4" />
+              Label
+            </span>
+            <input
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              placeholder="e.g. Blue drill bits"
+              maxLength={120}
+              data-testid="inventory-label-input"
+              className={`h-12 rounded-lg border ${styles.border} bg-black/25 px-3 text-base text-white outline-none placeholder:text-white/35 ${styles.focus}`}
+            />
+          </label>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="grid gap-1.5">
+              <span className={`text-sm font-medium ${styles.text}`}>Category</span>
+              <select
+                value={category}
+                onChange={(event) => setCategory(event.target.value)}
+                data-testid="inventory-category-select"
+                className={`h-12 rounded-lg border ${styles.border} bg-black/25 px-3 text-base text-white outline-none ${styles.focus}`}
+              >
+                {INVENTORY_CATEGORIES.map((item) => (
+                  <option key={item.value} value={item.value} className="bg-zinc-950">
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="grid gap-1.5">
+              <span className={`text-sm font-medium ${styles.text}`}>Location</span>
+              <select
+                value={location}
+                onChange={(event) => setLocation(event.target.value)}
+                data-testid="inventory-location-select"
+                className={`h-12 rounded-lg border ${styles.border} bg-black/25 px-3 text-base text-white outline-none ${styles.focus}`}
+              >
+                {QUICK_LOCATIONS.map((item) => (
+                  <option key={item} value={item} className="bg-zinc-950">
+                    {item}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="grid gap-3 sm:flex sm:items-center">
+            <button
+              type="submit"
+              disabled={status.type === "saving"}
+              data-testid="save-inventory-capture"
+              className={`inline-flex h-12 w-full items-center justify-center gap-2 rounded-lg border px-4 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto ${styles.button}`}
+            >
+              <Camera className="h-4 w-4" />
+              {status.type === "saving" ? "Saving..." : "Save"}
+            </button>
+
+            {status.message && (
+              <p
+                className={`flex items-center gap-2 text-sm ${
+                  status.type === "error" ? "text-red-300" : "text-emerald-300"
+                }`}
+                role={status.type === "error" ? "alert" : "status"}
+              >
+                {status.type === "error" ? (
+                  <AlertCircle className="h-4 w-4" />
+                ) : (
+                  <CheckCircle2 className="h-4 w-4" />
+                )}
+                {status.message}
+              </p>
+            )}
+          </div>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/lib/inventory-store.ts
+++ b/lib/inventory-store.ts
@@ -22,6 +22,11 @@ export interface InventoryItem {
   totalValue: number
   expiryDate?: string
   barcode?: string
+  label?: string
+  photoUrl?: string
+  photoFileId?: string
+  photoUploadedAt?: string
+  capturedBy?: string
   consumptionHistory: Array<{
     date: string
     quantity: number

--- a/tests/api/inventory.test.ts
+++ b/tests/api/inventory.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest"
+import { GET, POST } from "@/app/api/inventory/route"
+
+vi.mock("@/lib/workflows", () => ({ routeToInngest: vi.fn().mockResolvedValue(undefined) }))
+
+const operatorHeaders = {
+  "x-user-id": "charl",
+  "x-user-role": "operator",
+  "x-user-email": "charl@houseofv.com",
+  "Content-Type": "application/json",
+}
+
+describe("POST /api/inventory", () => {
+  it("creates a photo-labelled inventory item for an operator", async () => {
+    const label = `Photo label ${Date.now()}`
+    const request = new Request("http://localhost/api/inventory", {
+      method: "POST",
+      headers: operatorHeaders,
+      body: JSON.stringify({
+        name: label,
+        label,
+        category: "workshop_consumables",
+        unit: "units",
+        currentStock: 1,
+        minStock: 1,
+        maxStock: 1,
+        reorderPoint: 1,
+        location: "Workshop Store",
+        photoUrl: "/api/uploads/file_test_photo",
+        photoFileId: "file_test_photo",
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.item).toMatchObject({
+      name: label,
+      label,
+      photoUrl: "/api/uploads/file_test_photo",
+      photoFileId: "file_test_photo",
+      capturedBy: "charl",
+    })
+    expect(data.item.photoUploadedAt).toEqual(expect.any(String))
+  })
+
+  it("does not store unsafe photo URLs", async () => {
+    const label = `Unsafe photo ${Date.now()}`
+    const request = new Request("http://localhost/api/inventory", {
+      method: "POST",
+      headers: operatorHeaders,
+      body: JSON.stringify({
+        name: label,
+        label,
+        category: "workshop_consumables",
+        unit: "units",
+        location: "Workshop Store",
+        photoUrl: "javascript:alert(1)",
+        photoFileId: "file_unsafe",
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.item.photoUrl).toBeUndefined()
+    expect(data.item.capturedBy).toBeUndefined()
+  })
+})
+
+describe("GET /api/inventory", () => {
+  it("requires authentication", async () => {
+    const response = await GET(new Request("http://localhost/api/inventory"))
+    expect(response.status).toBe(401)
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared mobile-first Inventory Capture panel to Hans, Charl, Lucky, and Irma dashboards
- let authenticated users take/upload an item photo, label it, select category/location, and save it to inventory
- store optional photo metadata on inventory items with safe URL validation
- add focused inventory API coverage for photo-labelled item creation and unsafe URL rejection

## Validation
- pnpm test tests/api/inventory.test.ts
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

## Notes
- local browser check skipped per request; deploying for live testing after CI is green
- no production secrets or demo-data defaults changed