### PR TITLE
fix: use auth ownership for inventory uploads

### DIFF
--- a/app/api/uploads/route.ts
+++ b/app/api/uploads/route.ts
@@ -167,26 +167,19 @@ export const GET = withAuth(async (request) => {
   })
 })
 
-export const POST = withAuth(async (request) => {
+export const POST = withAuth(async (request, context) => {
   try {
     await ensureUploadDir()
 
     const formData = await request.formData()
     const file = formData.get("file") as File | null
-    const userId = formData.get("userId") as string
     const category = (formData.get("category") as string) || "general"
     const resourceType = formData.get("resourceType") as string | null
     const resourceId = formData.get("resourceId") as string | null
-
-    const authUserId = request.headers.get("x-user-id") || userId
-    const uploader = userId || authUserId
+    const uploader = context.userId
 
     if (!file) {
       return NextResponse.json({ error: "No file provided" }, { status: 400 })
-    }
-
-    if (!uploader) {
-      return NextResponse.json({ error: "userId or authenticated user required" }, { status: 400 })
     }
 
     if (file.size > MAX_FILE_SIZE) {

--- a/components/inventory-photo-capture.tsx
+++ b/components/inventory-photo-capture.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { apiFetch } from "@/lib/api-client"
-import { useAuth } from "@/lib/auth-context"
 import { logger } from "@/lib/logger"
 import { AlertCircle, Camera, CheckCircle2, Tag, Upload } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
@@ -92,7 +91,6 @@ export function InventoryPhotoCapture({
   defaultLocation = "Workshop Store",
   onSaved,
 }: InventoryPhotoCaptureProps) {
-  const { user } = useAuth()
   const styles = toneClasses[tone]
   const [label, setLabel] = useState("")
   const [category, setCategory] = useState(defaultCategory)
@@ -138,13 +136,11 @@ export function InventoryPhotoCapture({
       return
     }
 
-    const userId = user?.id ?? persona
     setStatus({ type: "saving", message: "Uploading photo..." })
 
     try {
       const formData = new FormData()
       formData.append("file", photo)
-      formData.append("userId", userId)
       formData.append("category", "image")
       formData.append("resourceType", "inventory")
 

--- a/tests/api/uploads.test.ts
+++ b/tests/api/uploads.test.ts
@@ -1,0 +1,35 @@
+import { POST } from "@/app/api/uploads/route"
+import { describe, expect, it } from "vitest"
+
+const authHeaders = {
+  "x-user-id": "charl",
+  "x-user-role": "operator",
+  "x-user-email": "charl@example.com",
+}
+
+describe("POST /api/uploads", () => {
+  it("uses the authenticated user as uploader instead of a form userId", async () => {
+    const formData = new FormData()
+    formData.append(
+      "file",
+      new File(["photo"], "inventory.jpg", { type: "image/jpeg" })
+    )
+    formData.append("userId", "hans")
+    formData.append("category", "image")
+    formData.append("resourceType", "inventory")
+
+    const response = await POST(
+      new Request("http://localhost/api/uploads", {
+        method: "POST",
+        headers: authHeaders,
+        body: formData,
+      })
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.file.uploadedBy).toBe("charl")
+    expect(body.file.resourceType).toBe("inventory")
+    expect(body.file.url).toMatch(/^\/api\/uploads\/file_/)
+  })
+})


### PR DESCRIPTION
## Summary
- remove client-supplied userId from inventory photo uploads
- make /api/uploads POST store uploadedBy from the authenticated route context
- add a regression test proving form userId spoofing does not change upload ownership

## Architecture check
The universal inventory capture shape is otherwise sound: shared capture component, authenticated upload API, inventory API stores upload URL metadata, and universal persona inventory navigation/route are covered by tests. This PR fixes the one bad boundary: identity belonged in auth context, not form data.

## Validation
- pnpm test tests/api/uploads.test.ts tests/api/inventory.test.ts tests/lib/nav-config.test.ts
- pnpm exec tsc --noEmit
- pnpm exec eslint components/inventory-photo-capture.tsx app/api/uploads/route.ts tests/api/uploads.test.ts app/dashboard/[persona]/inventory/page.tsx lib/nav-config.ts tests/lib/nav-config.test.ts