### PR TITLE
fix: make inventory capture universal

### DIFF
--- a/app/dashboard/[persona]/inventory/page.tsx
+++ b/app/dashboard/[persona]/inventory/page.tsx
@@ -1,0 +1,77 @@
+import DashboardLayout from "@/components/dashboard-layout"
+import { InventoryPhotoCapture } from "@/components/inventory-photo-capture"
+import { Boxes } from "lucide-react"
+import { notFound } from "next/navigation"
+
+const PERSONA_CONFIG = {
+  hans: {
+    tone: "blue",
+    category: "other",
+    location: "House",
+    title: "Inventory",
+    description: "Capture and label inventory photos.",
+  },
+  charl: {
+    tone: "amber",
+    category: "workshop_consumables",
+    location: "Workshop Store",
+    title: "Workshop Inventory",
+    description: "Take a photo, add a label, and save the item.",
+  },
+  lucky: {
+    tone: "green",
+    category: "garden_supplies",
+    location: "Yard",
+    title: "Garden Inventory",
+    description: "Capture supplies from the yard or garden store.",
+  },
+  irma: {
+    tone: "purple",
+    category: "household",
+    location: "House",
+    title: "Household Inventory",
+    description: "Photograph and label household items.",
+  },
+} as const
+
+type Persona = keyof typeof PERSONA_CONFIG
+
+function isPersona(value: string): value is Persona {
+  return value in PERSONA_CONFIG
+}
+
+interface UniversalInventoryPageProps {
+  params: Promise<{ persona: string }>
+}
+
+export default async function UniversalInventoryPage({ params }: UniversalInventoryPageProps) {
+  const { persona } = await params
+  const personaParam = persona.toLowerCase()
+
+  if (!isPersona(personaParam)) {
+    notFound()
+  }
+
+  const config = PERSONA_CONFIG[personaParam]
+
+  return (
+    <DashboardLayout persona={personaParam}>
+      <div className="relative z-10 space-y-6">
+        <div>
+          <h1 className="flex items-center gap-3 text-2xl font-bold text-white sm:text-3xl">
+            <Boxes className="h-8 w-8 text-white/80" />
+            {config.title}
+          </h1>
+          <p className="mt-1 text-white/60">{config.description}</p>
+        </div>
+
+        <InventoryPhotoCapture
+          persona={personaParam}
+          tone={config.tone}
+          defaultCategory={config.category}
+          defaultLocation={config.location}
+        />
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/lib/nav-config.ts
+++ b/lib/nav-config.ts
@@ -104,7 +104,6 @@ const PAGE_DEFINITIONS: PageDef[] = [
     href: "/dashboard",
     icon: Boxes,
     category: "Operations",
-    requiredResponsibility: "Inventory",
   },
   {
     name: "Maintenance",
@@ -166,6 +165,7 @@ const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
     "Time Clock": "/dashboard/charl/time",
     "Vehicles (Soon)": "/dashboard/charl/vehicles",
     Assets: "/dashboard/charl/assets",
+    Inventory: "/dashboard/charl/inventory",
     "My Documents": "/dashboard/charl/documents",
     Settings: "/dashboard/charl/settings",
   },
@@ -184,6 +184,7 @@ const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
     "My Dashboard": "/dashboard/irma",
     Work: "/dashboard/irma/projects",
     "Household Tasks": "/dashboard/irma/tasks",
+    Inventory: "/dashboard/irma/inventory",
     "My Documents": "/dashboard/irma/documents",
     Settings: "/dashboard/irma/settings",
   },

--- a/tests/lib/nav-config.test.ts
+++ b/tests/lib/nav-config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { buildNavEntries, isCategory, type NavEntry } from "@/lib/nav-config"
+
+function flatten(entries: NavEntry[]) {
+  return entries.flatMap((entry) => (isCategory(entry) ? entry.items : [entry]))
+}
+
+describe("nav-config inventory access", () => {
+  it("shows inventory for every persona", () => {
+    const personas = [
+      ["hans", "admin", "/dashboard/hans/inventory"],
+      ["charl", "operator", "/dashboard/charl/inventory"],
+      ["lucky", "employee", "/dashboard/lucky/inventory"],
+      ["irma", "resident", "/dashboard/irma/inventory"],
+    ] as const
+
+    for (const [persona, role, href] of personas) {
+      const items = flatten(buildNavEntries(persona, role, []))
+      expect(items).toContainEqual(expect.objectContaining({ name: "Inventory", href }))
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- make Inventory navigation available to every persona, not only users with the Inventory responsibility
- add explicit Charl and Irma inventory routes
- add a universal /dashboard/[persona]/inventory page with the mobile photo capture flow
- add a regression test that verifies all personas have an Inventory link

## Root cause
The prior fix only covered the dedicated Hans and Lucky inventory pages because those were the only persona-specific inventory routes. Charl and Irma had dashboard capture panels, but no Inventory nav destination with photo upload.

## Validation
- pnpm test tests/lib/nav-config.test.ts tests/api/inventory.test.ts
- pnpm exec tsc --noEmit
- pnpm exec eslint lib/nav-config.ts app/dashboard/[persona]/inventory/page.tsx tests/lib/nav-config.test.ts