### PR TITLE
Persist inventory through Cosmos repository

### DIFF
--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -1,11 +1,7 @@
 import { NextResponse } from "next/server"
 import { routeToInngest } from "@/lib/workflows"
-import {
-  getInventory,
-  restockByName,
-  findIndexById,
-  type InventoryItem,
-} from "@/lib/inventory-store"
+import type { InventoryItem } from "@/lib/inventory-store"
+import { getInventoryRepository } from "@/lib/repositories/inventory-repository"
 import { withRole } from "@/lib/auth/rbac"
 
 function guessCategory(name: string): InventoryItem["category"] {
@@ -108,7 +104,6 @@ export const GET = withRole(
   "employee",
   "resident"
 )(async (request: Request, context) => {
-  const inventory = getInventory()
   const { searchParams } = new URL(request.url)
   const category = searchParams.get("category")
   const lowStock = searchParams.get("lowStock") === "true"
@@ -116,6 +111,8 @@ export const GET = withRole(
   const barcode = searchParams.get("barcode")
   const search = searchParams.get("search")
 
+  const { repository } = await getInventoryRepository()
+  const inventory = await repository.list()
   let items =
     context.role === "resident"
       ? inventory.filter((item) => isLinkedToUser(item, context.userId))
@@ -183,8 +180,8 @@ export const POST = withRole(
   "employee",
   "resident"
 )(async (request: Request, context) => {
-  const inventory = getInventory()
   try {
+    const { repository } = await getInventoryRepository()
     const body = await request.json()
     const { action } = body
 
@@ -194,26 +191,26 @@ export const POST = withRole(
       }
       const { itemId, quantity, usedBy, purpose } = body
 
-      const index = findIndexById(itemId)
-      if (index === -1) {
+      const existing = await repository.findById(itemId)
+      if (!existing) {
         return NextResponse.json({ error: "Item not found" }, { status: 404 })
       }
 
-      if (inventory[index].currentStock < quantity) {
+      if (existing.currentStock < quantity) {
         return NextResponse.json({ error: "Insufficient stock" }, { status: 400 })
       }
 
-      inventory[index].currentStock -= quantity
-      inventory[index].totalValue = inventory[index].currentStock * inventory[index].unitCost
-      inventory[index].consumptionHistory.push({
+      existing.currentStock -= quantity
+      existing.totalValue = existing.currentStock * existing.unitCost
+      existing.consumptionHistory.push({
         date: new Date().toISOString().split("T")[0],
         quantity,
         usedBy,
         purpose,
       })
 
-      const needsAlert = inventory[index].currentStock <= inventory[index].reorderPoint
-      const item = inventory[index]
+      const item = await repository.update(existing)
+      const needsAlert = item.currentStock <= item.reorderPoint
 
       if (needsAlert) {
         const urgency =
@@ -251,21 +248,22 @@ export const POST = withRole(
       }
       const { itemId, quantity, unitCost } = body
 
-      const index = findIndexById(itemId)
-      if (index === -1) {
+      const existing = await repository.findById(itemId)
+      if (!existing) {
         return NextResponse.json({ error: "Item not found" }, { status: 404 })
       }
 
-      inventory[index].currentStock += quantity
+      existing.currentStock += quantity
       if (unitCost) {
-        inventory[index].unitCost = unitCost
+        existing.unitCost = unitCost
       }
-      inventory[index].totalValue = inventory[index].currentStock * inventory[index].unitCost
-      inventory[index].lastRestocked = new Date().toISOString().split("T")[0]
+      existing.totalValue = existing.currentStock * existing.unitCost
+      existing.lastRestocked = new Date().toISOString().split("T")[0]
+      const item = await repository.update(existing)
 
       return NextResponse.json({
         success: true,
-        item: inventory[index],
+        item,
       })
     }
 
@@ -334,7 +332,7 @@ export const POST = withRole(
       consumptionHistory: [],
     }
 
-    inventory.push(newItem)
+    await repository.create(newItem)
 
     return NextResponse.json({
       success: true,
@@ -351,8 +349,9 @@ export const PUT = withRole(
   "operator",
   "employee"
 )(async (request: Request) => {
-  const inventory = getInventory()
   try {
+    const { repository } = await getInventoryRepository()
+    const inventory = await repository.list()
     const body = await request.json()
     const { action, store } = body
 
@@ -379,7 +378,7 @@ export const PUT = withRole(
           existing.totalValue = existing.currentStock * existing.unitCost
           existing.lastRestocked = new Date().toISOString().split("T")[0]
           if (supplier) existing.supplier = supplier
-          updatedItems.push(existing)
+          updatedItems.push(await repository.update(existing))
         } else {
           const unitCost = price || (total && quantity ? total / quantity : 0)
           const newItem: InventoryItem = {
@@ -399,8 +398,7 @@ export const PUT = withRole(
             totalValue: (quantity || 1) * unitCost,
             consumptionHistory: [],
           }
-          inventory.push(newItem)
-          importedItems.push(newItem)
+          importedItems.push(await repository.create(newItem))
         }
       }
 

--- a/app/api/kiosk/requests/route.ts
+++ b/app/api/kiosk/requests/route.ts
@@ -5,7 +5,7 @@ import {
   sanitizeKioskDocs,
   type KioskRequestDoc,
 } from "@/lib/db/kiosk-store"
-import { restockByName } from "@/lib/inventory-store"
+import { getInventoryRepository } from "@/lib/repositories/inventory-repository"
 import { logger } from "@/lib/logger"
 import { NotificationChannel, sendNotification } from "@/lib/services/notification-service"
 import { routeToInngest } from "@/lib/workflows"
@@ -289,7 +289,8 @@ export const PATCH = withRole("admin")(async (request, context) => {
       const itemName = d?.itemName
       const quantity = typeof d?.quantity === "number" ? d.quantity : 0
       if (itemName && quantity > 0) {
-        const restocked = restockByName(itemName, quantity)
+        const { repository: inventoryRepository } = await getInventoryRepository()
+        const restocked = await inventoryRepository.restockByName(itemName, quantity)
         if (restocked) {
           logger.info("Kiosk: Auto-restocked inventory from approved stock order", {
             itemName,

--- a/lib/repositories/inventory-repository.ts
+++ b/lib/repositories/inventory-repository.ts
@@ -1,0 +1,147 @@
+import type { Collection } from "mongodb"
+import { getCollection, isMongoConfigured } from "@/lib/db/mongodb"
+import { getInventory, type InventoryItem } from "@/lib/inventory-store"
+
+export interface InventoryRepository {
+  list(): Promise<InventoryItem[]>
+  findById(id: string): Promise<InventoryItem | undefined>
+  findByName(name: string): Promise<InventoryItem | undefined>
+  create(item: InventoryItem): Promise<InventoryItem>
+  update(item: InventoryItem): Promise<InventoryItem>
+  restockByName(itemName: string, quantity: number): Promise<InventoryItem | null>
+}
+
+type InventoryDocument = InventoryItem
+
+function clone(item: InventoryItem): InventoryItem {
+  return JSON.parse(JSON.stringify(item)) as InventoryItem
+}
+
+function toDocument(item: InventoryItem): InventoryDocument {
+  return clone(item)
+}
+
+function fromDocument(document: InventoryDocument): InventoryItem {
+  return clone(document)
+}
+
+function findMatchingItem(items: InventoryItem[], name: string): InventoryItem | undefined {
+  const normalized = name.toLowerCase().trim()
+  if (!normalized) return undefined
+  return items.find(
+    (item) =>
+      item.name.toLowerCase().trim() === normalized ||
+      item.name.toLowerCase().includes(normalized) ||
+      normalized.includes(item.name.toLowerCase())
+  )
+}
+
+const memoryRepository: InventoryRepository = {
+  async list() {
+    return getInventory().map(clone)
+  },
+  async findById(id) {
+    const item = getInventory().find((candidate) => candidate.id === id)
+    return item ? clone(item) : undefined
+  },
+  async findByName(name) {
+    const item = findMatchingItem(getInventory(), name)
+    return item ? clone(item) : undefined
+  },
+  async create(item) {
+    getInventory().push(item)
+    return clone(item)
+  },
+  async update(item) {
+    const items = getInventory()
+    const index = items.findIndex((candidate) => candidate.id === item.id)
+    if (index === -1) throw new Error("Inventory item not found")
+    items[index] = item
+    return clone(item)
+  },
+  async restockByName(itemName, quantity) {
+    if (quantity <= 0) return null
+    const item = findMatchingItem(getInventory(), itemName)
+    if (!item) return null
+    item.currentStock += quantity
+    item.totalValue = item.currentStock * item.unitCost
+    item.lastRestocked = new Date().toISOString().slice(0, 10)
+    return clone(item)
+  },
+}
+
+async function createMongoRepository(): Promise<InventoryRepository> {
+  const collection: Collection<InventoryDocument> = await getCollection<InventoryDocument>(
+    "inventory_items"
+  )
+  await Promise.all([
+    collection.createIndex({ id: 1 }, { unique: true }),
+    collection.createIndex({ barcode: 1 }),
+    collection.createIndex({ capturedBy: 1 }),
+    collection.createIndex({ ownerId: 1 }),
+    collection.createIndex({ responsibleUserId: 1 }),
+    collection.createIndex({ linkedUserIds: 1 }),
+  ])
+
+  const repository: InventoryRepository = {
+    async list() {
+      const documents = await collection.find({}).sort({ name: 1 }).toArray()
+      return documents.map(fromDocument)
+    },
+    async findById(id) {
+      const document = await collection.findOne({ id })
+      return document ? fromDocument(document) : undefined
+    },
+    async findByName(name) {
+      const item = findMatchingItem(await repository.list(), name)
+      return item
+    },
+    async create(item) {
+      await collection.insertOne(toDocument(item))
+      return clone(item)
+    },
+    async update(item) {
+      const result = await collection.replaceOne({ id: item.id }, toDocument(item))
+      if (result.matchedCount === 0) throw new Error("Inventory item not found")
+      return clone(item)
+    },
+    async restockByName(itemName, quantity) {
+      if (quantity <= 0) return null
+      const item = await repository.findByName(itemName)
+      if (!item) return null
+      item.currentStock += quantity
+      item.totalValue = item.currentStock * item.unitCost
+      item.lastRestocked = new Date().toISOString().slice(0, 10)
+      return repository.update(item)
+    },
+  }
+  return repository
+}
+
+let cachedRepository: InventoryRepository | null = null
+let cachedMode: "mongodb" | "memory" | null = null
+
+export async function getInventoryRepository(): Promise<{
+  repository: InventoryRepository
+  mode: "mongodb" | "memory"
+}> {
+  if (cachedRepository && cachedMode) {
+    return { repository: cachedRepository, mode: cachedMode }
+  }
+
+  const useMemory = process.env.E2E_TEST === "1" || process.env.CI === "true" || !isMongoConfigured()
+  if (useMemory) {
+    cachedRepository = memoryRepository
+    cachedMode = "memory"
+    return { repository: cachedRepository, mode: cachedMode }
+  }
+
+  cachedRepository = await createMongoRepository()
+  cachedMode = "mongodb"
+  return { repository: cachedRepository, mode: cachedMode }
+}
+
+export function resetInventoryRepositoryForTests() {
+  cachedRepository = null
+  cachedMode = null
+}

--- a/lib/workflows/inventory-expiry.ts
+++ b/lib/workflows/inventory-expiry.ts
@@ -1,5 +1,5 @@
 import { inngest } from "@/lib/inngest/client"
-import { getInventory } from "@/lib/inventory-store"
+import { getInventoryRepository } from "@/lib/repositories/inventory-repository"
 import { sendNotification } from "@/lib/services/notification-service"
 import { getAdminNotificationRecipient } from "@/lib/workflows/notification-recipients"
 import { daysUntil, getAlertLevel, buildSummaryMessage } from "@/lib/workflows/utils"
@@ -8,7 +8,8 @@ export const inventoryExpiryCheck = inngest.createFunction(
   { id: "inventory-expiry-check", retries: 2 },
   { cron: "0 7 * * *" },
   async ({ step }) => {
-    const items = getInventory().filter((i) => i.expiryDate)
+    const { repository } = await getInventoryRepository()
+    const items = (await repository.list()).filter((i) => i.expiryDate)
     const alerts: Array<{
       item: { id: string; name: string; expiryDate: string }
       days: number

--- a/lib/workflows/reorder-automation.ts
+++ b/lib/workflows/reorder-automation.ts
@@ -1,6 +1,6 @@
 import { getKioskStore } from "@/lib/db/kiosk-store"
 import { inngest } from "@/lib/inngest/client"
-import { getInventory } from "@/lib/inventory-store"
+import { getInventoryRepository } from "@/lib/repositories/inventory-repository"
 import { sendNotification } from "@/lib/services/notification-service"
 import { getLowStockNotificationRecipient } from "@/lib/workflows/notification-recipients"
 
@@ -28,7 +28,8 @@ export const reorderAutomation = inngest.createFunction(
   { id: "reorder-automation", retries: 2 },
   { cron: "0 10 * * *" },
   async ({ step }) => {
-    const items = getInventory().filter((i) => i.currentStock <= i.reorderPoint)
+    const { repository } = await getInventoryRepository()
+    const items = (await repository.list()).filter((i) => i.currentStock <= i.reorderPoint)
     if (items.length === 0) return { created: 0 }
 
     const PAGE_SIZE = 100

--- a/lib/workflows/supplier-order.ts
+++ b/lib/workflows/supplier-order.ts
@@ -1,12 +1,13 @@
 import { inngest } from "@/lib/inngest/client"
-import { getInventory } from "@/lib/inventory-store"
+import { getInventoryRepository } from "@/lib/repositories/inventory-repository"
 import { getAdminNotificationRecipient } from "@/lib/workflows/notification-recipients"
 import { sendNotification } from "@/lib/services/notification-service"
 import { runNotificationStep } from "@/lib/workflows/utils"
 import type { StockOrderApprovedPayload } from "./schema"
 
-function findSupplierForItem(itemName: string): string | undefined {
-  const items = getInventory()
+async function findSupplierForItem(itemName: string): Promise<string | undefined> {
+  const { repository } = await getInventoryRepository()
+  const items = await repository.list()
   const lower = itemName.toLowerCase()
   const item = items.find(
     (i) => i.name.toLowerCase().includes(lower) || lower.includes(i.name.toLowerCase())
@@ -21,7 +22,7 @@ export const supplierOrderPlaced = inngest.createFunction(
     const { requestId, itemName, quantity, employeeId, reviewedBy } =
       event.data as StockOrderApprovedPayload
 
-    const supplier = findSupplierForItem(itemName)
+    const supplier = await findSupplierForItem(itemName)
 
     await runNotificationStep(step, async () => {
       await sendNotification({

--- a/tests/lib/inventory-repository.test.ts
+++ b/tests/lib/inventory-repository.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  getInventoryRepository,
+  resetInventoryRepositoryForTests,
+} from "@/lib/repositories/inventory-repository"
+
+describe("inventory repository", () => {
+  beforeEach(() => {
+    vi.stubEnv("MONGODB_URI", "")
+    vi.stubEnv("MONGO_URL", "")
+    vi.stubEnv("E2E_TEST", "1")
+    resetInventoryRepositoryForTests()
+  })
+
+  it("persists inventory mutations through the repository contract", async () => {
+    const { repository, mode } = await getInventoryRepository()
+    const item = {
+      id: "inv_repository_test",
+      name: "Repository test item",
+      category: "other" as const,
+      unit: "units",
+      currentStock: 2,
+      minStock: 1,
+      maxStock: 5,
+      reorderPoint: 1,
+      lastRestocked: "2026-07-24",
+      averageConsumption: 0,
+      location: "Test Store",
+      unitCost: 10,
+      totalValue: 20,
+      consumptionHistory: [],
+    }
+
+    expect(mode).toBe("memory")
+    await repository.create(item)
+    expect(await repository.findById(item.id)).toEqual(item)
+
+    const updated = (await repository.findById(item.id))!
+    updated.currentStock = 4
+    updated.totalValue = 40
+    await repository.update(updated)
+    expect((await repository.findByName("repository test"))?.currentStock).toBe(4)
+
+    const restocked = await repository.restockByName("Repository test item", 1)
+    expect(restocked).toMatchObject({ currentStock: 5, totalValue: 50 })
+  })
+})


### PR DESCRIPTION
## Summary\n- add a repository boundary with Cosmos Mongo and test/in-memory adapters\n- persist inventory create, restock, consume, OCR import, kiosk restocks, and scheduled checks\n- index inventory ownership, responsibility, links, barcode, and stable IDs\n- keep photos as URL references; no image bytes are stored in Cosmos\n\n## Production configuration\nThe existing App Service already has MONGODB_URI and DB_NAME configured for nlprodhovcosmos / house_of_veritas.\n\n## Validation\n- pnpm exec tsc --noEmit\n- pnpm run lint\n- pnpm test (50 files, 317 tests)\n- pnpm run build\n\n## Deployment note\nAfter merge, smoke-test inventory add/list/restock against production and verify the inventory_items collection is created in Cosmos.