### PR TITLE
Fix inventory auth, Sluice preview, and invite flows

### DIFF
--- a/app/api/inventory/batch-identify/route.ts
+++ b/app/api/inventory/batch-identify/route.ts
@@ -1,9 +1,32 @@
 import { NextResponse } from "next/server"
+import { readFile, readdir } from "fs/promises"
+import { existsSync } from "fs"
+import path from "path"
 import { withAuth } from "@/lib/auth/rbac"
+import { isPostgresConfigured, query, ensureSchema } from "@/lib/db/postgres"
 import {
   identifyInventoryBatchWithSluice,
   type SluiceInventoryImage,
 } from "@/lib/integrations/sluice"
+
+const UPLOAD_DIR = "/tmp/hov-uploads"
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+}
+
+let schemaEnsured = false
+
+async function ensureSchemaOnce() {
+  if (!schemaEnsured && isPostgresConfigured()) {
+    await ensureSchema()
+    schemaEnsured = true
+  }
+}
 
 function validImage(value: unknown): value is SluiceInventoryImage {
   if (!value || typeof value !== "object") return false
@@ -13,6 +36,48 @@ function validImage(value: unknown): value is SluiceInventoryImage {
     typeof item.photoUrl === "string" &&
     item.photoUrl.startsWith("/api/uploads/")
   )
+}
+
+async function readUploadForService(image: SluiceInventoryImage): Promise<SluiceInventoryImage> {
+  if (!/^file_[a-zA-Z0-9_-]+$/.test(image.uploadId)) return image
+
+  let storedName: string | null = null
+  let mimeType = image.mimeType || "application/octet-stream"
+
+  if (isPostgresConfigured()) {
+    await ensureSchemaOnce()
+    const { rows } = await query<{ stored_name: string; mime_type: string }>(
+      `SELECT stored_name, mime_type FROM file_uploads WHERE id = $1`,
+      [image.uploadId]
+    )
+    if (rows[0]) {
+      storedName = rows[0].stored_name
+      mimeType = rows[0].mime_type
+    }
+  }
+
+  if (!storedName && existsSync(UPLOAD_DIR)) {
+    const files = await readdir(UPLOAD_DIR)
+    const match = files.find((file) => path.basename(file, path.extname(file)) === image.uploadId)
+    if (match) {
+      storedName = match
+      mimeType = MIME_BY_EXT[path.extname(match).toLowerCase()] || mimeType
+    }
+  }
+
+  if (!storedName) return image
+
+  const filePath = path.join(UPLOAD_DIR, storedName)
+  if (!existsSync(filePath)) return image
+
+  const buffer = await readFile(filePath)
+  const imageBase64 = buffer.toString("base64")
+  return {
+    ...image,
+    mimeType,
+    imageBase64,
+    dataUrl: `data:${mimeType};base64,${imageBase64}`,
+  }
 }
 
 export const POST = withAuth(async (request: Request) => {
@@ -31,7 +96,8 @@ export const POST = withAuth(async (request: Request) => {
       )
     }
 
-    const result = await identifyInventoryBatchWithSluice(images)
+    const serviceImages = await Promise.all(images.map(readUploadForService))
+    const result = await identifyInventoryBatchWithSluice(serviceImages)
 
     return NextResponse.json({
       previewOnly: true,

--- a/app/api/inventory/batch-identify/route.ts
+++ b/app/api/inventory/batch-identify/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server"
+import { withAuth } from "@/lib/auth/rbac"
+import {
+  identifyInventoryBatchWithSluice,
+  type SluiceInventoryImage,
+} from "@/lib/integrations/sluice"
+
+function validImage(value: unknown): value is SluiceInventoryImage {
+  if (!value || typeof value !== "object") return false
+  const item = value as Record<string, unknown>
+  return (
+    typeof item.uploadId === "string" &&
+    typeof item.photoUrl === "string" &&
+    item.photoUrl.startsWith("/api/uploads/")
+  )
+}
+
+export const POST = withAuth(async (request: Request) => {
+  try {
+    const body = await request.json()
+    const images = Array.isArray(body.images) ? body.images.filter(validImage) : []
+
+    if (images.length === 0) {
+      return NextResponse.json({ error: "images are required" }, { status: 400 })
+    }
+
+    if (images.length > 20) {
+      return NextResponse.json(
+        { error: "Batch preview is limited to 20 images" },
+        { status: 400 }
+      )
+    }
+
+    const result = await identifyInventoryBatchWithSluice(images)
+
+    return NextResponse.json({
+      previewOnly: true,
+      aiPowered: result.aiPowered,
+      suggestions: result.suggestions,
+      message: result.aiPowered
+        ? "Preview suggestions from Sluice. Review before saving."
+        : "Preview only. Sluice is unavailable or unconfigured; review and correct manually.",
+    })
+  } catch {
+    return NextResponse.json({ error: "Batch identification failed" }, { status: 500 })
+  }
+})

--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -71,13 +71,43 @@ function optionalPhotoUrl(value: unknown): string | undefined {
   return undefined
 }
 
+function optionalTextList(value: unknown, maxLength: number): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const values = value
+    .map((item) => optionalText(item, maxLength))
+    .filter((item): item is string => !!item)
+  return values.length ? Array.from(new Set(values)) : undefined
+}
+
+function optionalImageBounds(value: unknown): InventoryItem["imageBounds"] | undefined {
+  if (!value || typeof value !== "object") return undefined
+  const bounds = value as Record<string, unknown>
+  const x = Number(bounds.x)
+  const y = Number(bounds.y)
+  const width = Number(bounds.width)
+  const height = Number(bounds.height)
+  if (![x, y, width, height].every(Number.isFinite)) return undefined
+  if (x < 0 || y < 0 || width <= 0 || height <= 0) return undefined
+  if (x + width > 1 || y + height > 1) return undefined
+  return { x, y, width, height }
+}
+
+function isLinkedToUser(item: InventoryItem, userId: string): boolean {
+  return (
+    item.capturedBy === userId ||
+    item.ownerId === userId ||
+    item.responsibleUserId === userId ||
+    item.linkedUserIds?.includes(userId) === true
+  )
+}
+
 // GET - List inventory with filters
 export const GET = withRole(
   "admin",
   "operator",
   "employee",
   "resident"
-)(async (request: Request) => {
+)(async (request: Request, context) => {
   const inventory = getInventory()
   const { searchParams } = new URL(request.url)
   const category = searchParams.get("category")
@@ -86,7 +116,10 @@ export const GET = withRole(
   const barcode = searchParams.get("barcode")
   const search = searchParams.get("search")
 
-  let items = [...inventory]
+  let items =
+    context.role === "resident"
+      ? inventory.filter((item) => isLinkedToUser(item, context.userId))
+      : [...inventory]
 
   if (barcode) {
     items = items.filter((i) => i.barcode === barcode)
@@ -110,7 +143,7 @@ export const GET = withRole(
     items = items.filter((i) => i.location.toLowerCase().includes(location.toLowerCase()))
   }
 
-  const alerts = inventory
+  const alerts = items
     .filter((i) => i.currentStock <= i.reorderPoint)
     .map((i) => ({
       id: i.id,
@@ -149,13 +182,16 @@ export const POST = withRole(
   "operator",
   "employee",
   "resident"
-)(async (request: Request) => {
+)(async (request: Request, context) => {
   const inventory = getInventory()
   try {
     const body = await request.json()
     const { action } = body
 
     if (action === "consume") {
+      if (context.role === "resident") {
+        return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
+      }
       const { itemId, quantity, usedBy, purpose } = body
 
       const index = findIndexById(itemId)
@@ -210,6 +246,9 @@ export const POST = withRole(
     }
 
     if (action === "restock") {
+      if (context.role === "resident") {
+        return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
+      }
       const { itemId, quantity, unitCost } = body
 
       const index = findIndexById(itemId)
@@ -244,7 +283,20 @@ export const POST = withRole(
       label,
       photoUrl,
       photoFileId,
+      ownerId,
+      responsibleUserId,
+      linkedUserIds,
+      imageBounds,
     } = body
+    const sanitizedPhotoUrl = optionalPhotoUrl(photoUrl)
+    const isResidentCapture = context.role === "resident"
+
+    if (isResidentCapture && !sanitizedPhotoUrl) {
+      return NextResponse.json(
+        { error: "Residents can only add inventory through photo capture" },
+        { status: 403 }
+      )
+    }
 
     if (!name || !category || !unit || !location) {
       return NextResponse.json(
@@ -258,23 +310,27 @@ export const POST = withRole(
       name: optionalText(name, 120) ?? name,
       category,
       unit: optionalText(unit, 40) ?? unit,
-      currentStock: currentStock || 0,
-      minStock: minStock || 1,
-      maxStock: maxStock || 10,
-      reorderPoint: reorderPoint || minStock || 1,
+      currentStock: isResidentCapture ? 1 : currentStock || 0,
+      minStock: isResidentCapture ? 1 : minStock || 1,
+      maxStock: isResidentCapture ? 1 : maxStock || 10,
+      reorderPoint: isResidentCapture ? 1 : reorderPoint || minStock || 1,
       lastRestocked: new Date().toISOString().split("T")[0],
       averageConsumption: 0,
       location: optionalText(location, 120) ?? location,
       supplier: optionalText(supplier, 120),
-      unitCost: unitCost || 0,
-      totalValue: (currentStock || 0) * (unitCost || 0),
+      unitCost: isResidentCapture ? 0 : unitCost || 0,
+      totalValue: isResidentCapture ? 0 : (currentStock || 0) * (unitCost || 0),
       label: optionalText(label, 120),
-      photoUrl: optionalPhotoUrl(photoUrl),
+      photoUrl: sanitizedPhotoUrl,
       photoFileId: optionalText(photoFileId, 120),
-      photoUploadedAt: optionalPhotoUrl(photoUrl) ? new Date().toISOString() : undefined,
-      capturedBy: optionalPhotoUrl(photoUrl)
-        ? optionalText(request.headers.get("x-user-id"), 80)
-        : undefined,
+      photoUploadedAt: sanitizedPhotoUrl ? new Date().toISOString() : undefined,
+      capturedBy: sanitizedPhotoUrl ? context.userId : undefined,
+      ownerId: isResidentCapture ? context.userId : optionalText(ownerId, 80),
+      responsibleUserId: isResidentCapture
+        ? context.userId
+        : optionalText(responsibleUserId, 80),
+      linkedUserIds: isResidentCapture ? [context.userId] : optionalTextList(linkedUserIds, 80),
+      imageBounds: optionalImageBounds(imageBounds),
       consumptionHistory: [],
     }
 

--- a/app/api/users/[id]/invite/route.ts
+++ b/app/api/users/[id]/invite/route.ts
@@ -17,5 +17,9 @@ export const POST = withRole("admin")(async (_request, context) => {
   if (!result.sent) {
     return NextResponse.json({ error: result.error || "Failed to send invite" }, { status: 500 })
   }
-  return NextResponse.json({ success: true })
+  return NextResponse.json({
+    success: true,
+    inviteLink: result.inviteLink,
+    channels: result.channels,
+  })
 })

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -2,6 +2,13 @@ import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import { getUserWithManagement, updateUserManagement } from "@/lib/user-management"
 
+function optionalEmail(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim().toLowerCase()
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) return undefined
+  return trimmed
+}
+
 export const GET = withRole("admin")(async (_request, context) => {
   const params = await context.params
   const id = params?.id
@@ -17,9 +24,16 @@ export const PATCH = withRole("admin")(async (request, context) => {
   if (!id) return NextResponse.json({ error: "User ID required" }, { status: 400 })
   try {
     const body = await request.json()
-    const { status, role, responsibilities, onboardingStatus, offboardingStatus } = body
+    const { status, email, role, responsibilities, onboardingStatus, offboardingStatus } = body
     const updates: Record<string, unknown> = {}
     if (status != null) updates.status = status
+    if (email != null) {
+      const normalizedEmail = optionalEmail(email)
+      if (!normalizedEmail) {
+        return NextResponse.json({ error: "Invalid email" }, { status: 400 })
+      }
+      updates.email = normalizedEmail
+    }
     if (role != null) updates.role = role
     if (responsibilities != null) updates.responsibilities = responsibilities
     if (onboardingStatus != null) updates.onboardingStatus = onboardingStatus

--- a/app/dashboard/[persona]/inventory/page.tsx
+++ b/app/dashboard/[persona]/inventory/page.tsx
@@ -1,5 +1,7 @@
 import DashboardLayout from "@/components/dashboard-layout"
+import { InventoryBatchCapturePreview } from "@/components/inventory-batch-capture-preview"
 import { InventoryPhotoCapture } from "@/components/inventory-photo-capture"
+import { ScopedInventoryList } from "@/components/scoped-inventory-list"
 import { Boxes } from "lucide-react"
 import { notFound } from "next/navigation"
 
@@ -71,6 +73,10 @@ export default async function UniversalInventoryPage({ params }: UniversalInvent
           defaultCategory={config.category}
           defaultLocation={config.location}
         />
+
+        <InventoryBatchCapturePreview defaultLocation={config.location} />
+
+        <ScopedInventoryList />
       </div>
     </DashboardLayout>
   )

--- a/app/dashboard/hans/team/page.tsx
+++ b/app/dashboard/hans/team/page.tsx
@@ -34,6 +34,7 @@ import {
   UserPlus,
   Briefcase,
   Send,
+  Copy,
 } from "lucide-react"
 import { logger } from "@/lib/logger"
 import { apiFetch } from "@/lib/api-client"
@@ -70,6 +71,11 @@ export default function HansTeamPage() {
   const [editForm, setEditForm] = useState<Partial<UserWithManagement>>({})
   const [processing, setProcessing] = useState(false)
   const [invitingId, setInvitingId] = useState<string | null>(null)
+  const [inviteResult, setInviteResult] = useState<{
+    userId: string
+    inviteLink: string
+    channels?: string[]
+  } | null>(null)
 
   const fetchUsers = useCallback(async () => {
     try {
@@ -106,8 +112,19 @@ export default function HansTeamPage() {
 
   const handleInvite = async (user: UserWithManagement) => {
     setInvitingId(user.id)
+    setInviteResult(null)
     try {
-      await apiFetch(`/api/users/${user.id}/invite`, { method: "POST", label: "Invite" })
+      const result = await apiFetch<{
+        inviteLink?: string
+        channels?: string[]
+      }>(`/api/users/${user.id}/invite`, { method: "POST", label: "Invite" })
+      if (result.inviteLink) {
+        setInviteResult({
+          userId: user.id,
+          inviteLink: result.inviteLink,
+          channels: result.channels,
+        })
+      }
       await fetchUsers()
     } catch (error) {
       logger.error("Invite failed", {
@@ -160,6 +177,7 @@ export default function HansTeamPage() {
   const openEdit = (user: UserWithManagement) => {
     setSelectedUser(user)
     setEditForm({
+      email: user.email,
       status: user.status,
       role: user.role,
       responsibilities: user.responsibilities || [],
@@ -204,6 +222,40 @@ export default function HansTeamPage() {
           </TabsList>
 
           <TabsContent value="users" className="space-y-4">
+            {inviteResult && (
+              <Card className="border-blue-500/30 bg-blue-950/30">
+                <CardContent className="space-y-3 pt-6">
+                  <div>
+                    <p className="font-medium text-blue-100">Invite link ready</p>
+                    <p className="text-sm text-blue-100/60">
+                      Send this link directly if email or SMS delivery is unavailable.
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Input
+                      readOnly
+                      value={inviteResult.inviteLink}
+                      className="border-blue-500/20 bg-black/25 text-blue-50"
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="border-blue-500/30 text-blue-100"
+                      onClick={() => navigator.clipboard.writeText(inviteResult.inviteLink)}
+                    >
+                      <Copy className="mr-2 h-4 w-4" />
+                      Copy
+                    </Button>
+                  </div>
+                  {inviteResult.channels && (
+                    <p className="text-xs text-blue-100/45">
+                      Channels attempted: {inviteResult.channels.join(", ")}
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
             <Card className="border-white/10 bg-[#0d0d12]/80">
               <CardHeader>
                 <CardTitle className="text-white">Platform Users</CardTitle>
@@ -328,10 +380,20 @@ export default function HansTeamPage() {
             <DialogHeader>
               <DialogTitle>Edit User</DialogTitle>
               <DialogDescription className="text-white/60">
-                Update status, role, and responsibilities.
+                Update contact details, status, role, and responsibilities.
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-4 py-4">
+              <div>
+                <Label className="text-white/80">Email</Label>
+                <Input
+                  type="email"
+                  className="border-white/10 bg-white/5"
+                  value={editForm.email || ""}
+                  onChange={(e) => setEditForm((f) => ({ ...f, email: e.target.value }))}
+                  placeholder="name@example.com"
+                />
+              </div>
               <div>
                 <Label className="text-white/80">Status</Label>
                 <Select

--- a/components/inventory-batch-capture-preview.tsx
+++ b/components/inventory-batch-capture-preview.tsx
@@ -1,0 +1,298 @@
+"use client"
+
+import { apiFetch } from "@/lib/api-client"
+import { logger } from "@/lib/logger"
+import { AlertCircle, Camera, CheckCircle2, Images, Sparkles, Upload } from "lucide-react"
+import { useState } from "react"
+
+const CATEGORIES = [
+  "workshop_consumables",
+  "building_materials",
+  "fuel",
+  "garden_supplies",
+  "cleaning_supplies",
+  "household",
+  "other",
+] as const
+
+const LOCATIONS = ["Workshop Store", "Tool Wall", "Fuel Store", "Yard", "Container", "House"]
+
+interface DraftItem {
+  id: string
+  uploadId: string
+  photoUrl: string
+  label: string
+  category: string
+  location: string
+  confidence: number | null
+  imageBounds?: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
+}
+
+interface UploadResult {
+  file: {
+    id: string
+    url: string
+    originalName?: string
+    mimeType?: string
+  }
+}
+
+export function InventoryBatchCapturePreview({ defaultLocation = "House" }: { defaultLocation?: string }) {
+  const [files, setFiles] = useState<File[]>([])
+  const [drafts, setDrafts] = useState<DraftItem[]>([])
+  const [status, setStatus] = useState<{ type: "idle" | "busy" | "success" | "error"; message: string }>({
+    type: "idle",
+    message: "",
+  })
+
+  async function identifyBatch() {
+    if (files.length === 0) {
+      setStatus({ type: "error", message: "Choose photos first." })
+      return
+    }
+
+    setStatus({ type: "busy", message: "Uploading preview batch..." })
+    try {
+      const uploads = await Promise.all(
+        files.map(async (file) => {
+          const formData = new FormData()
+          formData.append("file", file)
+          formData.append("category", "image")
+          formData.append("resourceType", "inventory")
+          const uploaded = await apiFetch<UploadResult>("/api/uploads", {
+            method: "POST",
+            body: formData,
+            label: "InventoryBatchUpload",
+          })
+          return {
+            uploadId: uploaded.file.id,
+            photoUrl: uploaded.file.url,
+            originalName: uploaded.file.originalName || file.name,
+            mimeType: uploaded.file.mimeType || file.type,
+          }
+        })
+      )
+
+      setStatus({ type: "busy", message: "Preparing preview suggestions..." })
+      const identified = await apiFetch<{
+        suggestions?: Array<{
+          id?: string
+          uploadId: string
+          photoUrl: string
+          label: string
+          category: string
+          location?: string
+          confidence: number | null
+          imageBounds?: DraftItem["imageBounds"]
+        }>
+      }>("/api/inventory/batch-identify", {
+        method: "POST",
+        body: { images: uploads },
+        label: "InventoryBatchIdentify",
+      })
+
+      setDrafts(
+        (identified.suggestions || []).map((item) => ({
+          id: item.id || `${item.uploadId}-${globalThis.crypto.randomUUID()}`,
+          uploadId: item.uploadId,
+          photoUrl: item.photoUrl,
+          label: item.label,
+          category: CATEGORIES.includes(item.category as (typeof CATEGORIES)[number])
+            ? item.category
+            : "other",
+          location: item.location || defaultLocation,
+          confidence: item.confidence,
+          imageBounds: item.imageBounds,
+        }))
+      )
+      setStatus({ type: "success", message: "Preview ready. Review before saving." })
+    } catch (error) {
+      logger.error("Inventory batch preview failed", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      setStatus({ type: "error", message: "Could not prepare preview." })
+    }
+  }
+
+  async function saveDrafts() {
+    if (drafts.length === 0) return
+    setStatus({ type: "busy", message: "Saving corrected items..." })
+
+    try {
+      for (const draft of drafts) {
+        const label = draft.label.trim()
+        if (!label) continue
+        await apiFetch("/api/inventory", {
+          method: "POST",
+          body: {
+            name: label,
+            label,
+            category: draft.category,
+            unit: "units",
+            currentStock: 1,
+            minStock: 1,
+            maxStock: 1,
+            reorderPoint: 1,
+            location: draft.location,
+            unitCost: 0,
+            photoUrl: draft.photoUrl,
+            photoFileId: draft.uploadId,
+            imageBounds: draft.imageBounds,
+          },
+          label: "InventoryBatchSave",
+        })
+      }
+      setFiles([])
+      setDrafts([])
+      setStatus({ type: "success", message: "Corrected batch saved." })
+    } catch (error) {
+      logger.error("Inventory batch save failed", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      setStatus({ type: "error", message: "Could not save every item." })
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-cyan-500/25 bg-cyan-950/30 p-4 sm:p-5">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Images className="h-5 w-5 text-cyan-200" />
+          <div>
+            <h2 className="font-semibold text-cyan-100">Batch Capture</h2>
+            <p className="text-sm text-cyan-100/55">Preview only. AI suggestions require review.</p>
+          </div>
+        </div>
+        <span className="rounded-full border border-cyan-300/30 px-2 py-1 text-xs font-semibold uppercase text-cyan-100">
+          Preview
+        </span>
+      </div>
+
+      <div className="grid gap-3">
+        <label className="flex min-h-32 cursor-pointer flex-col items-center justify-center rounded-lg border border-dashed border-cyan-300/30 bg-black/20 p-4 text-center text-cyan-100/65">
+          <Upload className="mb-2 h-7 w-7" />
+          Choose photos
+          <input
+            type="file"
+            multiple
+            accept="image/*"
+            capture="environment"
+            className="sr-only"
+            onChange={(event) => setFiles(Array.from(event.target.files || []).slice(0, 20))}
+          />
+        </label>
+
+        {files.length > 0 && <p className="text-sm text-cyan-100/65">{files.length} photo(s) selected</p>}
+
+        <button
+          type="button"
+          onClick={identifyBatch}
+          disabled={status.type === "busy"}
+          className="inline-flex h-12 items-center justify-center gap-2 rounded-lg border border-cyan-300/30 bg-cyan-500 px-4 text-sm font-semibold text-black disabled:opacity-60"
+        >
+          <Sparkles className="h-4 w-4" />
+          Prepare Preview
+        </button>
+
+        {drafts.length > 0 && (
+          <div className="grid gap-3">
+            {drafts.map((draft, index) => (
+              <article key={draft.id} className="grid gap-3 rounded-lg border border-white/10 bg-black/20 p-3 sm:grid-cols-[96px_1fr]">
+                <div className="relative h-24 w-full overflow-hidden rounded-md sm:w-24">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={draft.photoUrl} alt="" className="h-full w-full object-cover" />
+                  {draft.imageBounds && (
+                    <span
+                      className="absolute border-2 border-cyan-300 bg-cyan-300/10"
+                      style={{
+                        left: `${draft.imageBounds.x * 100}%`,
+                        top: `${draft.imageBounds.y * 100}%`,
+                        width: `${draft.imageBounds.width * 100}%`,
+                        height: `${draft.imageBounds.height * 100}%`,
+                      }}
+                    />
+                  )}
+                </div>
+                <div className="grid gap-2">
+                  <input
+                    value={draft.label}
+                    onChange={(event) =>
+                      setDrafts((current) =>
+                        current.map((item, i) =>
+                          i === index ? { ...item, label: event.target.value } : item
+                        )
+                      )
+                    }
+                    className="h-11 rounded-lg border border-white/10 bg-black/25 px-3 text-white"
+                  />
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <select
+                      value={draft.category}
+                      onChange={(event) =>
+                        setDrafts((current) =>
+                          current.map((item, i) =>
+                            i === index ? { ...item, category: event.target.value } : item
+                          )
+                        )
+                      }
+                      className="h-11 rounded-lg border border-white/10 bg-black/25 px-3 text-white"
+                    >
+                      {CATEGORIES.map((category) => (
+                        <option key={category} value={category} className="bg-zinc-950">
+                          {category.replace(/_/g, " ")}
+                        </option>
+                      ))}
+                    </select>
+                    <select
+                      value={draft.location}
+                      onChange={(event) =>
+                        setDrafts((current) =>
+                          current.map((item, i) =>
+                            i === index ? { ...item, location: event.target.value } : item
+                          )
+                        )
+                      }
+                      className="h-11 rounded-lg border border-white/10 bg-black/25 px-3 text-white"
+                    >
+                      {LOCATIONS.map((location) => (
+                        <option key={location} value={location} className="bg-zinc-950">
+                          {location}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </article>
+            ))}
+            <button
+              type="button"
+              onClick={saveDrafts}
+              disabled={status.type === "busy"}
+              className="inline-flex h-12 items-center justify-center gap-2 rounded-lg border border-emerald-300/30 bg-emerald-500 px-4 text-sm font-semibold text-black disabled:opacity-60"
+            >
+              <Camera className="h-4 w-4" />
+              Save Corrected Batch
+            </button>
+          </div>
+        )}
+
+        {status.message && (
+          <p
+            className={`flex items-center gap-2 text-sm ${
+              status.type === "error" ? "text-red-300" : "text-emerald-300"
+            }`}
+            role={status.type === "error" ? "alert" : "status"}
+          >
+            {status.type === "error" ? <AlertCircle className="h-4 w-4" /> : <CheckCircle2 className="h-4 w-4" />}
+            {status.message}
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/components/scoped-inventory-list.tsx
+++ b/components/scoped-inventory-list.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { apiFetch } from "@/lib/api-client"
+import { logger } from "@/lib/logger"
+import { Boxes } from "lucide-react"
+import { useEffect, useState } from "react"
+
+interface ScopedInventoryItem {
+  id: string
+  name: string
+  label?: string
+  category: string
+  location: string
+  photoUrl?: string
+}
+
+export function ScopedInventoryList() {
+  const [items, setItems] = useState<ScopedInventoryItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let active = true
+
+    apiFetch<{ items?: ScopedInventoryItem[] }>("/api/inventory", { label: "ScopedInventory" })
+      .then((data) => {
+        if (active) setItems(data?.items || [])
+      })
+      .catch((error) => {
+        logger.error("Failed to fetch scoped inventory", {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return (
+    <section className="rounded-xl border border-white/10 bg-white/5 p-4 sm:p-5">
+      <div className="mb-4 flex items-center gap-3">
+        <Boxes className="h-5 w-5 text-white/70" />
+        <h2 className="font-semibold text-white">Your inventory</h2>
+      </div>
+
+      {loading ? (
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
+      ) : items.length === 0 ? (
+        <p className="text-sm text-white/55">No inventory linked to you yet.</p>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {items.map((item) => (
+            <article
+              key={item.id}
+              className="grid grid-cols-[64px_1fr] gap-3 rounded-lg border border-white/10 bg-black/20 p-3"
+            >
+              <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-md bg-white/10">
+                {item.photoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={item.photoUrl} alt="" className="h-full w-full object-cover" />
+                ) : (
+                  <Boxes className="h-6 w-6 text-white/35" />
+                )}
+              </div>
+              <div className="min-w-0">
+                <p className="truncate font-medium text-white">{item.label || item.name}</p>
+                <p className="truncate text-sm text-white/50">{item.location}</p>
+                <p className="mt-1 text-xs uppercase tracking-wide text-white/35">
+                  {item.category.replace(/_/g, " ")}
+                </p>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/lib/auth/rbac.ts
+++ b/lib/auth/rbac.ts
@@ -80,7 +80,11 @@ async function resolveAuthContext(request: Request): Promise<{
     // Dev/test fallback below preserves route unit tests and local API harnesses.
   }
 
-  if (process.env.NODE_ENV !== "production" || process.env.ALLOW_HEADER_AUTH === "true") {
+  if (
+    process.env.NODE_ENV !== "production" ||
+    process.env.ALLOW_HEADER_AUTH === "true" ||
+    process.env.E2E_TEST === "1"
+  ) {
     return getAuthContext(request)
   }
 

--- a/lib/auth/rbac.ts
+++ b/lib/auth/rbac.ts
@@ -1,10 +1,12 @@
 import { NextResponse, type NextRequest } from "next/server"
+import { auth } from "@/auth"
 import type { UserRole } from "@/lib/users"
 import {
   hasResponsibility,
   getDefaultResponsibilities,
   type Responsibility,
 } from "@/lib/access-config"
+import { getUserWithManagement } from "@/lib/user-management"
 
 export interface AuthenticatedRequest extends NextRequest {
   userId: string
@@ -42,6 +44,49 @@ export function getAuthContext(request: Request): {
   return { userId, role, email, responsibilities }
 }
 
+async function resolveAuthContext(request: Request): Promise<{
+  userId: string
+  role: UserRole
+  email: string
+  responsibilities?: string[]
+} | null> {
+  try {
+    const session = await auth()
+    const userId = session?.user?.userId
+
+    if (userId) {
+      const managed = await getUserWithManagement(userId).catch(() => null)
+      if (managed) {
+        return {
+          userId: managed.id,
+          role: managed.role,
+          email: managed.email,
+          responsibilities: managed.responsibilities?.length
+            ? managed.responsibilities
+            : getDefaultResponsibilities(managed.role),
+        }
+      }
+
+      if (session.user.role && session.user.email) {
+        return {
+          userId,
+          role: session.user.role,
+          email: session.user.email,
+          responsibilities: getDefaultResponsibilities(session.user.role),
+        }
+      }
+    }
+  } catch {
+    // Dev/test fallback below preserves route unit tests and local API harnesses.
+  }
+
+  if (process.env.NODE_ENV !== "production" || process.env.ALLOW_HEADER_AUTH === "true") {
+    return getAuthContext(request)
+  }
+
+  return null
+}
+
 export function isAdminOrOperator(role: UserRole): boolean {
   return role === "admin" || role === "operator"
 }
@@ -65,16 +110,16 @@ export function withRole(...allowedRoles: UserRole[]) {
       request: Request,
       routeContext?: { params?: Promise<Record<string, string>> }
     ) {
-      const auth = getAuthContext(request)
-      if (!auth) {
+      const authContext = await resolveAuthContext(request)
+      if (!authContext) {
         return NextResponse.json({ error: "Authentication required" }, { status: 401 })
       }
 
-      if (auth.role !== "admin" && !allowedRoles.includes(auth.role)) {
+      if (authContext.role !== "admin" && !allowedRoles.includes(authContext.role)) {
         return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
       }
 
-      const context: RouteContext = { ...auth, params: routeContext?.params }
+      const context: RouteContext = { ...authContext, params: routeContext?.params }
       return handler(request, context)
     }
   }
@@ -90,16 +135,19 @@ export function withResponsibility(required: Responsibility) {
       request: Request,
       routeContext?: { params?: Promise<Record<string, string>> }
     ) {
-      const auth = getAuthContext(request)
-      if (!auth) {
+      const authContext = await resolveAuthContext(request)
+      if (!authContext) {
         return NextResponse.json({ error: "Authentication required" }, { status: 401 })
       }
 
-      if (auth.role !== "admin" && !hasResponsibility(auth.responsibilities ?? [], required)) {
+      if (
+        authContext.role !== "admin" &&
+        !hasResponsibility(authContext.responsibilities ?? [], required)
+      ) {
         return NextResponse.json({ error: `Requires responsibility: ${required}` }, { status: 403 })
       }
 
-      const context: RouteContext = { ...auth, params: routeContext?.params }
+      const context: RouteContext = { ...authContext, params: routeContext?.params }
       return handler(request, context)
     }
   }
@@ -110,11 +158,11 @@ export function withAuth(handler: RouteHandler) {
     request: Request,
     routeContext?: { params?: Promise<Record<string, string>> }
   ) {
-    const auth = getAuthContext(request)
-    if (!auth) {
+    const authContext = await resolveAuthContext(request)
+    if (!authContext) {
       return NextResponse.json({ error: "Authentication required" }, { status: 401 })
     }
-    const context: RouteContext = { ...auth, params: routeContext?.params }
+    const context: RouteContext = { ...authContext, params: routeContext?.params }
     return handler(request, context)
   }
 }

--- a/lib/integrations/sluice.ts
+++ b/lib/integrations/sluice.ts
@@ -5,6 +5,8 @@ export interface SluiceInventoryImage {
   photoUrl: string
   originalName?: string
   mimeType?: string
+  imageBase64?: string
+  dataUrl?: string
 }
 
 export interface SluiceInventorySuggestion {
@@ -61,7 +63,12 @@ export async function identifyInventoryBatchWithSluice(
         "Content-Type": "application/json",
         ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
       },
-      body: JSON.stringify({ images }),
+      body: JSON.stringify({
+        images: images.map((image) => ({
+          ...image,
+          imageUrl: image.photoUrl,
+        })),
+      }),
       signal: controller.signal,
     })
 

--- a/lib/integrations/sluice.ts
+++ b/lib/integrations/sluice.ts
@@ -1,0 +1,91 @@
+import { logger } from "@/lib/logger"
+
+export interface SluiceInventoryImage {
+  uploadId: string
+  photoUrl: string
+  originalName?: string
+  mimeType?: string
+}
+
+export interface SluiceInventorySuggestion {
+  id?: string
+  uploadId: string
+  photoUrl: string
+  label: string
+  category: string
+  location?: string
+  confidence: number | null
+  imageBounds?: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
+  notes?: string
+}
+
+function cleanFilename(name?: string): string {
+  const base = (name || "Inventory item").replace(/\.[^.]+$/, "")
+  return base.replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim() || "Inventory item"
+}
+
+function fallbackSuggestion(image: SluiceInventoryImage): SluiceInventorySuggestion {
+  return {
+    uploadId: image.uploadId,
+    photoUrl: image.photoUrl,
+    label: cleanFilename(image.originalName),
+    category: "other",
+    confidence: null,
+    notes: "Sluice identification is not configured; review and correct manually.",
+  }
+}
+
+export async function identifyInventoryBatchWithSluice(
+  images: SluiceInventoryImage[]
+): Promise<{ aiPowered: boolean; suggestions: SluiceInventorySuggestion[] }> {
+  const baseUrl = process.env.SLUICE_API_URL || process.env.SLUICE_INVENTORY_IDENTIFY_URL
+  const apiKey = process.env.SLUICE_API_KEY
+
+  if (!baseUrl) {
+    return { aiPowered: false, suggestions: images.map(fallbackSuggestion) }
+  }
+
+  const endpoint = process.env.SLUICE_INVENTORY_IDENTIFY_URL || `${baseUrl.replace(/\/$/, "")}/api/inventory/identify-batch`
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 8000)
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({ images }),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      logger.warn("Sluice inventory identification returned non-OK", {
+        status: response.status,
+        statusText: response.statusText,
+      })
+      return { aiPowered: false, suggestions: images.map(fallbackSuggestion) }
+    }
+
+    const data = (await response.json()) as { suggestions?: SluiceInventorySuggestion[] }
+    const suggestions = Array.isArray(data.suggestions) ? data.suggestions : []
+    if (suggestions.length === 0) {
+      return { aiPowered: false, suggestions: images.map(fallbackSuggestion) }
+    }
+
+    return { aiPowered: true, suggestions }
+  } catch (error) {
+    logger.warn("Sluice inventory identification failed", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { aiPowered: false, suggestions: images.map(fallbackSuggestion) }
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/lib/inventory-store.ts
+++ b/lib/inventory-store.ts
@@ -27,6 +27,15 @@ export interface InventoryItem {
   photoFileId?: string
   photoUploadedAt?: string
   capturedBy?: string
+  ownerId?: string
+  responsibleUserId?: string
+  linkedUserIds?: string[]
+  imageBounds?: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
   consumptionHistory: Array<{
     date: string
     quantity: number

--- a/lib/invite.ts
+++ b/lib/invite.ts
@@ -286,7 +286,7 @@ export async function invalidateInviteToken(token: string): Promise<void> {
 export async function sendInvite(
   userId: string,
   baseUrl: string
-): Promise<{ sent: boolean; error?: string }> {
+): Promise<{ sent: boolean; error?: string; inviteLink?: string; channels?: string[] }> {
   try {
     const token = await createInviteToken(userId)
     const user = await findUserByIdAsync(userId)
@@ -311,7 +311,7 @@ export async function sendInvite(
     })
 
     logger.info("Invite sent", { userId, channels })
-    return { sent: true }
+    return { sent: true, inviteLink: link, channels }
   } catch (err) {
     logger.error("Invite send failed", { error: err instanceof Error ? err.message : String(err) })
     return { sent: false, error: err instanceof Error ? err.message : String(err) }

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -104,7 +104,7 @@ const USER_PHONES: Record<string, string> = {
 // User emails (in production, fetch from database)
 const USER_EMAILS: Record<string, string> = {
   hans: "smit.jurie@gmail.com",
-  charl: "charl@houseofv.com",
+  charl: "chapmancharl28@gmail.com",
   lucky: "lucky@houseofv.com",
   irma: "irma@houseofv.com",
 }

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -4,6 +4,7 @@
 import twilio from "twilio"
 import { EmailClient as AcsEmailClient } from "@azure/communication-email"
 import { logger } from "@/lib/logger"
+import { findUserByIdAsync } from "@/lib/users"
 
 let _acsEmailClient: AcsEmailClient | null | undefined
 function getAcsEmailClient(): AcsEmailClient | null {
@@ -266,7 +267,8 @@ export async function sendNotification(
 ): Promise<NotificationResult[]> {
   const results: NotificationResult[] = []
   const userPhone = USER_PHONES[payload.userId]
-  const userEmail = USER_EMAILS[payload.userId] || `${payload.userId}@houseofv.com`
+  const user = await findUserByIdAsync(payload.userId).catch(() => null)
+  const userEmail = user?.email || USER_EMAILS[payload.userId] || `${payload.userId}@houseofv.com`
 
   // Get user preference if requested
   let channels = payload.channels

--- a/lib/user-management.ts
+++ b/lib/user-management.ts
@@ -169,6 +169,7 @@ export async function updateUserManagement(
   id: string,
   updates: Partial<{
     status: UserStatus
+    email: string
     role: UserRole
     responsibilities: string[]
     onboardingStatus: OnboardingStatus
@@ -187,6 +188,10 @@ export async function updateUserManagement(
   if (updates.status != null) {
     setClauses.push(`status = $${idx++}`)
     values.push(updates.status)
+  }
+  if (updates.email != null) {
+    setClauses.push(`email = $${idx++}`)
+    values.push(updates.email)
   }
   if (updates.role != null) {
     setClauses.push(`role = $${idx++}`)

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -92,7 +92,7 @@ export const USERS: Record<string, User> = {
   charl: {
     id: "charl",
     name: "Charl",
-    email: "charl@houseofv.com",
+    email: "chapmancharl28@gmail.com",
     phone: "+27711488390",
     role: "operator",
     description: "Tasks, assets, time tracking, vehicles coming soon",

--- a/terraform/environments/production/canonical.tfvars.example
+++ b/terraform/environments/production/canonical.tfvars.example
@@ -22,6 +22,9 @@ key_vault_name                   = "nl-prod-hov-kv"
 key_vault_network_default_action = "Allow"
 terraform_key_vault_access_policy_object_id = "593a093c-d4fd-4390-977b-a64abfc97606"
 db_server_name                   = "nl-prod-hov-pg"
+db_sku_name                      = "B_Standard_B1ms"
+db_storage_mb                    = 32768
+db_app_database_name             = "house_of_veritas"
 cosmos_account_name              = "nlprodhovcosmos"
 document_intelligence_name       = "nl-prod-hov-di"
 web_app_name                     = "nl-prod-hov-app"
@@ -34,7 +37,7 @@ cosmos_enable_free_tier = true
 
 # Cost-control switches for the initial canonical stack.
 enable_cosmos_mongo          = true
-enable_database              = false
+enable_database              = true
 enable_operational_services  = false
 enable_application_gateway   = false
 enable_dns_records           = false

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -103,6 +103,9 @@ module "database" {
   server_name         = var.db_server_name
   admin_username      = var.db_admin_username
   admin_password      = var.db_admin_password
+  sku_name            = var.db_sku_name
+  storage_mb          = var.db_storage_mb
+  app_database_name   = var.db_app_database_name
   database_subnet_id  = module.network.database_subnet_id
   vnet_id             = module.network.vnet_id
 
@@ -270,13 +273,15 @@ module "webapp" {
   document_intelligence_endpoint                   = try(module.cognitive[0].endpoint, "")
   document_intelligence_key                        = try(module.cognitive[0].primary_access_key, "")
   extra_app_settings = {
-    MONGODB_URI = try(module.cosmos_mongo[0].mongo_connection_string, "")
-    DB_NAME     = try(module.cosmos_mongo[0].mongo_database_name, "")
+    DATABASE_URL = try(module.database[0].connection_string_app, "")
+    POSTGRES_URL = try(module.database[0].connection_string_app, "")
+    MONGODB_URI  = try(module.cosmos_mongo[0].mongo_connection_string, "")
+    DB_NAME      = try(module.cosmos_mongo[0].mongo_database_name, "")
   }
 
   tags = local.common_tags
 
-  depends_on = [module.network, module.storage, module.security]
+  depends_on = [module.network, module.storage, module.security, module.database]
 }
 
 # DNS Module (Azure DNS records for nexamesh.ai)

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -28,6 +28,11 @@ output "database_server_fqdn" {
   value       = try(module.database[0].server_fqdn, null)
 }
 
+output "app_database_name" {
+  description = "Name of the House of Veritas application database"
+  value       = try(module.database[0].app_database_name, null)
+}
+
 output "cosmos_account_name" {
   description = "Cosmos DB account name"
   value       = try(module.cosmos_mongo[0].account_name, null)

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -149,6 +149,24 @@ variable "db_admin_password" {
   sensitive   = true
 }
 
+variable "db_sku_name" {
+  description = "PostgreSQL Flexible Server Terraform SKU. B_Standard_B1ms is the cheapest burstable option available in South Africa North."
+  type        = string
+  default     = "B_Standard_B1ms"
+}
+
+variable "db_storage_mb" {
+  description = "PostgreSQL storage in MB. 32768 is the minimum managed disk size returned in South Africa North."
+  type        = number
+  default     = 32768
+}
+
+variable "db_app_database_name" {
+  description = "Database name for the House of Veritas web app"
+  type        = string
+  default     = "house_of_veritas"
+}
+
 variable "cosmos_account_name" {
   description = "Cosmos DB account name (Mongo API)"
   type        = string

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -13,9 +13,9 @@ resource "azurerm_postgresql_flexible_server" "main" {
   administrator_login    = var.admin_username
   administrator_password = var.admin_password
 
-  storage_mb = 32768
+  storage_mb = var.storage_mb
 
-  sku_name = "B_Standard_B1ms"
+  sku_name = var.sku_name
 
   backup_retention_days        = 7
   geo_redundant_backup_enabled = false
@@ -57,6 +57,13 @@ resource "azurerm_postgresql_flexible_server_database" "docuseal" {
 
 resource "azurerm_postgresql_flexible_server_database" "baserow" {
   name      = "baserow_production"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  collation = "en_US.utf8"
+  charset   = "UTF8"
+}
+
+resource "azurerm_postgresql_flexible_server_database" "app" {
+  name      = var.app_database_name
   server_id = azurerm_postgresql_flexible_server.main.id
   collation = "en_US.utf8"
   charset   = "UTF8"

--- a/terraform/modules/database/outputs.tf
+++ b/terraform/modules/database/outputs.tf
@@ -18,6 +18,11 @@ output "baserow_database_name" {
   value       = azurerm_postgresql_flexible_server_database.baserow.name
 }
 
+output "app_database_name" {
+  description = "Name of the House of Veritas application database"
+  value       = azurerm_postgresql_flexible_server_database.app.name
+}
+
 output "connection_string_docuseal" {
   description = "Connection string for DocuSeal database"
   value       = "postgresql://${var.admin_username}:${var.admin_password}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/${azurerm_postgresql_flexible_server_database.docuseal.name}?sslmode=require"
@@ -27,5 +32,11 @@ output "connection_string_docuseal" {
 output "connection_string_baserow" {
   description = "Connection string for Baserow database"
   value       = "postgresql://${var.admin_username}:${var.admin_password}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/${azurerm_postgresql_flexible_server_database.baserow.name}?sslmode=require"
+  sensitive   = true
+}
+
+output "connection_string_app" {
+  description = "Connection string for the House of Veritas application database"
+  value       = "postgresql://${var.admin_username}:${var.admin_password}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/${azurerm_postgresql_flexible_server_database.app.name}?sslmode=require"
   sensitive   = true
 }

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -25,6 +25,24 @@ variable "admin_password" {
   sensitive   = true
 }
 
+variable "sku_name" {
+  description = "PostgreSQL Flexible Server Terraform SKU. B_Standard_B1ms maps to the lowest burstable Standard_B1ms SKU available in South Africa North."
+  type        = string
+  default     = "B_Standard_B1ms"
+}
+
+variable "storage_mb" {
+  description = "Provisioned PostgreSQL storage in MB. 32768 is the minimum managed disk size returned for South Africa North."
+  type        = number
+  default     = 32768
+}
+
+variable "app_database_name" {
+  description = "Database name for the House of Veritas web application"
+  type        = string
+  default     = "house_of_veritas"
+}
+
 variable "database_subnet_id" {
   description = "ID of the database subnet"
   type        = string

--- a/terraform/modules/webapp/variables.tf
+++ b/terraform/modules/webapp/variables.tf
@@ -224,6 +224,7 @@ variable "extra_app_settings" {
   description = "Additional app settings to merge"
   type        = map(string)
   default     = {}
+  sensitive   = true
 }
 
 variable "tags" {

--- a/tests/api/inventory-batch-identify.test.ts
+++ b/tests/api/inventory-batch-identify.test.ts
@@ -1,5 +1,6 @@
 import { POST } from "@/app/api/inventory/batch-identify/route"
-import { describe, expect, it } from "vitest"
+import { mkdir, rm, writeFile } from "fs/promises"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 const authHeaders = {
   "x-user-id": "irma",
@@ -9,6 +10,12 @@ const authHeaders = {
 }
 
 describe("POST /api/inventory/batch-identify", () => {
+  afterEach(async () => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+    await rm("/tmp/hov-uploads/file_sluice_payload.jpg", { force: true })
+  })
+
   it("returns preview-only manual suggestions when Sluice is not configured", async () => {
     const response = await POST(
       new Request("http://localhost/api/inventory/batch-identify", {
@@ -54,5 +61,54 @@ describe("POST /api/inventory/batch-identify", () => {
     )
 
     expect(response.status).toBe(400)
+  })
+
+  it("sends service-readable image bytes to configured Sluice", async () => {
+    await mkdir("/tmp/hov-uploads", { recursive: true })
+    await writeFile("/tmp/hov-uploads/file_sluice_payload.jpg", "image-bytes")
+    vi.stubEnv("SLUICE_API_URL", "https://sluice.example")
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          suggestions: [
+            {
+              uploadId: "file_sluice_payload",
+              photoUrl: "/api/uploads/file_sluice_payload",
+              label: "Detected item",
+              category: "other",
+              confidence: 0.8,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    )
+
+    const response = await POST(
+      new Request("http://localhost/api/inventory/batch-identify", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({
+          images: [
+            {
+              uploadId: "file_sluice_payload",
+              photoUrl: "/api/uploads/file_sluice_payload",
+              originalName: "shelf.jpg",
+              mimeType: "image/jpeg",
+            },
+          ],
+        }),
+      })
+    )
+
+    expect(response.status).toBe(200)
+    const requestBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))
+    expect(requestBody.images[0]).toMatchObject({
+      uploadId: "file_sluice_payload",
+      photoUrl: "/api/uploads/file_sluice_payload",
+      imageUrl: "/api/uploads/file_sluice_payload",
+      imageBase64: Buffer.from("image-bytes").toString("base64"),
+      dataUrl: `data:image/jpeg;base64,${Buffer.from("image-bytes").toString("base64")}`,
+    })
   })
 })

--- a/tests/api/inventory-batch-identify.test.ts
+++ b/tests/api/inventory-batch-identify.test.ts
@@ -1,0 +1,58 @@
+import { POST } from "@/app/api/inventory/batch-identify/route"
+import { describe, expect, it } from "vitest"
+
+const authHeaders = {
+  "x-user-id": "irma",
+  "x-user-role": "resident",
+  "x-user-email": "irma@houseofv.com",
+  "Content-Type": "application/json",
+}
+
+describe("POST /api/inventory/batch-identify", () => {
+  it("returns preview-only manual suggestions when Sluice is not configured", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/inventory/batch-identify", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({
+          images: [
+            {
+              uploadId: "file_123",
+              photoUrl: "/api/uploads/file_123",
+              originalName: "pool-chlorine.jpg",
+              mimeType: "image/jpeg",
+            },
+          ],
+        }),
+      })
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.previewOnly).toBe(true)
+    expect(data.aiPowered).toBe(false)
+    expect(data.suggestions).toEqual([
+      expect.objectContaining({
+        uploadId: "file_123",
+        photoUrl: "/api/uploads/file_123",
+        label: "pool chlorine",
+        category: "other",
+        confidence: null,
+      }),
+    ])
+  })
+
+  it("rejects non-upload URLs", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/inventory/batch-identify", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({
+          images: [{ uploadId: "file_123", photoUrl: "https://example.com/photo.jpg" }],
+        }),
+      })
+    )
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/tests/api/inventory.test.ts
+++ b/tests/api/inventory.test.ts
@@ -10,7 +10,53 @@ const operatorHeaders = {
   "Content-Type": "application/json",
 }
 
+const residentHeaders = {
+  "x-user-id": "irma",
+  "x-user-role": "resident",
+  "x-user-email": "irma@houseofv.com",
+  "Content-Type": "application/json",
+}
+
 describe("POST /api/inventory", () => {
+  it("keeps typed inventory add available for operators", async () => {
+    const name = `Typed item ${Date.now()}`
+    const request = new Request("http://localhost/api/inventory", {
+      method: "POST",
+      headers: operatorHeaders,
+      body: JSON.stringify({
+        name,
+        category: "workshop_consumables",
+        unit: "boxes",
+        currentStock: 12,
+        minStock: 2,
+        maxStock: 24,
+        reorderPoint: 4,
+        location: "Workshop Store",
+        supplier: "Builders Warehouse",
+        unitCost: 15,
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.item).toMatchObject({
+      name,
+      category: "workshop_consumables",
+      unit: "boxes",
+      currentStock: 12,
+      minStock: 2,
+      maxStock: 24,
+      reorderPoint: 4,
+      location: "Workshop Store",
+      supplier: "Builders Warehouse",
+      unitCost: 15,
+      totalValue: 180,
+    })
+    expect(data.item.photoUrl).toBeUndefined()
+    expect(data.item.capturedBy).toBeUndefined()
+  })
+
   it("creates a photo-labelled inventory item for an operator", async () => {
     const label = `Photo label ${Date.now()}`
     const request = new Request("http://localhost/api/inventory", {
@@ -66,11 +112,113 @@ describe("POST /api/inventory", () => {
     expect(data.item.photoUrl).toBeUndefined()
     expect(data.item.capturedBy).toBeUndefined()
   })
+
+  it("allows residents to create photo capture items only", async () => {
+    const label = `Resident photo ${Date.now()}`
+    const request = new Request("http://localhost/api/inventory", {
+      method: "POST",
+      headers: residentHeaders,
+      body: JSON.stringify({
+        name: label,
+        label,
+        category: "household",
+        unit: "units",
+        currentStock: 99,
+        minStock: 10,
+        maxStock: 200,
+        reorderPoint: 25,
+        location: "House",
+        unitCost: 500,
+        photoUrl: "/api/uploads/file_resident_photo",
+        photoFileId: "file_resident_photo",
+        imageBounds: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.item).toMatchObject({
+      name: label,
+      photoUrl: "/api/uploads/file_resident_photo",
+      capturedBy: "irma",
+      currentStock: 1,
+      minStock: 1,
+      maxStock: 1,
+      reorderPoint: 1,
+      unitCost: 0,
+      totalValue: 0,
+      imageBounds: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+    })
+  })
+
+  it("rejects resident inventory creates without a photo", async () => {
+    const request = new Request("http://localhost/api/inventory", {
+      method: "POST",
+      headers: residentHeaders,
+      body: JSON.stringify({
+        name: "No photo",
+        category: "household",
+        unit: "units",
+        location: "House",
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(403)
+  })
+
+  it("rejects resident stock mutations", async () => {
+    const request = new Request("http://localhost/api/inventory", {
+      method: "POST",
+      headers: residentHeaders,
+      body: JSON.stringify({
+        action: "consume",
+        itemId: "inv_001",
+        quantity: 1,
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(403)
+  })
 })
 
 describe("GET /api/inventory", () => {
   it("requires authentication", async () => {
     const response = await GET(new Request("http://localhost/api/inventory"))
     expect(response.status).toBe(401)
+  })
+
+  it("exposes only resident-linked inventory to residents", async () => {
+    const label = `Resident scoped ${Date.now()}`
+    await POST(
+      new Request("http://localhost/api/inventory", {
+        method: "POST",
+        headers: residentHeaders,
+        body: JSON.stringify({
+          name: label,
+          label,
+          category: "household",
+          unit: "units",
+          location: "House",
+          photoUrl: "/api/uploads/file_resident_scoped",
+          photoFileId: "file_resident_scoped",
+        }),
+      })
+    )
+
+    const response = await GET(
+      new Request("http://localhost/api/inventory", {
+        headers: residentHeaders,
+      })
+    )
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.items.length).toBeGreaterThan(0)
+    expect(data.items.every((item: { capturedBy?: string }) => item.capturedBy === "irma")).toBe(
+      true
+    )
+    expect(data.items.some((item: { name: string }) => item.name === label)).toBe(true)
   })
 })

--- a/tests/api/users-management.test.ts
+++ b/tests/api/users-management.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const getUserWithManagement = vi.fn()
+const updateUserManagement = vi.fn()
+
+vi.mock("@/lib/user-management", () => ({
+  getUserWithManagement,
+  updateUserManagement,
+}))
+
+const adminHeaders = {
+  "x-user-id": "hans",
+  "x-user-role": "admin",
+  "x-user-email": "smit.jurie@gmail.com",
+  "Content-Type": "application/json",
+}
+
+describe("PATCH /api/users/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("updates a normalized user email", async () => {
+    updateUserManagement.mockResolvedValue({
+      id: "charl",
+      email: "chapmancharl28@gmail.com",
+    })
+    const { PATCH } = await import("@/app/api/users/[id]/route")
+
+    const response = await PATCH(
+      new Request("http://localhost/api/users/charl", {
+        method: "PATCH",
+        headers: adminHeaders,
+        body: JSON.stringify({ email: " ChapmanCharl28@GMAIL.com " }),
+      }),
+      { params: Promise.resolve({ id: "charl" }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateUserManagement).toHaveBeenCalledWith("charl", {
+      email: "chapmancharl28@gmail.com",
+    })
+  })
+
+  it("rejects malformed email updates", async () => {
+    const { PATCH } = await import("@/app/api/users/[id]/route")
+
+    const response = await PATCH(
+      new Request("http://localhost/api/users/charl", {
+        method: "PATCH",
+        headers: adminHeaders,
+        body: JSON.stringify({ email: "not-an-email" }),
+      }),
+      { params: Promise.resolve({ id: "charl" }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(updateUserManagement).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/notification-service.test.ts
+++ b/tests/lib/notification-service.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { logger } from "@/lib/logger"
+import { sendNotification } from "@/lib/services/notification-service"
+import { findUserByIdAsync } from "@/lib/users"
+
+vi.mock("@/lib/users", () => ({
+  findUserByIdAsync: vi.fn(),
+}))
+
+describe("sendNotification", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("routes email notifications to the current user email", async () => {
+    vi.mocked(findUserByIdAsync).mockResolvedValue({
+      id: "charl",
+      name: "Charl",
+      email: "edited-charl@example.com",
+      phone: "",
+      role: "operator",
+      description: "",
+      color: "blue",
+      icon: "user",
+      specialty: [],
+    })
+    const info = vi.spyOn(logger, "info").mockImplementation(() => undefined)
+
+    await sendNotification({
+      type: "system_alert",
+      userId: "charl",
+      title: "Invite",
+      message: "Link",
+      channels: ["email"],
+    })
+
+    expect(info).toHaveBeenCalledWith(
+      "Email simulated (ACS_CONNECTION_STRING not set)",
+      expect.objectContaining({ to: "edited-charl@example.com", subject: "Invite" })
+    )
+  })
+})

--- a/tests/lib/rbac.test.ts
+++ b/tests/lib/rbac.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { afterEach, describe, it, expect, vi } from "vitest"
 import { NextResponse } from "next/server"
 import {
   getAuthContext,
@@ -19,6 +19,10 @@ function makeRequest(headers: Record<string, string> = {}): Request {
 }
 
 describe("RBAC", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   describe("getAuthContext", () => {
     it("should extract auth context from headers", () => {
       const req = makeRequest({
@@ -105,6 +109,23 @@ describe("RBAC", () => {
         })
       )
       expect(res.status).toBe(403)
+    })
+
+    it("rejects header-only auth in production outside CI", async () => {
+      vi.stubEnv("NODE_ENV", "production")
+      vi.stubEnv("E2E_TEST", "")
+      vi.stubEnv("ALLOW_HEADER_AUTH", "")
+
+      const handler = withRole("admin")(async () => ok())
+      const res = await handler(
+        makeRequest({
+          "x-user-id": "hans",
+          "x-user-role": "admin",
+          "x-user-email": "smit.jurie@gmail.com",
+        })
+      )
+
+      expect(res.status).toBe(401)
     })
   })
 


### PR DESCRIPTION
## Summary
- move API RBAC toward Mystira/Auth.js session context, with header auth limited to non-production, explicit ALLOW_HEADER_AUTH, or the E2E_TEST harness
- scope resident inventory reads to captured, owned, responsible, or linked items; block resident stock mutations and require resident creates to come through photo capture
- add mobile batch inventory capture preview with human correction, Preview-only Sluice identification integration, and support for multiple item bounds per image
- send Sluice service-readable image payloads as imageBase64/dataUrl from stored uploads instead of browser-relative protected URLs only
- keep typed/manual inventory add available for operators and admins
- correct Charl's fallback/contact email to chapmancharl28@gmail.com
- allow admin user email edits and return/display copyable invite links from the Hans team page
- route notification email delivery through the current user record before static fallback so edited invite addresses are used
- wire production Terraform to the cheapest South Africa North PostgreSQL Flexible Server path: B_Standard_B1ms, 32GB storage, HOV app database, and DATABASE_URL/POSTGRES_URL app settings

## Validation
- pnpm run lint
- pnpm exec tsc --noEmit
- pnpm test tests/lib/rbac.test.ts tests/api/inventory.test.ts tests/api/inventory-batch-identify.test.ts tests/api/uploads.test.ts tests/lib/nav-config.test.ts tests/api/users-management.test.ts
- pnpm test tests/api/inventory.test.ts tests/api/inventory-batch-identify.test.ts tests/api/uploads.test.ts
- pnpm test tests/api/inventory-batch-identify.test.ts tests/lib/notification-service.test.ts tests/lib/rbac.test.ts
- pnpm exec playwright test tests/e2e/02-kiosk-approval.spec.ts
- terraform -chdir=terraform/environments/production fmt -recursive
- terraform -chdir=terraform/environments/production init -backend=false
- terraform -chdir=terraform/environments/production validate
- Live smoke: https://hov.neuralliquid.ai/dashboard/hans/inventory redirects unauthenticated users to /login?redirect=%2Fdashboard%2Fhans%2Finventory
- Live smoke: Continue with Mystira redirects to identity.mystira.app with client_id neuralliquid-hov-web and HOV callback
- Azure check: South Africa North PostgreSQL Flexible Server supports Standard_B1ms; Terraform provider SKU is B_Standard_B1ms

## Notes
- HOV production currently has no ACS_CONNECTION_STRING, so app-native email invite delivery is not active. The PR makes invite links visible/copyable in the Team UI.
- Sent Charl a fresh production invite link via the connected Gmail account to chapmancharl28@gmail.com because HOV email delivery is not configured.
- Sluice identification is Preview-only; without SLUICE_API_URL or SLUICE_INVENTORY_IDENTIFY_URL it returns manual fallback suggestions.