### PR TITLE
fix: show photo capture on inventory pages

### DIFF
--- a/app/dashboard/hans/inventory/page.tsx
+++ b/app/dashboard/hans/inventory/page.tsx
@@ -34,6 +34,7 @@ import {
 import { ScannerButton } from "@/components/barcode-scanner"
 import { LabelPrintDialog } from "@/components/barcode-label-generator"
 import { BatchScanDialog } from "@/components/batch-scanner"
+import { InventoryPhotoCapture } from "@/components/inventory-photo-capture"
 import {
   Boxes,
   Plus,
@@ -333,6 +334,14 @@ export default function InventoryPage() {
             </Button>
           </div>
         </div>
+
+        <InventoryPhotoCapture
+          persona="hans"
+          tone="blue"
+          defaultCategory={selectedCategory === "all" ? "workshop_consumables" : selectedCategory}
+          defaultLocation="Workshop Store"
+          onSaved={fetchInventory}
+        />
 
         {/* Alerts Banner */}
         {alerts.length > 0 && (

--- a/app/dashboard/lucky/inventory/page.tsx
+++ b/app/dashboard/lucky/inventory/page.tsx
@@ -19,6 +19,7 @@ import {
 import { Boxes, Search, AlertTriangle, Package, ArrowDown, Leaf } from "lucide-react"
 import { logger } from "@/lib/logger"
 import { apiFetch } from "@/lib/api-client"
+import { InventoryPhotoCapture } from "@/components/inventory-photo-capture"
 
 interface InventoryItem {
   id: string
@@ -111,6 +112,14 @@ export default function LuckyInventoryPage() {
           </h1>
           <p className="mt-1 text-white/60">Track and use garden supplies</p>
         </div>
+
+        <InventoryPhotoCapture
+          persona="lucky"
+          tone="green"
+          defaultCategory="garden_supplies"
+          defaultLocation="Yard"
+          onSaved={fetchInventory}
+        />
 
         {/* Search */}
         <Card className="border-white/10 bg-white/5">

--- a/components/inventory-photo-capture.tsx
+++ b/components/inventory-photo-capture.tsx
@@ -82,6 +82,7 @@ interface InventoryPhotoCaptureProps {
   tone: InventoryTone
   defaultCategory?: string
   defaultLocation?: string
+  onSaved?: () => void
 }
 
 export function InventoryPhotoCapture({
@@ -89,6 +90,7 @@ export function InventoryPhotoCapture({
   tone,
   defaultCategory = "workshop_consumables",
   defaultLocation = "Workshop Store",
+  onSaved,
 }: InventoryPhotoCaptureProps) {
   const { user } = useAuth()
   const styles = toneClasses[tone]
@@ -180,6 +182,7 @@ export function InventoryPhotoCapture({
       setPhoto(null)
       clearPreview()
       setStatus({ type: "success", message: "Saved to inventory." })
+      onSaved?.()
     } catch (error) {
       logger.error("Failed to save inventory photo label", {
         error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary
- add the existing mobile photo capture panel to Hans inventory management
- add the same capture panel to Lucky garden inventory
- refresh inventory lists after a photo-labelled item is saved

## Validation
- pnpm test tests/api/inventory.test.ts
- pnpm exec tsc --noEmit
- pnpm exec eslint components/inventory-photo-capture.tsx app/dashboard/hans/inventory/page.tsx app/dashboard/lucky/inventory/page.tsx

## Notes
- Full local lint/build hung on this machine with many existing Node processes; relying on GitHub Actions for full lint/build/deployment checklist.