### PR TITLE
Add seed and repeat flow for kitchen recipes

### DIFF
--- a/app/api/recipes/[id]/ratings/route.ts
+++ b/app/api/recipes/[id]/ratings/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server"
+import { randomUUID } from "crypto"
+import { updateTask } from "@/lib/services/baserow"
+import { withRole } from "@/lib/auth/rbac"
+import { getExpandedAudienceAliases, isRecipeAudienceMatch } from "@/lib/recipes"
+import {
+  getRecipeById,
+  getRecipeMealInstanceById,
+  getRecipeRating,
+  getRecipeRatingSummary,
+  listRecipeRatings,
+  upsertRecipeRating,
+} from "@/lib/repositories/recipe-repository"
+import { logger } from "@/lib/logger"
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function asInt1To5(value: unknown): 1 | 2 | 3 | 4 | 5 | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 5) return null
+  return value as 1 | 2 | 3 | 4 | 5
+}
+
+function asInt(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value.trim(), 10)
+    return Number.isInteger(parsed) ? parsed : null
+  }
+  return null
+}
+
+function canAccessRecipe(contextRole: string, contextUserId: string, audienceUserIds: string[]): boolean {
+  if (contextRole === "admin") return true
+  return isRecipeAudienceMatch(audienceUserIds, contextUserId)
+}
+
+function normalizeResidentUserId(userId: string, residentIds: string[]): string {
+  const normalizedUserId = userId.toLowerCase().trim()
+  const aliasMatch = residentIds.find((residentId) =>
+    getExpandedAudienceAliases(residentId).includes(normalizedUserId)
+  )
+  return aliasMatch ?? userId
+}
+
+function hasTaskForMeal(taskId: number, taskIds: number[]): boolean {
+  return taskIds.includes(taskId)
+}
+
+function taskBelongsToResident(
+  taskId: number,
+  mealInstance: Awaited<ReturnType<typeof getRecipeMealInstanceById>>,
+  userId: string
+): boolean {
+  const normalizedAliases = getExpandedAudienceAliases(userId)
+  const assignment = mealInstance?.ratingTaskAssignments?.find((entry) => entry.taskId === taskId)
+  if (assignment) return normalizedAliases.includes(assignment.residentUserId.toLowerCase())
+  return hasTaskForMeal(taskId, mealInstance?.ratingTaskIds ?? [])
+}
+
+export const GET = withRole("admin", "operator", "employee", "resident")(
+  async (request, context) => {
+    try {
+      const params = await context.params
+      const id = params?.id
+      if (!id) return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+
+      const recipe = await getRecipeById(id)
+      if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+      if (!canAccessRecipe(context.role, context.userId, recipe.audienceUserIds)) {
+        return NextResponse.json({ error: "You do not have access to this recipe" }, { status: 403 })
+      }
+      if (context.role !== "admin" && recipe.status !== "published") {
+        return NextResponse.json({ error: "Recipe is not published" }, { status: 403 })
+      }
+
+      const mealInstanceId = asString(new URL(request.url).searchParams.get("mealInstanceId"))
+      const ratings = mealInstanceId
+        ? (await listRecipeRatings(id)).filter((rating) => rating.mealInstanceId === mealInstanceId)
+        : await listRecipeRatings(id)
+      const summary = await getRecipeRatingSummary(id)
+
+      return NextResponse.json({ ratings, summary })
+    } catch (error) {
+      logger.error("Failed to list ratings", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return NextResponse.json({ error: "Failed to list ratings" }, { status: 500 })
+    }
+  }
+)
+
+export const POST = withRole("admin", "operator", "employee", "resident")(
+  async (request, context) => {
+    try {
+      const params = await context.params
+      const id = params?.id
+      if (!id) return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+
+      const recipe = await getRecipeById(id)
+      if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+      if (!canAccessRecipe(context.role, context.userId, recipe.audienceUserIds)) {
+        return NextResponse.json({ error: "You do not have access to this recipe" }, { status: 403 })
+      }
+      if (context.role !== "admin" && recipe.status !== "published") {
+        return NextResponse.json({ error: "Recipe is not published" }, { status: 403 })
+      }
+
+      const body = await request.json()
+      const mealInstanceId = asString(body.mealInstanceId)
+      const score = asInt1To5(body.score)
+      const taskId = asInt(body.taskId)
+      if (!mealInstanceId) return NextResponse.json({ error: "mealInstanceId is required" }, { status: 400 })
+      if (!score) return NextResponse.json({ error: "score must be an integer 1 to 5" }, { status: 400 })
+
+      const meal = await getRecipeMealInstanceById(mealInstanceId)
+      if (!meal || meal.recipeId !== id) {
+        return NextResponse.json({ error: "Meal instance not found for this recipe" }, { status: 404 })
+      }
+
+      const isResidentAssigned = isRecipeAudienceMatch(meal.residentUserIds, context.userId)
+      if (!isResidentAssigned && context.role !== "admin") {
+        return NextResponse.json({ error: "You are not assigned this rating task" }, { status: 403 })
+      }
+
+      if (taskId !== null && !hasTaskForMeal(taskId, meal.ratingTaskIds)) {
+        return NextResponse.json(
+          { error: "taskId does not match this meal instance" },
+          { status: 400 }
+        )
+      }
+
+      if (taskId !== null && !taskBelongsToResident(taskId, meal, context.userId) && context.role !== "admin") {
+        return NextResponse.json(
+          { error: "taskId does not match this meal instance" },
+          { status: 400 }
+        )
+      }
+
+      const residentUserId = normalizeResidentUserId(context.userId, meal.residentUserIds)
+      const ratingPayload = await getRecipeRating(id, mealInstanceId, residentUserId)
+
+      const rating = await upsertRecipeRating({
+        id: ratingPayload?.id ?? `rating-${randomUUID()}`,
+        recipeId: id,
+        mealInstanceId,
+        residentUserId,
+        score,
+        comment: asString(body.comment),
+        taskId,
+        submittedBy: context.userId,
+        submittedAt: ratingPayload?.submittedAt ?? new Date().toISOString(),
+      })
+
+      if (taskId) {
+        await updateTask(taskId, {
+          status: "Completed",
+          completionNotes: `Rating submitted: ${score}/5`,
+        }).catch(() => null)
+      }
+
+      const summary = await getRecipeRatingSummary(id)
+      return NextResponse.json({ rating, summary })
+    } catch (error) {
+      logger.error("Failed to submit recipe rating", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return NextResponse.json({ error: "Failed to submit rating" }, { status: 500 })
+    }
+  }
+)

--- a/app/api/recipes/[id]/ratings/route.ts
+++ b/app/api/recipes/[id]/ratings/route.ts
@@ -24,13 +24,13 @@ function asInt1To5(value: unknown): 1 | 2 | 3 | 4 | 5 | null {
   return value as 1 | 2 | 3 | 4 | 5
 }
 
-function asInt(value: unknown): number | null {
+function asInt(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isInteger(value)) return value
   if (typeof value === "string") {
     const parsed = Number.parseInt(value.trim(), 10)
-    return Number.isInteger(parsed) ? parsed : null
+    return Number.isInteger(parsed) ? parsed : undefined
   }
-  return null
+  return undefined
 }
 
 function canAccessRecipe(contextRole: string, contextUserId: string, audienceUserIds: string[]): boolean {
@@ -126,14 +126,18 @@ export const POST = withRole("admin", "operator", "employee", "resident")(
         return NextResponse.json({ error: "You are not assigned this rating task" }, { status: 403 })
       }
 
-      if (taskId !== null && !hasTaskForMeal(taskId, meal.ratingTaskIds)) {
+      if (taskId !== undefined && !hasTaskForMeal(taskId, meal.ratingTaskIds)) {
         return NextResponse.json(
           { error: "taskId does not match this meal instance" },
           { status: 400 }
         )
       }
 
-      if (taskId !== null && !taskBelongsToResident(taskId, meal, context.userId) && context.role !== "admin") {
+      if (
+        taskId !== undefined &&
+        !taskBelongsToResident(taskId, meal, context.userId) &&
+        context.role !== "admin"
+      ) {
         return NextResponse.json(
           { error: "taskId does not match this meal instance" },
           { status: 400 }
@@ -150,12 +154,12 @@ export const POST = withRole("admin", "operator", "employee", "resident")(
         residentUserId,
         score,
         comment: asString(body.comment),
-        taskId,
+        taskId: taskId ?? undefined,
         submittedBy: context.userId,
         submittedAt: ratingPayload?.submittedAt ?? new Date().toISOString(),
       })
 
-      if (taskId) {
+      if (taskId !== undefined) {
         await updateTask(taskId, {
           status: "Completed",
           completionNotes: `Rating submitted: ${score}/5`,

--- a/app/api/recipes/[id]/repeat/route.ts
+++ b/app/api/recipes/[id]/repeat/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from "next/server"
+import { isRecipeAudienceMatch } from "@/lib/recipes"
+import { withRole } from "@/lib/auth/rbac"
+import { createMealFromRecipe } from "@/lib/recipe-serving"
+import {
+  getRecipeById,
+  getRecipeMealInstanceById,
+  getRecipeRatingSummary,
+  listRecipeMealInstances,
+  listRecipeRatings,
+} from "@/lib/repositories/recipe-repository"
+import { logger } from "@/lib/logger"
+
+function asBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value
+  return value === 1 || value === "1" || value === "true" || value === "yes"
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function buildMealSummary(mealId: string, ratings: number[]): { mealInstanceId: string; totalRatings: number; averageScore: number } {
+  if (ratings.length === 0) {
+    return {
+      mealInstanceId: mealId,
+      totalRatings: 0,
+      averageScore: 0,
+    }
+  }
+
+  const total = ratings.reduce((sum, value) => sum + value, 0)
+  return {
+    mealInstanceId: mealId,
+    totalRatings: ratings.length,
+    averageScore: Number((total / ratings.length).toFixed(2)),
+  }
+}
+
+export const POST = withRole("admin", "operator", "employee", "resident")(
+  async (request, context) => {
+    try {
+      const params = await context.params
+      const id = params?.id
+      if (!id) return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+
+      const recipe = await getRecipeById(id)
+      if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+      if (!isRecipeAudienceMatch(recipe.audienceUserIds, context.userId) && context.role !== "admin") {
+        return NextResponse.json({ error: "You cannot repeat this recipe" }, { status: 403 })
+      }
+
+      const body = (await request.json().catch(() => ({}))) as {
+        sourceMealInstanceId?: string
+        fromLatest?: boolean | string
+        mealName?: string
+        residentUserIds?: string[]
+        createRatingTasks?: boolean
+        servedBy?: string
+      }
+
+      let sourceMeal = null as Awaited<ReturnType<typeof getRecipeMealInstanceById>>
+      if (asString(body?.sourceMealInstanceId)) {
+        const sourceMealInstanceId = asString(body.sourceMealInstanceId)
+        if (sourceMealInstanceId) {
+          const candidate = await getRecipeMealInstanceById(sourceMealInstanceId)
+          if (!candidate || candidate.recipeId !== id) {
+            return NextResponse.json(
+              { error: "Source meal instance not found for this recipe" },
+              { status: 404 }
+            )
+          }
+          sourceMeal = candidate
+        }
+      } else if (asBoolean(body?.fromLatest)) {
+        const history = await listRecipeMealInstances(id)
+        if (history.length > 0) {
+          sourceMeal = history[0]
+        } else {
+          return NextResponse.json({ error: "No meal instance found to repeat" }, { status: 404 })
+        }
+      }
+
+      if (sourceMeal && context.role !== "admin" && !isRecipeAudienceMatch(sourceMeal.residentUserIds, context.userId)) {
+        return NextResponse.json(
+          { error: "You are not assigned to the source meal" },
+          { status: 403 }
+        )
+      }
+
+      const sourceMealId = sourceMeal?.id
+      const sourceSummary = sourceMeal
+        ? buildMealSummary(
+            sourceMeal.id,
+            (await listRecipeRatings(id))
+              .filter((rating) => rating.mealInstanceId === sourceMeal?.id)
+              .map((rating) => rating.score)
+          )
+        : null
+
+      const mealName =
+        asString(body.mealName) ??
+        (sourceMeal?.mealName ? `${sourceMeal.mealName} (repeat)` : recipe.titleEn)
+
+      const servedBy = asString(body.servedBy) ?? context.userId
+      const createRatingTasks = body.createRatingTasks === undefined ? true : body.createRatingTasks === true
+
+      const { mealInstance: meal } = await createMealFromRecipe({
+        recipe,
+        mealName,
+        residentUserIds: body?.residentUserIds,
+        servedBy,
+        createRatingTasks,
+      })
+
+      const summary = await getRecipeRatingSummary(id)
+
+      return NextResponse.json({
+        mealInstance: meal,
+        sourceMealInstanceId: sourceMealId,
+        sourceSummary,
+        ratingSummary: summary,
+      })
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("No valid resident recipients")) {
+        return NextResponse.json({ error: error.message }, { status: 400 })
+      }
+
+      logger.error("Failed to repeat recipe meal", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return NextResponse.json({ error: "Failed to repeat meal" }, { status: 500 })
+    }
+  }
+)

--- a/app/api/recipes/[id]/route.ts
+++ b/app/api/recipes/[id]/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server"
+import {
+  isRecipeAudienceMatch,
+  KNOWN_RECIPE_STATUSES,
+  normalizeRecipeAudienceUserIds,
+  type RecipeCreatePayload,
+  type RecipeRecord,
+} from "@/lib/recipes"
+import {
+  getRecipeById,
+  replaceRecipe,
+} from "@/lib/repositories/recipe-repository"
+import { logger } from "@/lib/logger"
+import { withRole } from "@/lib/auth/rbac"
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const normalized = value.trim()
+  return normalized.length ? normalized : undefined
+}
+
+function asNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined
+  if (!Number.isInteger(value) || value < 0) return undefined
+  return value
+}
+
+function ensureValidRecipeStatus(value: unknown): value is typeof KNOWN_RECIPE_STATUSES[number] {
+  return typeof value === "string" && (KNOWN_RECIPE_STATUSES as string[]).includes(value)
+}
+
+function buildRecipePayload(base: RecipeRecord, updates: Partial<RecipeCreatePayload>): RecipeRecord {
+  const audienceUserIds = normalizeRecipeAudienceUserIds(
+    updates.audienceUserIds ?? base.audienceUserIds
+  )
+  const titleEn = asString(updates.titleEn ?? base.titleEn) as string
+  const titleAf = asString(updates.titleAf ?? base.titleAf) as string
+  const ingredients = updates.ingredients
+    ? updates.ingredients
+        .filter((ingredient) => asString(ingredient.name))
+        .map((ingredient, index) => ({
+          id: asString(ingredient.id) ?? `ing-${base.id}-${index + 1}`,
+          quantity: ingredient.quantity,
+          unit: asString(ingredient.unit),
+          name: asString(ingredient.name) as string,
+          preparationNote: asString(ingredient.preparationNote),
+          section: asString(ingredient.section),
+        }))
+    : base.ingredients
+  const steps = updates.steps
+    ? updates.steps.map((step, index) => ({
+        id: asString(step.id) ?? `step-${base.id}-${index + 1}`,
+        order: asNonNegativeInt(step.order as number) || index + 1,
+        instructionEn: asString(step.instructionEn) ?? "",
+        instructionAf: asString(step.instructionAf) ?? "",
+        timerMinutes: asNonNegativeInt(step.timerMinutes as number),
+        section: asString(step.section),
+      }))
+    : base.steps
+
+  return {
+    ...base,
+    status: updates.status ?? base.status,
+    audienceUserIds,
+    titleEn,
+    summaryEn: asString(updates.summaryEn) ?? base.summaryEn,
+    titleAf,
+    summaryAf: asString(updates.summaryAf) ?? base.summaryAf,
+    servings: asNonNegativeInt(updates.servings) ?? base.servings,
+    prepMinutes: asNonNegativeInt(updates.prepMinutes) ?? base.prepMinutes,
+    cookMinutes: asNonNegativeInt(updates.cookMinutes) ?? base.cookMinutes,
+    cuisine: asString(updates.cuisine) ?? base.cuisine,
+    category: asString(updates.category) ?? base.category,
+    image: (updates as RecipeCreatePayload).image ?? base.image,
+    ingredients,
+    steps,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+function validateRecipe(recipe: RecipeRecord): string | null {
+  if (!recipe.titleEn || !recipe.titleAf) return "titleEn and titleAf are required"
+  if (!recipe.image?.url) return "Image URL is required"
+  if (!recipe.image?.source) return "Image source is required"
+  if (!recipe.image?.license) return "Image license is required"
+  if (!recipe.image?.attributionText) return "Image attribution text is required"
+  if (recipe.ingredients.length === 0) return "At least one ingredient is required"
+  if (recipe.steps.length === 0) return "At least one step is required"
+  if (recipe.steps.some((step) => !step.instructionEn || !step.instructionAf)) {
+    return "All steps must include English and Afrikaans instructions"
+  }
+  return null
+}
+
+async function ensureEditableRecipe(
+  id: string,
+  context: { role: string; userId: string },
+  allowAdmin: boolean
+) {
+  const existing = await getRecipeById(id)
+  if (!existing) {
+    return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+  }
+
+  if (context.role === "admin" && allowAdmin) return existing
+
+  if (!isRecipeAudienceMatch(existing.audienceUserIds, context.userId)) {
+    return NextResponse.json(
+      { error: "You do not have access to this recipe" },
+      { status: 403 }
+    )
+  }
+  return existing
+}
+
+export const GET = withRole("admin", "operator", "employee", "resident")(
+  async (_request, context) => {
+    try {
+      const { id } = await context.params
+      const recipe = await getRecipeById(id)
+      if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+
+      if (context.role !== "admin" && recipe.status !== "published") {
+        return NextResponse.json({ error: "Recipe is not published" }, { status: 403 })
+      }
+
+      if (context.role !== "admin" && !isRecipeAudienceMatch(recipe.audienceUserIds, context.userId)) {
+        return NextResponse.json(
+          { error: "You do not have access to this recipe" },
+          { status: 403 }
+        )
+      }
+
+      return NextResponse.json({ recipe })
+    } catch (error) {
+      logger.error("Failed to get recipe", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return NextResponse.json({ error: "Failed to get recipe" }, { status: 500 })
+    }
+  }
+)
+
+export const PATCH = withRole("admin", "operator", "employee", "resident")(
+  async (request, context) => {
+    try {
+      const params = await context.params
+      const id = params?.id
+      if (!id) return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+
+      const existingByRole = await ensureEditableRecipe(id, context, true)
+      if (existingByRole instanceof Response) return existingByRole
+      const recipePayload = existingByRole as RecipeRecord
+
+      const body = (await request.json()) as Partial<RecipeCreatePayload>
+      if (body.status !== undefined && !ensureValidRecipeStatus(body.status)) {
+        return NextResponse.json({ error: "Invalid recipe status" }, { status: 400 })
+      }
+
+      const merged = buildRecipePayload(recipePayload, body)
+      const validation = validateRecipe(merged)
+      if (validation) return NextResponse.json({ error: validation }, { status: 400 })
+
+      const updated = await replaceRecipe(merged)
+      if (!updated) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+      return NextResponse.json({ recipe: updated })
+    } catch (error) {
+      logger.error("Failed to update recipe", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return NextResponse.json({ error: "Failed to update recipe" }, { status: 500 })
+    }
+  }
+)

--- a/app/api/recipes/[id]/route.ts
+++ b/app/api/recipes/[id]/route.ts
@@ -116,7 +116,10 @@ async function ensureEditableRecipe(
 export const GET = withRole("admin", "operator", "employee", "resident")(
   async (_request, context) => {
     try {
-      const { id } = await context.params
+      const params = await context.params
+      const id = params?.id
+      if (!id) return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+
       const recipe = await getRecipeById(id)
       if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
 

--- a/app/api/recipes/[id]/serve/route.ts
+++ b/app/api/recipes/[id]/serve/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server"
+import { withRole } from "@/lib/auth/rbac"
+import {
+  isRecipeAudienceMatch,
+} from "@/lib/recipes"
+import { createMealFromRecipe } from "@/lib/recipe-serving"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
+import { logger } from "@/lib/logger"
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const normalized = value.trim()
+  return normalized.length ? normalized : undefined
+}
+
+export const POST = withRole("admin", "operator", "employee", "resident")(
+  async (request, context) => {
+    try {
+      const params = await context.params
+      const id = params?.id
+      if (!id) return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+
+      const recipe = await getRecipeById(id)
+      if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+      if (!isRecipeAudienceMatch(recipe.audienceUserIds, context.userId) && context.role !== "admin") {
+        return NextResponse.json({ error: "You cannot serve this recipe" }, { status: 403 })
+      }
+
+      const body = await request.json()
+      const mealName = asString(body.mealName)
+      const servedBy = asString(body.servedBy) ?? context.userId
+      const createRatingTasks =
+        body.createRatingTasks === undefined ? true : body.createRatingTasks === true
+      const { mealInstance: meal } = await createMealFromRecipe({
+        recipe,
+        mealName,
+        residentUserIds: body.residentUserIds,
+        servedBy,
+        createRatingTasks,
+      })
+
+      return NextResponse.json({ mealInstance: meal })
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("No valid resident recipients")) {
+        return NextResponse.json({ error: error.message }, { status: 400 })
+      }
+
+      logger.error("Failed to serve recipe", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return NextResponse.json({ error: "Failed to serve recipe" }, { status: 500 })
+    }
+  }
+)

--- a/app/api/recipes/route.ts
+++ b/app/api/recipes/route.ts
@@ -1,0 +1,190 @@
+import { randomUUID } from "crypto"
+import { NextResponse } from "next/server"
+import {
+  getExpandedAudienceAliases,
+  KNOWN_RECIPE_STATUSES,
+  normalizeRecipeAudienceUserIds,
+  type RecipeCreatePayload,
+  type RecipeRecord,
+  isRecipeAudienceMatch,
+} from "@/lib/recipes"
+import {
+  getRecipeRatingSummaries,
+  createRecipe,
+  listRecipes,
+} from "@/lib/repositories/recipe-repository"
+import { logger } from "@/lib/logger"
+import { withRole } from "@/lib/auth/rbac"
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function asNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined
+  if (!Number.isInteger(value) || value < 0) return undefined
+  return value
+}
+
+function buildRecipe(payload: RecipeCreatePayload, ownerUserId: string, id = `recipe-${randomUUID()}`): RecipeRecord {
+  const now = new Date().toISOString()
+  const audienceUserIds = normalizeRecipeAudienceUserIds(payload.audienceUserIds)
+  const titleEn = asString(payload.titleEn)
+  const titleAf = asString(payload.titleAf)
+  if (!titleEn || !titleAf) throw new Error("titleEn/titleAf are required")
+
+  const ingredients =
+    (Array.isArray(payload.ingredients) ? payload.ingredients : [])
+      .filter((ingredient) => asString(ingredient.name))
+      .map((ingredient, index) => ({
+        id: asString(ingredient.id) ?? `ing-${id}-${index + 1}`,
+        quantity: ingredient.quantity,
+        unit: asString(ingredient.unit),
+        name: asString(ingredient.name) as string,
+        preparationNote: asString(ingredient.preparationNote),
+        section: asString(ingredient.section),
+      }))
+
+  const steps =
+    (Array.isArray(payload.steps) ? payload.steps : []).map((step, index) => {
+      const order = asNonNegativeInt(step.order as number) || index + 1
+      return {
+        id: asString(step.id) ?? `step-${id}-${index + 1}`,
+        order,
+        instructionEn: asString(step.instructionEn) ?? "",
+        instructionAf: asString(step.instructionAf) ?? "",
+        timerMinutes: asNonNegativeInt(step.timerMinutes as number),
+        section: asString(step.section),
+      }
+    })
+
+  return {
+    id,
+    status: payload.status || "draft",
+    ownerUserId,
+    audienceUserIds,
+    titleEn,
+    summaryEn: asString(payload.summaryEn),
+    titleAf,
+    summaryAf: asString(payload.summaryAf),
+    servings: asNonNegativeInt(payload.servings),
+    prepMinutes: asNonNegativeInt(payload.prepMinutes),
+    cookMinutes: asNonNegativeInt(payload.cookMinutes),
+    cuisine: asString(payload.cuisine),
+    category: asString(payload.category),
+    image: payload.image,
+    ingredients,
+    steps,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function ensureValidRecipeStatus(value: unknown): value is typeof KNOWN_RECIPE_STATUSES[number] {
+  return typeof value === "string" && (KNOWN_RECIPE_STATUSES as string[]).includes(value)
+}
+
+function validatePayload(recipe: RecipeRecord): string | null {
+  if (!recipe.titleEn || !recipe.titleAf) return "titleEn and titleAf are required"
+  if (recipe.ingredients.length === 0) return "At least one ingredient is required"
+  if (recipe.steps.length === 0) return "At least one step is required"
+  if (!recipe.image.url) return "Image URL is required"
+  if (!recipe.image.source) return "Image source is required"
+  if (!recipe.image.license) return "Image license is required"
+  if (!recipe.image.attributionText) return "Image attribution text is required"
+  const badSteps = recipe.steps.some((step) => !step.instructionEn || !step.instructionAf)
+  if (badSteps) return "All steps must include English and Afrikaans instructions"
+  return null
+}
+
+async function buildFilteredRecipesWithSummary(role: string, userId: string, filters: URLSearchParams) {
+  const requestedStatus = asString(filters.get("status"))
+  const includeStats = filters.get("withStats") === "true"
+  const includeDrafts = filters.get("includeDrafts") === "true"
+
+  let filteredStatus: RecipeRecord["status"] | RecipeRecord["status"][] | undefined
+  if (requestedStatus) {
+    if (!ensureValidRecipeStatus(requestedStatus)) {
+      return NextResponse.json({ error: "Invalid status" }, { status: 400 })
+    }
+    if (role !== "admin" && requestedStatus !== "published") {
+      return NextResponse.json({ error: "Only published recipes can be listed by residents" }, { status: 403 })
+    }
+  }
+
+  if (role === "admin") {
+    if (requestedStatus) {
+      if (includeDrafts && (requestedStatus === "published" || requestedStatus === "draft")) {
+        filteredStatus = ["draft", "published"]
+      } else {
+        filteredStatus = requestedStatus
+      }
+    } else if (includeDrafts) {
+      filteredStatus = ["published", "draft"]
+    } else {
+      filteredStatus = "published"
+    }
+  } else {
+    filteredStatus = "published"
+  }
+
+  const recipes = await listRecipes({
+    status: filteredStatus,
+    ...(role === "admin" ? {} : { audienceUserIds: getExpandedAudienceAliases(userId) }),
+  })
+
+  const filteredByRequest = recipes.filter((recipe) => {
+    if (role === "admin") return true
+    return isRecipeAudienceMatch(recipe.audienceUserIds, userId)
+  })
+
+  if (!includeStats) return { recipes: filteredByRequest }
+
+  const summaries = await getRecipeRatingSummaries(filteredByRequest.map((recipe) => recipe.id))
+  return {
+    recipes: filteredByRequest.map((recipe) => ({
+      ...recipe,
+      ratingSummary: summaries[recipe.id],
+    })),
+  }
+}
+
+export const GET = withRole("admin", "operator", "employee", "resident")(async (request, context) => {
+  try {
+    const response = await buildFilteredRecipesWithSummary(
+      context.role,
+      context.userId,
+      new URL(request.url).searchParams
+    )
+    if (response && response instanceof NextResponse) return response
+    return NextResponse.json(response)
+  } catch (error) {
+    logger.error("Failed to list recipes", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Failed to list recipes" }, { status: 500 })
+  }
+})
+
+export const POST = withRole("admin", "operator", "employee", "resident")(async (request, context) => {
+  try {
+    const body = (await request.json()) as RecipeCreatePayload
+    if (!body?.titleEn || !body?.titleAf || !body?.image || !Array.isArray(body.steps)) {
+      return NextResponse.json({ error: "titleEn, titleAf, image, ingredients and steps are required" }, { status: 400 })
+    }
+
+    const recipe = buildRecipe(body, context.userId)
+    const validation = validatePayload(recipe)
+    if (validation) return NextResponse.json({ error: validation }, { status: 400 })
+
+    const created = await createRecipe(recipe)
+    return NextResponse.json({ recipe: created })
+  } catch (error) {
+    logger.error("Failed to create recipe", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to create recipe" }, { status: 500 })
+  }
+})

--- a/app/api/recipes/route.ts
+++ b/app/api/recipes/route.ts
@@ -103,6 +103,7 @@ async function buildFilteredRecipesWithSummary(role: string, userId: string, fil
   const requestedStatus = asString(filters.get("status"))
   const includeStats = filters.get("withStats") === "true"
   const includeDrafts = filters.get("includeDrafts") === "true"
+  let requestedStatusFilter: RecipeRecord["status"] | undefined
 
   let filteredStatus: RecipeRecord["status"] | RecipeRecord["status"][] | undefined
   if (requestedStatus) {
@@ -112,14 +113,15 @@ async function buildFilteredRecipesWithSummary(role: string, userId: string, fil
     if (role !== "admin" && requestedStatus !== "published") {
       return NextResponse.json({ error: "Only published recipes can be listed by residents" }, { status: 403 })
     }
+    requestedStatusFilter = requestedStatus
   }
 
   if (role === "admin") {
-    if (requestedStatus) {
-      if (includeDrafts && (requestedStatus === "published" || requestedStatus === "draft")) {
+    if (requestedStatusFilter) {
+      if (includeDrafts && (requestedStatusFilter === "published" || requestedStatusFilter === "draft")) {
         filteredStatus = ["draft", "published"]
       } else {
-        filteredStatus = requestedStatus
+        filteredStatus = requestedStatusFilter
       }
     } else if (includeDrafts) {
       filteredStatus = ["published", "draft"]

--- a/app/api/recipes/seed/route.ts
+++ b/app/api/recipes/seed/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server"
+import { withRole } from "@/lib/auth/rbac"
+import { seedSampleRecipes } from "@/lib/repositories/recipe-repository"
+import { logger } from "@/lib/logger"
+
+function asBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value
+  if (typeof value === "string") {
+    const lowered = value.trim().toLowerCase()
+    if (lowered === "true") return true
+    if (lowered === "false") return false
+  }
+  return undefined
+}
+
+export const POST = withRole("admin")(
+  async (request, context) => {
+    try {
+      const body = (await request.json().catch(() => ({}))) as { force?: boolean | string }
+      const force = asBoolean(body?.force) ?? false
+      const result = await seedSampleRecipes(context.userId, { force })
+      return NextResponse.json({ seed: result })
+    } catch (error) {
+      logger.error("Failed to seed sample recipes", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return NextResponse.json({ error: "Failed to seed sample recipes" }, { status: 500 })
+    }
+  }
+)

--- a/docs/handoffs/2026-07-24-kitchen-recipes-next.md
+++ b/docs/handoffs/2026-07-24-kitchen-recipes-next.md
@@ -1,0 +1,82 @@
+# Handoff - Kitchen recipes for Hans and Irma
+
+- **Date:** 2026-07-24
+- **Repo:** `C:\Users\smitj\repos\house-of-veritas`
+- **Production:** `https://hov.neuralliquid.ai`
+- **Status:** Next feature; no recipe implementation started.
+- **Audience:** Hans and Irma initially.
+- **Languages:** English and Afrikaans unless the product owner changes the bilingual pair.
+- **Area:** Kitchen content, meal planning, recipe presentation, open-source media
+
+## Product Goal
+
+Create a practical recipe experience for Hans and Irma. Each recipe should provide:
+
+- a clearly sourced, open-license picture;
+- bilingual title, summary, ingredients, and instructions;
+- numbered step-by-step preparation and cooking instructions;
+- ingredient quantities, units, servings, prep time, and cook time;
+- readable mobile presentation for kitchen use;
+- a useful empty state when no recipes are configured.
+
+The first screen should be the usable recipe list/detail experience, not a marketing page.
+
+## Content and Licensing Requirements
+
+- Store the image source URL, author/creator, license, attribution text, and retrieval date with every image.
+- Prefer Wikimedia Commons, Unsplash, Pexels, or another source with a clear reusable license.
+- Do not copy images without a license record or silently hotlink unstable assets.
+- Keep recipe text and image metadata separate so content can be corrected without replacing media.
+- Make attribution visible from the recipe detail view.
+
+## Suggested Data Model
+
+`Recipe` should have a stable ID, status (`draft`, `published`, `archived`), owner/audience links, image metadata, servings, prep/cook times, cuisine/category, and localized fields.
+
+Use structured arrays rather than one large text field:
+
+- `ingredients[]`: quantity, unit, ingredient name, optional preparation note, optional group/section;
+- `steps[]`: ordinal, English instruction, Afrikaans instruction, optional timer and section;
+- localized title/summary fields for `en` and `af`.
+
+Keep recipe ownership and visibility explicit. Initial visibility can be Hans and Irma only, with a future household-wide option. Do not expose private drafts through the general resident inventory or kitchen APIs.
+
+## Architecture Direction
+
+- Reuse Mystira/Auth.js session resolution and existing HOV RBAC.
+- Use the established repository boundary and existing Cosmos Mongo account for recipe records.
+- Store only image references and attribution in Cosmos; use Azure Blob Storage for any HOV-hosted image copy.
+- Add a dedicated recipe repository/API rather than extending the kitchen incident/meal-feedback route.
+- Keep recipe generation/import separate from published content. Any AI-assisted translation or drafting must remain human-reviewable before publish.
+- Preserve the existing kitchen meal-planning and feedback workflows; recipes should become a source those workflows can reference.
+
+## Recommended Delivery Order
+
+1. Inspect the current Irma meal-planning UI and existing kitchen route, then define the recipe schema and visibility rules.
+2. Add Cosmos repository and API routes for list, detail, create/edit draft, publish, and archive.
+3. Add a mobile recipe list/detail view with language toggle or paired bilingual sections, ingredient checklist, and numbered steps.
+4. Add image sourcing/import with license and attribution validation.
+5. Add Hans authoring/review controls and Irma read/use controls.
+6. Add tests for authorization, bilingual completeness, ingredient/step validation, image attribution, empty states, and mobile browser flow.
+7. Seed no demo recipes by default. Use an explicit import or controlled fixture for initial real recipes.
+
+## Acceptance Criteria
+
+- Hans can create and edit a draft recipe in both languages.
+- Hans can publish or archive a recipe.
+- Irma can view published recipes intended for her and use them comfortably on a phone.
+- A published recipe cannot omit required bilingual fields, ingredients, ordered steps, or image license metadata.
+- Every recipe image displays attributable source information.
+- Unauthorized users cannot read private drafts or modify recipes.
+- The feature works with empty Cosmos state and does not invent recipes by default.
+
+## Current HOV Closeout Context
+
+- Inventory persistence was merged in PR #123 as `e2cc6ba` and deployed successfully.
+- Production health is healthy; `MONGODB_URI` and `DB_NAME` are configured.
+- The existing kitchen endpoint handles meal feedback and cross-contamination reports; it is not a recipe repository.
+- Existing Irma dashboard meal sections are empty-state surfaces and are likely the natural entry point for published recipes.
+
+## Next Owner Action
+
+Start with schema and UI inventory, then implement the recipe repository/API as a separate PR. Before sourcing images, record the permitted source/license policy in code and tests.

--- a/lib/recipe-serving.ts
+++ b/lib/recipe-serving.ts
@@ -17,13 +17,13 @@ function asString(value: unknown): string | undefined {
   return trimmed.length ? trimmed : undefined
 }
 
-function dedupeSorted(values: string[]): string[] {
+function dedupeSorted(values: readonly string[]): string[] {
   return [...new Set(values)]
 }
 
 function collectRatingTaskResidents(
   input: unknown,
-  fallbackResidents: string[]
+  fallbackResidents: readonly string[]
 ): string[] {
   if (Array.isArray(input) && input.length > 0) {
     return dedupeSorted(

--- a/lib/recipe-serving.ts
+++ b/lib/recipe-serving.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from "crypto"
+import { toISODateString } from "@/lib/utils"
+import { createTask } from "@/lib/services/baserow"
+import {
+  getExpandedAudienceAliases,
+  RATING_RECIPE_RECIPIENTS,
+  resolveTaskRecipientPersona,
+  TASK_RECIPIENT_TO_BASEROW_ID,
+  type RecipeMealInstance,
+  type RecipeRecord,
+} from "@/lib/recipes"
+import { createRecipeMealInstance } from "@/lib/repositories/recipe-repository"
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function dedupeSorted(values: string[]): string[] {
+  return [...new Set(values)]
+}
+
+function collectRatingTaskResidents(
+  input: unknown,
+  fallbackResidents: string[]
+): string[] {
+  if (Array.isArray(input) && input.length > 0) {
+    return dedupeSorted(
+      input
+        .map((value) => asString(value)?.toLowerCase())
+        .filter((value): value is string => !!value)
+    )
+  }
+
+  return dedupeSorted((fallbackResidents ?? []).map((value) => value.toLowerCase()))
+}
+
+function resolveResidentPersonas(residentUserIds: string[]): string[] {
+  return dedupeSorted(
+    residentUserIds
+      .map((residentUserId) => resolveTaskRecipientPersona(residentUserId))
+      .filter((persona): persona is string => Boolean(persona))
+  )
+}
+
+export interface CreateMealFromRecipeInput {
+  recipe: RecipeRecord
+  mealName?: string
+  residentUserIds?: unknown
+  servedBy?: string
+  createRatingTasks?: boolean
+}
+
+export interface CreateMealFromRecipeResult {
+  mealInstance: RecipeMealInstance
+}
+
+export async function createMealFromRecipe(
+  input: CreateMealFromRecipeInput
+): Promise<CreateMealFromRecipeResult> {
+  const now = new Date().toISOString()
+  const mealInstanceId = `meal-${randomUUID()}`
+  const createRatingTasks = input.createRatingTasks !== false
+  const requestedResidents = collectRatingTaskResidents(
+    input.residentUserIds,
+    input.recipe.audienceUserIds.length > 0 ? input.recipe.audienceUserIds : RATING_RECIPE_RECIPIENTS
+  )
+
+  const residentPersonas = dedupeSorted(
+    requestedResidents.flatMap((residentUserId) => getExpandedAudienceAliases(residentUserId))
+  )
+  const residentUserIds = resolveResidentPersonas(residentPersonas)
+
+  if (residentUserIds.length === 0) {
+    throw new Error("No valid resident recipients were provided or configured for this recipe")
+  }
+
+  const ratingTaskIds: number[] = []
+  const ratingTaskAssignments: Array<{ residentUserId: string; taskId: number }> = []
+
+  if (createRatingTasks) {
+    for (const persona of residentUserIds) {
+      const assignedTo = TASK_RECIPIENT_TO_BASEROW_ID[persona]
+      if (!assignedTo) continue
+
+      const task = await createTask({
+        title: `Rate meal: ${input.recipe.titleEn}`,
+        description:
+          `Meal rating needed for ${input.mealName ?? input.recipe.titleEn}\n` +
+          `Recipe ID: ${input.recipe.id}\n` +
+          `Meal Instance ID: ${mealInstanceId}\n` +
+          `Meal name: ${input.mealName ?? ""}\n` +
+          `Resident: ${persona}\n` +
+          `Served by: ${input.servedBy}\n` +
+          `Please submit rating (1-5) via the meal rating endpoint.\n`,
+        assignedTo,
+        dueDate: toISODateString(),
+        priority: "Medium",
+        status: "Not Started",
+        project: "Kitchen",
+      })
+
+      if (task?.id) {
+        ratingTaskIds.push(task.id)
+        ratingTaskAssignments.push({ residentUserId: persona, taskId: task.id })
+      }
+    }
+  }
+
+  const meal = await createRecipeMealInstance({
+    id: mealInstanceId,
+    recipeId: input.recipe.id,
+    recipeTitleEn: input.recipe.titleEn,
+    recipeTitleAf: input.recipe.titleAf,
+    mealName: asString(input.mealName),
+    residentUserIds,
+    servedBy: asString(input.servedBy),
+    servedAt: now,
+    ratingTaskIds,
+    ratingTaskAssignments,
+    createdBy: input.servedBy ?? "system",
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  return { mealInstance: meal }
+}

--- a/lib/recipes.ts
+++ b/lib/recipes.ts
@@ -1,0 +1,354 @@
+export type RecipeStatus = "draft" | "published" | "archived"
+
+export interface RecipeIngredient {
+  id: string
+  quantity?: string | number
+  unit?: string
+  name: string
+  preparationNote?: string
+  section?: string
+}
+
+export interface RecipeStep {
+  id: string
+  order: number
+  instructionEn: string
+  instructionAf: string
+  timerMinutes?: number
+  section?: string
+}
+
+export interface RecipeImageMetadata {
+  url: string
+  source: string
+  author?: string
+  license: string
+  attributionText: string
+  retrievedAt: string
+}
+
+export interface RecipeRecord {
+  id: string
+  status: RecipeStatus
+  ownerUserId: string
+  audienceUserIds: string[]
+  titleEn: string
+  summaryEn?: string
+  titleAf: string
+  summaryAf?: string
+  servings?: number
+  prepMinutes?: number
+  cookMinutes?: number
+  cuisine?: string
+  category?: string
+  image: RecipeImageMetadata
+  ingredients: RecipeIngredient[]
+  steps: RecipeStep[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface RecipeMealInstance {
+  id: string
+  recipeId: string
+  recipeTitleEn: string
+  recipeTitleAf: string
+  mealName?: string
+  residentUserIds: string[]
+  servedBy?: string
+  servedAt: string
+  ratingTaskIds: number[]
+  ratingTaskAssignments?: Array<{
+    residentUserId: string
+    taskId: number
+  }>
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface RecipeRating {
+  id: string
+  recipeId: string
+  mealInstanceId: string
+  residentUserId: string
+  score: 1 | 2 | 3 | 4 | 5
+  comment?: string
+  taskId?: number
+  submittedBy: string
+  submittedAt: string
+}
+
+export interface RecipeRatingSummary {
+  recipeId: string
+  averageScore: number
+  totalRatings: number
+  totalMeals: number
+}
+
+export interface RecipeCreatePayload {
+  status?: RecipeStatus
+  audienceUserIds?: string[]
+  titleEn: string
+  summaryEn?: string
+  titleAf: string
+  summaryAf?: string
+  servings?: number
+  prepMinutes?: number
+  cookMinutes?: number
+  cuisine?: string
+  category?: string
+  image: RecipeImageMetadata
+  ingredients: Array<{
+    id?: string
+    quantity?: string | number
+    unit?: string
+    name: string
+    preparationNote?: string
+    section?: string
+  }>
+  steps: Array<{
+    id?: string
+    order?: number
+    instructionEn: string
+    instructionAf: string
+    timerMinutes?: number
+    section?: string
+  }>
+}
+
+export const KNOWN_RECIPE_STATUSES: RecipeStatus[] = ["draft", "published", "archived"]
+export const DEFAULT_RECIPE_AUDIENCE_IDS = ["hans", "irma"]
+export const RATING_RECIPE_RECIPIENTS = ["hans", "irma"] as const
+
+export const TASK_RECIPIENT_TO_BASEROW_ID: Record<string, number> = {
+  hans: 1,
+  charl: 2,
+  lucky: 3,
+  irma: 4,
+}
+
+export const RESIDENT_AUDIENCE_HINTS: Record<string, string[]> = {
+  hans: ["hans", "demo-user-1"],
+  charl: ["charl", "demo-user-2"],
+  irma: ["irma", "demo-user-3"],
+  lucky: ["lucky", "demo-user-4"],
+}
+
+export function getExpandedAudienceAliases(userId: string): string[] {
+  const normalizedUserId = userId.toLowerCase().trim()
+  const matchedPersona = Object.entries(RESIDENT_AUDIENCE_HINTS).find(([, aliases]) =>
+    aliases.map((alias) => alias.toLowerCase()).includes(normalizedUserId)
+  )
+
+  if (!matchedPersona) return [normalizedUserId]
+
+  const [persona, aliases] = matchedPersona
+  return [normalizedUserId, persona, ...aliases.map((alias) => alias.toLowerCase())]
+}
+
+export function isRecipeAudienceMatch(audienceUserIds: string[], userId: string): boolean {
+  const candidateIds = getExpandedAudienceAliases(userId)
+  const normalizedAudience = audienceUserIds.map((value) => value.toLowerCase().trim())
+  return normalizedAudience.length === 0 || normalizedAudience.some((value) => candidateIds.includes(value))
+}
+
+export function normalizeRecipeAudienceUserIds(audienceUserIds: unknown): string[] {
+  if (!Array.isArray(audienceUserIds) || audienceUserIds.length === 0) {
+    return [...DEFAULT_RECIPE_AUDIENCE_IDS]
+  }
+
+  return [
+    ...new Set(
+      audienceUserIds
+        .map((value) => String(value).trim().toLowerCase())
+        .filter((value) => value.length > 0)
+    ),
+  ]
+}
+
+export function resolveTaskRecipientPersona(userId: string): string | undefined {
+  const normalizedUserId = userId.toLowerCase().trim()
+  if (Object.keys(TASK_RECIPIENT_TO_BASEROW_ID).includes(normalizedUserId)) return normalizedUserId
+
+  const match = Object.entries(RESIDENT_AUDIENCE_HINTS).find(([, aliases]) =>
+    aliases.map((alias) => alias.toLowerCase()).includes(normalizedUserId)
+  )
+  return match?.[0]
+}
+
+export const SAMPLE_RECIPES: RecipeCreatePayload[] = [
+  {
+    status: "draft",
+    audienceUserIds: ["hans", "irma"],
+    titleEn: "Mushroom & Egg Fried Rice (Budget-Friendly)",
+    summaryEn:
+      "A fast, filling fried rice with mushrooms and eggs that works with simple pantry staples.",
+    titleAf: "Swam- en eierbrasnoedels (begroting)",
+    summaryAf:
+      "'n Vinnige, bevredigende fried rice met sampioene en eiers wat goed werk met eenvoudige kombuisbestellings.",
+    servings: 4,
+    prepMinutes: 10,
+    cookMinutes: 20,
+    cuisine: "Family",
+    category: "Main",
+    image: {
+      url: "https://upload.wikimedia.org/wikipedia/commons/6/6f/Chinese_fried_rice_1.jpg",
+      source: "Wikimedia Commons",
+      author: "Commons Contributor",
+      license: "CC BY-SA 4.0",
+      attributionText: "Image sourced from Wikimedia Commons",
+      retrievedAt: "2026-07-24",
+    },
+    ingredients: [
+      { name: "Uncooked rice", quantity: "2", unit: "cups" },
+      { name: "Mushrooms", quantity: "250", unit: "g" },
+      { name: "Onions", quantity: "2", unit: "large, diced" },
+      { name: "Eggs", quantity: 6 },
+      { name: "Garlic", quantity: "3-4", unit: "cloves, minced" },
+      { name: "Cooking oil", quantity: "3-4", unit: "tablespoons" },
+      { name: "Salt", quantity: "to taste" },
+      { name: "Black pepper", quantity: "to taste" },
+      { name: "Paprika", quantity: "to taste (optional)" },
+      { name: "Curry powder", quantity: "to taste (optional)" },
+      { name: "Soy sauce", quantity: "1-2", unit: "tablespoons (optional)" },
+    ],
+    steps: [
+      {
+        order: 1,
+        instructionEn:
+          "Cook the rice according to the package instructions. For the best fried rice, spread it out to cool completely or refrigerate overnight.",
+        instructionAf:
+          "Kook die rys volgens die pakketinstruksies. Vir die beste fried rice, versprei dit uit om heeltemal af te koel of sit dit oornag in die yskas.",
+      },
+      {
+        order: 2,
+        instructionEn: "Beat the eggs with a pinch of salt. Fry as a soft scramble and set aside.",
+        instructionAf: "Klop die eiers met 'n knippie sout. Braai dit as 'n sagte scramble en sit dit op die kant.",
+      },
+      {
+        order: 3,
+        instructionEn:
+          "Brown onions for 5 to 8 minutes. Add mushrooms and cook until their moisture has evaporated and they develop a brown colour.",
+        instructionAf:
+          "Braai die uie vir 5 tot 8 minute tot goudbruin. Voeg dan sampioene by en kook dit tot die vog verdamp en dit mooi bruin kleur kry.",
+      },
+      {
+        order: 4,
+        instructionEn: "Add garlic and cook another 30 seconds.",
+        instructionAf: "Voeg knoffel by en kook nog 30 sekondes.",
+      },
+      {
+        order: 5,
+        instructionEn:
+          "Add cooled rice. Break up clumps and fry for 4 to 5 minutes until heated through and lightly crisp.",
+        instructionAf:
+          "Voeg die afgekoelde rys by. Breek klonte uitmekaar en braai vir 4 tot 5 minute totdat dit warm is en effens bros word.",
+      },
+      {
+        order: 6,
+        instructionEn:
+          "Season with salt, black pepper, optional paprika, optional curry powder, and optional soy sauce. Return scrambled eggs and fold gently through.",
+        instructionAf:
+          "Sout, swartpeper, opsionele paprika, opsionele kerriepoeier en opsionele sojasous by. Voeg die scramble daarna weer by en vou dit versigtig in.",
+      },
+    ],
+  },
+  {
+    status: "draft",
+    audienceUserIds: ["hans", "irma"],
+    titleEn: "Sampioen-, Spek- en Uie-Sous vir Mieliepap",
+    summaryEn:
+      "A rich mushroom sauce with bacon and onions that scales well for serving with mieliepap.",
+    titleAf: "Sampioen-, Spek- en Uie-Sous vir Mieliepap",
+    summaryAf:
+      "'n Ryk sampioen- en speksous met uie en knoffel vir mieliepap met eenvoudige begrotingsaanpassings.",
+    servings: 4,
+    prepMinutes: 10,
+    cookMinutes: 20,
+    cuisine: "Family",
+    category: "Sauce",
+    image: {
+      url: "https://upload.wikimedia.org/wikipedia/commons/8/8b/Mushroom_sauce.jpg",
+      source: "Wikimedia Commons",
+      author: "Commons Contributor",
+      license: "CC BY-SA 4.0",
+      attributionText: "Image sourced from Wikimedia Commons",
+      retrievedAt: "2026-07-24",
+    },
+    ingredients: [
+      { name: "Fresh mushrooms", quantity: "200", unit: "g, sliced" },
+      { name: "Onion", quantity: 1, unit: "large, sliced" },
+      { name: "Bacon or bacon bits", quantity: "50-100", unit: "g" },
+      { name: "Garlic", quantity: 2, unit: "cloves, finely chopped" },
+      { name: "Flour", quantity: 1, unit: "tablespoon" },
+      { name: "Beef or chicken stock", quantity: "1 to 1.5", unit: "cups" },
+      { name: "Soy sauce", quantity: 1, unit: "teaspoon" },
+      { name: "Worcestershire sauce", quantity: 1, unit: "teaspoon" },
+      { name: "Smoked paprika", quantity: 1, unit: "teaspoon" },
+      { name: "Salt", quantity: "to taste" },
+      { name: "Black pepper", quantity: "to taste" },
+      { name: "Marmite or Bovril", quantity: 1, unit: "teaspoon (optional)" },
+      { name: "Peas", quantity: "1/2 cup (optional)" },
+      { name: "Spinach", quantity: "1 cup (optional)" },
+    ],
+    steps: [
+      {
+        order: 1,
+        instructionEn: "Heat a large pan over medium heat and fry the bacon until lightly crispy.",
+        instructionAf:
+          "Verhit 'n groot pan oor medium hitte en braai die spek totdat dit liggies bros is.",
+      },
+      {
+        order: 2,
+        instructionEn: "Remove the bacon and keep it; reserve the rendered bacon fat in the pan.",
+        instructionAf:
+          "Verwyder die spek en hou dit eenkant. Laat die spekvet vir die pan oor.",
+      },
+      {
+        order: 3,
+        instructionEn:
+          "Add onion and slowly braise for 10 to 15 minutes until golden and lightly caramelised.",
+        instructionAf:
+          "Voeg die ui by en braai stadig vir 10 tot 15 minute tot dit goudbruin en effens gekaramelliseer is.",
+      },
+      {
+        order: 4,
+        instructionEn:
+          "Add mushrooms and cook until the moisture has evaporated and they begin to brown well.",
+        instructionAf:
+          "Voeg die sampioene by en braai dit totdat die vloeistof verdamp en dit begin bruin.",
+      },
+      {
+        order: 5,
+        instructionEn: "Add garlic and cook for 30 seconds.",
+        instructionAf: "Voeg knoffel by en kook vir omtrent 30 sekondes.",
+      },
+      {
+        order: 6,
+        instructionEn: "Stir in flour and cook for about 1 minute.",
+        instructionAf: "Roer die meel in en laat vir omtrent 1 minuut gaar word.",
+      },
+      {
+        order: 7,
+        instructionEn:
+          "Slowly add stock while stirring to avoid clumps. Return bacon and simmer 5 to 10 minutes on low heat.",
+        instructionAf:
+          "Giet die aftreksel stadig by terwyl jy roer om klonte te voorkom. Plaas die spek terug en laat prut vir 5 tot 10 minute.",
+      },
+      {
+        order: 8,
+        instructionEn:
+          "Add soy sauce, Worcestershire sauce, optional Marmite/Bovril. Adjust salt and flavour at the end.",
+        instructionAf:
+          "Voeg sojasous, Worcestersaus en, indien gebruik, Marmite/Bovril by. Pas sout en geur aan om laaste.",
+      },
+      {
+        order: 9,
+        instructionEn: "Optionally fold in peas or spinach for extra nutrition. Serve with mieliepap.",
+        instructionAf:
+          "Opsioneel: voeg ertjies of spinasie by vir meer voeding. Bedien saam met mieliepap.",
+      },
+    ],
+  },
+]

--- a/lib/repositories/recipe-repository.ts
+++ b/lib/repositories/recipe-repository.ts
@@ -1,0 +1,507 @@
+import { mkdir, readFile, writeFile } from "fs/promises"
+import { dirname, join } from "path"
+import type { Filter } from "mongodb"
+import { getCollection, isMongoConfigured, withoutMongoId } from "@/lib/db/mongodb"
+import { randomUUID } from "crypto"
+import {
+  DEFAULT_RECIPE_AUDIENCE_IDS,
+  normalizeRecipeAudienceUserIds,
+  RecipeMealInstance,
+  RecipeRating,
+  RecipeRecord,
+  RecipeRatingSummary,
+  RecipeStatus,
+  SAMPLE_RECIPES,
+  type RecipeCreatePayload,
+} from "@/lib/recipes"
+
+const RECIPES_FILE = join(process.cwd(), "data", "recipes.json")
+const RECIPE_MEAL_INSTANCES_FILE = join(process.cwd(), "data", "recipe-meal-instances.json")
+const RECIPE_RATINGS_FILE = join(process.cwd(), "data", "recipe-ratings.json")
+
+const RECIPES_COLLECTION = "recipes"
+const RECIPE_MEAL_INSTANCES_COLLECTION = "recipe_meal_instances"
+const RECIPE_RATINGS_COLLECTION = "recipe_ratings"
+
+type RecipeDocument = RecipeRecord & { _id?: unknown }
+type RecipeMealInstanceDocument = RecipeMealInstance & { _id?: unknown }
+type RecipeRatingDocument = RecipeRating & { _id?: unknown }
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function asNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined
+  if (!Number.isInteger(value) || value < 0) return undefined
+  return value
+}
+
+export interface SeedSampleRecipesResult {
+  inserted: number
+  skipped: number
+  existingCount: number
+  recipeIds: string[]
+  forced: boolean
+}
+
+function buildSeedRecipeRecord(payload: RecipeCreatePayload, ownerUserId: string, now: string): RecipeRecord {
+  const recipeId = `recipe-${randomUUID()}`
+  const audienceUserIds = normalizeRecipeAudienceUserIds(payload.audienceUserIds ?? [])
+  const normalizedImage = payload.image
+
+  const ingredients = (Array.isArray(payload.ingredients) ? payload.ingredients : [])
+    .filter((ingredient) => asString((ingredient as { name?: unknown }).name))
+    .map((ingredient, index) => ({
+      id: asString((ingredient as { id?: unknown }).id) ?? `ing-${recipeId}-${index + 1}`,
+      quantity: ingredient.quantity,
+      unit: asString((ingredient as { unit?: unknown })),
+      name: asString((ingredient as { name?: unknown }).name) as string,
+      preparationNote: asString((ingredient as { preparationNote?: unknown })),
+      section: asString((ingredient as { section?: unknown })),
+    }))
+
+  const steps = (Array.isArray(payload.steps) ? payload.steps : [])
+    .map((step, index) => ({
+      id: asString((step as { id?: unknown }).id) ?? `step-${recipeId}-${index + 1}`,
+      order: asNonNegativeInt((step as { order?: unknown }).order) || index + 1,
+      instructionEn: asString((step as { instructionEn?: unknown }).instructionEn) ?? "",
+      instructionAf: asString((step as { instructionAf?: unknown }).instructionAf) ?? "",
+      timerMinutes: asNonNegativeInt((step as { timerMinutes?: unknown })),
+      section: asString((step as { section?: unknown })),
+    }))
+
+  return {
+    id: recipeId,
+    status: payload.status || "draft",
+    ownerUserId,
+    audienceUserIds,
+    titleEn: asString(payload.titleEn) ?? "",
+    summaryEn: asString(payload.summaryEn),
+    titleAf: asString(payload.titleAf) ?? "",
+    summaryAf: asString(payload.summaryAf),
+    servings: asNonNegativeInt(payload.servings),
+    prepMinutes: asNonNegativeInt(payload.prepMinutes),
+    cookMinutes: asNonNegativeInt(payload.cookMinutes),
+    cuisine: asString(payload.cuisine),
+    category: asString(payload.category),
+    image: {
+      url: asString(normalizedImage?.url) ?? "",
+      source: asString(normalizedImage?.source) ?? "Unknown",
+      author: asString(normalizedImage?.author),
+      license: asString(normalizedImage?.license) ?? "Unknown",
+      attributionText: asString(normalizedImage?.attributionText) ?? "Unknown",
+      retrievedAt: asString(normalizedImage?.retrievedAt) ?? now.slice(0, 10),
+    },
+    ingredients,
+    steps,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function requireProductionStore(): void {
+  if (process.env.NODE_ENV === "production" && process.env.CI !== "true" && !isMongoConfigured()) {
+    throw new Error("Recipe datastore is not configured. Set MONGODB_URI for production.")
+  }
+}
+
+function useMemoryStore(): boolean {
+  return process.env.E2E_TEST === "1" || process.env.CI === "true" || !isMongoConfigured()
+}
+
+async function readJsonList<T>(filePath: string): Promise<T[]> {
+  try {
+    const data = await readFile(filePath, "utf-8")
+    const parsed = JSON.parse(data)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+async function writeJsonList<T>(filePath: string, data: T[]): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(filePath, JSON.stringify(data, null, 2), "utf-8")
+}
+
+async function readRecipes(): Promise<RecipeRecord[]> {
+  return readJsonList<RecipeRecord>(RECIPES_FILE)
+}
+
+async function writeRecipes(recipes: RecipeRecord[]): Promise<void> {
+  await writeJsonList(RECIPES_FILE, recipes)
+}
+
+async function readMealInstances(): Promise<RecipeMealInstance[]> {
+  return readJsonList<RecipeMealInstance>(RECIPE_MEAL_INSTANCES_FILE)
+}
+
+async function writeMealInstances(instances: RecipeMealInstance[]): Promise<void> {
+  await writeJsonList(RECIPE_MEAL_INSTANCES_FILE, instances)
+}
+
+async function readRatings(): Promise<RecipeRating[]> {
+  return readJsonList<RecipeRating>(RECIPE_RATINGS_FILE)
+}
+
+async function writeRatings(ratings: RecipeRating[]): Promise<void> {
+  await writeJsonList(RECIPE_RATINGS_FILE, ratings)
+}
+
+function sortByCreatedAtDescending<T extends { createdAt: string }>(items: T[]): T[] {
+  return [...items].sort((left, right) => {
+    return new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime()
+  })
+}
+
+function sortByServedAtDescending<T extends { servedAt: string }>(items: T[]): T[] {
+  return [...items].sort((left, right) => {
+    return new Date(right.servedAt).getTime() - new Date(left.servedAt).getTime()
+  })
+}
+
+function sortBySubmittedAtDescending<T extends { submittedAt: string }>(items: T[]): T[] {
+  return [...items].sort((left, right) => {
+    return new Date(right.submittedAt).getTime() - new Date(left.submittedAt).getTime()
+  })
+}
+
+export interface RecipeListFilter {
+  status?: RecipeStatus | RecipeStatus[]
+  ownerUserId?: string
+  audienceUserIds?: string[]
+}
+
+function filterRecipesInMemory(recipes: RecipeRecord[], filters?: RecipeListFilter): RecipeRecord[] {
+  let results = [...recipes]
+  if (!filters) return results
+
+  if (filters.status) {
+    const statuses = Array.isArray(filters.status) ? filters.status : [filters.status]
+    results = results.filter((recipe) => statuses.includes(recipe.status))
+  }
+
+  if (filters.ownerUserId) {
+    const requestedOwnerId = filters.ownerUserId.toLowerCase()
+    results = results.filter((recipe) => recipe.ownerUserId.toLowerCase() === requestedOwnerId)
+  }
+
+  if (filters.audienceUserIds && filters.audienceUserIds.length > 0) {
+    const audienceLookup = new Set(filters.audienceUserIds.map((value) => value.toLowerCase().trim()))
+    results = results.filter((recipe) =>
+      recipe.audienceUserIds.some((userId) => audienceLookup.has(userId.toLowerCase().trim()))
+    )
+  }
+
+  return results
+}
+
+export async function listRecipes(filters?: RecipeListFilter): Promise<RecipeRecord[]> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    const items = await readRecipes()
+    return sortByCreatedAtDescending(filterRecipesInMemory(items, filters))
+  }
+
+  const collection = await getCollection<RecipeDocument>(RECIPES_COLLECTION)
+  const mongoFilter: Record<string, unknown> = {}
+
+  if (filters?.status) {
+    mongoFilter.status = Array.isArray(filters.status) ? { $in: filters.status } : filters.status
+  }
+
+  if (filters?.ownerUserId) {
+    mongoFilter.ownerUserId = filters.ownerUserId.toLowerCase()
+  }
+
+  if (filters?.audienceUserIds?.length) {
+    mongoFilter.audienceUserIds = {
+      $in: filters.audienceUserIds.map((value) => value.toLowerCase().trim()),
+    }
+  }
+
+  const recipes = await collection.find(mongoFilter).sort({ createdAt: -1 }).toArray()
+  return recipes.map((recipe) => withoutMongoId(recipe))
+}
+
+export async function countRecipes(): Promise<number> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    const recipes = await readRecipes()
+    return recipes.length
+  }
+
+  const collection = await getCollection<RecipeDocument>(RECIPES_COLLECTION)
+  return collection.countDocuments({})
+}
+
+export async function getRecipeById(id: string): Promise<RecipeRecord | null> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    const recipes = await readRecipes()
+    return recipes.find((item) => item.id === id) ?? null
+  }
+
+  const collection = await getCollection<RecipeDocument>(RECIPES_COLLECTION)
+  const recipe = await collection.findOne({ id } as Filter<RecipeDocument>)
+  if (!recipe) return null
+  return withoutMongoId(recipe)
+}
+
+export async function seedSampleRecipes(
+  ownerUserId: string,
+  options?: { force?: boolean }
+): Promise<SeedSampleRecipesResult> {
+  requireProductionStore()
+  const force = options?.force === true
+  const seededBy = (ownerUserId || "system").toLowerCase()
+  const effectiveOwner = seededBy || "system"
+
+  const existingCount = await countRecipes()
+  if (existingCount > 0 && !force) {
+    return {
+      inserted: 0,
+      skipped: SAMPLE_RECIPES.length,
+      existingCount,
+      recipeIds: [],
+      forced: false,
+    }
+  }
+
+  const now = new Date().toISOString()
+  const recipeIds: string[] = []
+
+  for (const recipePayload of SAMPLE_RECIPES) {
+    const record = buildSeedRecipeRecord(recipePayload, effectiveOwner, now)
+    if (record.audienceUserIds.length === 0) {
+      record.audienceUserIds = [...DEFAULT_RECIPE_AUDIENCE_IDS]
+    }
+
+    const created = await createRecipe(record)
+    recipeIds.push(created.id)
+  }
+
+  return {
+    inserted: recipeIds.length,
+    skipped: 0,
+    existingCount,
+    recipeIds,
+    forced: force,
+  }
+}
+
+export async function createRecipe(data: RecipeRecord): Promise<RecipeRecord> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    const recipes = await readRecipes()
+    const stored: RecipeRecord = {
+      ...data,
+      id: data.id || `recipe-${randomUUID()}`,
+      createdAt: data.createdAt || new Date().toISOString(),
+      updatedAt: data.updatedAt || new Date().toISOString(),
+    }
+    recipes.push(stored)
+    await writeRecipes(recipes)
+    return stored
+  }
+
+  const collection = await getCollection<RecipeDocument>(RECIPES_COLLECTION)
+  await collection.insertOne(data)
+  return data
+}
+
+export async function replaceRecipe(updated: RecipeRecord): Promise<RecipeRecord | null> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    const recipes = await readRecipes()
+    const index = recipes.findIndex((recipe) => recipe.id === updated.id)
+    if (index === -1) return null
+    recipes[index] = { ...updated, updatedAt: new Date().toISOString() }
+    await writeRecipes(recipes)
+    return recipes[index]
+  }
+
+  const collection = await getCollection<RecipeDocument>(RECIPES_COLLECTION)
+  const updatedRecord = { ...updated, updatedAt: new Date().toISOString() }
+  const result = await collection.replaceOne(
+    { id: updated.id } as Filter<RecipeDocument>,
+    updatedRecord as RecipeDocument
+  )
+  if (result.matchedCount === 0) return null
+  return updatedRecord
+}
+
+export async function listRecipeMealInstances(recipeId: string): Promise<RecipeMealInstance[]> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    const instances = await readMealInstances()
+    return sortByServedAtDescending(instances.filter((instance) => instance.recipeId === recipeId))
+  }
+
+  const collection = await getCollection<RecipeMealInstanceDocument>(RECIPE_MEAL_INSTANCES_COLLECTION)
+  const instances = await collection.find({ recipeId }).sort({ servedAt: -1 }).toArray()
+  return instances.map((instance) => withoutMongoId(instance))
+}
+
+export async function getRecipeMealInstanceById(id: string): Promise<RecipeMealInstance | null> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    const instances = await readMealInstances()
+    return instances.find((instance) => instance.id === id) ?? null
+  }
+
+  const collection = await getCollection<RecipeMealInstanceDocument>(RECIPE_MEAL_INSTANCES_COLLECTION)
+  const instance = await collection.findOne({ id } as Filter<RecipeMealInstanceDocument>)
+  if (!instance) return null
+  return withoutMongoId(instance)
+}
+
+export async function createRecipeMealInstance(
+  meal: RecipeMealInstance
+): Promise<RecipeMealInstance> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    const instances = await readMealInstances()
+    const now = new Date().toISOString()
+    const stored: RecipeMealInstance = {
+      ...meal,
+      id: meal.id || `meal-${randomUUID()}`,
+      servedAt: meal.servedAt || now,
+      createdAt: meal.createdAt || now,
+      updatedAt: meal.updatedAt || now,
+    }
+    instances.push(stored)
+    await writeMealInstances(instances)
+    return stored
+  }
+
+  const collection = await getCollection<RecipeMealInstanceDocument>(
+    RECIPE_MEAL_INSTANCES_COLLECTION
+  )
+  await collection.insertOne(meal)
+  return meal
+}
+
+export async function listRecipeRatings(recipeId: string): Promise<RecipeRating[]> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    return sortBySubmittedAtDescending(
+      (await readRatings()).filter((rating) => rating.recipeId === recipeId)
+    )
+  }
+
+  const collection = await getCollection<RecipeRatingDocument>(RECIPE_RATINGS_COLLECTION)
+  const ratings = await collection.find({ recipeId }).sort({ submittedAt: -1 }).toArray()
+  return ratings.map((rating) => withoutMongoId(rating))
+}
+
+export async function getRecipeRating(
+  recipeId: string,
+  mealInstanceId: string,
+  residentUserId: string
+): Promise<RecipeRating | null> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    return (
+      (await readRatings()).find(
+        (rating) =>
+          rating.recipeId === recipeId &&
+          rating.mealInstanceId === mealInstanceId &&
+          rating.residentUserId.toLowerCase() === residentUserId.toLowerCase()
+      ) ?? null
+    )
+  }
+
+  const collection = await getCollection<RecipeRatingDocument>(RECIPE_RATINGS_COLLECTION)
+  const record = await collection.findOne({
+    recipeId,
+    mealInstanceId,
+    residentUserId,
+  } as Filter<RecipeRatingDocument>)
+  if (!record) return null
+  return withoutMongoId(record)
+}
+
+export async function upsertRecipeRating(rating: RecipeRating): Promise<RecipeRating> {
+  requireProductionStore()
+  if (useMemoryStore()) {
+    const ratings = await readRatings()
+    const now = new Date().toISOString()
+    const normalized: RecipeRating = {
+      ...rating,
+      id: rating.id || `rating-${randomUUID()}`,
+      submittedAt: now,
+    }
+    const index = ratings.findIndex(
+      (record) =>
+        record.recipeId === rating.recipeId &&
+        record.mealInstanceId === rating.mealInstanceId &&
+        record.residentUserId.toLowerCase() === rating.residentUserId.toLowerCase()
+    )
+    if (index >= 0) {
+      ratings[index] = normalized
+    } else {
+      ratings.push(normalized)
+    }
+    await writeRatings(ratings)
+    return normalized
+  }
+
+  const collection = await getCollection<RecipeRatingDocument>(RECIPE_RATINGS_COLLECTION)
+  const now = new Date().toISOString()
+  const document: RecipeRatingDocument = {
+    ...rating,
+    id: rating.id || `rating-${randomUUID()}`,
+    submittedAt: now,
+  }
+
+  const filter = {
+    recipeId: rating.recipeId,
+    mealInstanceId: rating.mealInstanceId,
+    residentUserId: rating.residentUserId,
+  }
+
+  const existing = await collection.findOne(filter as Filter<RecipeRatingDocument>)
+  if (existing) {
+    await collection.replaceOne(filter as Filter<RecipeRatingDocument>, document)
+    return withoutMongoId(document as RecipeRatingDocument)
+  }
+
+  await collection.insertOne(document)
+  return withoutMongoId(document)
+}
+
+export async function getRecipeRatingSummary(recipeId: string): Promise<RecipeRatingSummary> {
+  const ratings = await listRecipeRatings(recipeId)
+  const mealInstances = await listRecipeMealInstances(recipeId)
+  if (ratings.length === 0) {
+    return {
+      recipeId,
+      averageScore: 0,
+      totalRatings: 0,
+      totalMeals: mealInstances.length,
+    }
+  }
+
+  const scoreTotal = ratings.reduce((sum, rating) => sum + rating.score, 0)
+  return {
+    recipeId,
+    averageScore: Number((scoreTotal / ratings.length).toFixed(2)),
+    totalRatings: ratings.length,
+    totalMeals: mealInstances.length,
+  }
+}
+
+export async function getRecipeRatingSummaries(
+  recipeIds: string[]
+): Promise<Record<string, RecipeRatingSummary>> {
+  const uniqueRecipeIds = [...new Set(recipeIds)]
+  const summary = await Promise.all(uniqueRecipeIds.map((recipeId) => getRecipeRatingSummary(recipeId)))
+  return summary.reduce<Record<string, RecipeRatingSummary>>((acc, item) => {
+    acc[item.recipeId] = item
+    return acc
+  }, {})
+}

--- a/lib/repositories/recipe-repository.ts
+++ b/lib/repositories/recipe-repository.ts
@@ -108,7 +108,7 @@ function requireProductionStore(): void {
   }
 }
 
-function useMemoryStore(): boolean {
+function isUsingMemoryStore(): boolean {
   return process.env.E2E_TEST === "1" || process.env.CI === "true" || !isMongoConfigured()
 }
 
@@ -201,7 +201,7 @@ function filterRecipesInMemory(recipes: RecipeRecord[], filters?: RecipeListFilt
 
 export async function listRecipes(filters?: RecipeListFilter): Promise<RecipeRecord[]> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     const items = await readRecipes()
     return sortByCreatedAtDescending(filterRecipesInMemory(items, filters))
   }
@@ -229,7 +229,7 @@ export async function listRecipes(filters?: RecipeListFilter): Promise<RecipeRec
 
 export async function countRecipes(): Promise<number> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     const recipes = await readRecipes()
     return recipes.length
   }
@@ -240,7 +240,7 @@ export async function countRecipes(): Promise<number> {
 
 export async function getRecipeById(id: string): Promise<RecipeRecord | null> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     const recipes = await readRecipes()
     return recipes.find((item) => item.id === id) ?? null
   }
@@ -295,7 +295,7 @@ export async function seedSampleRecipes(
 
 export async function createRecipe(data: RecipeRecord): Promise<RecipeRecord> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     const recipes = await readRecipes()
     const stored: RecipeRecord = {
       ...data,
@@ -315,7 +315,7 @@ export async function createRecipe(data: RecipeRecord): Promise<RecipeRecord> {
 
 export async function replaceRecipe(updated: RecipeRecord): Promise<RecipeRecord | null> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     const recipes = await readRecipes()
     const index = recipes.findIndex((recipe) => recipe.id === updated.id)
     if (index === -1) return null
@@ -336,7 +336,7 @@ export async function replaceRecipe(updated: RecipeRecord): Promise<RecipeRecord
 
 export async function listRecipeMealInstances(recipeId: string): Promise<RecipeMealInstance[]> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     const instances = await readMealInstances()
     return sortByServedAtDescending(instances.filter((instance) => instance.recipeId === recipeId))
   }
@@ -348,7 +348,7 @@ export async function listRecipeMealInstances(recipeId: string): Promise<RecipeM
 
 export async function getRecipeMealInstanceById(id: string): Promise<RecipeMealInstance | null> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     const instances = await readMealInstances()
     return instances.find((instance) => instance.id === id) ?? null
   }
@@ -363,7 +363,7 @@ export async function createRecipeMealInstance(
   meal: RecipeMealInstance
 ): Promise<RecipeMealInstance> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     const instances = await readMealInstances()
     const now = new Date().toISOString()
     const stored: RecipeMealInstance = {
@@ -387,7 +387,7 @@ export async function createRecipeMealInstance(
 
 export async function listRecipeRatings(recipeId: string): Promise<RecipeRating[]> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     return sortBySubmittedAtDescending(
       (await readRatings()).filter((rating) => rating.recipeId === recipeId)
     )
@@ -404,7 +404,7 @@ export async function getRecipeRating(
   residentUserId: string
 ): Promise<RecipeRating | null> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     return (
       (await readRatings()).find(
         (rating) =>
@@ -427,7 +427,7 @@ export async function getRecipeRating(
 
 export async function upsertRecipeRating(rating: RecipeRating): Promise<RecipeRating> {
   requireProductionStore()
-  if (useMemoryStore()) {
+  if (isUsingMemoryStore()) {
     const ratings = await readRatings()
     const now = new Date().toISOString()
     const normalized: RecipeRating = {

--- a/lib/repositories/recipe-repository.ts
+++ b/lib/repositories/recipe-repository.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile } from "fs/promises"
 import { dirname, join } from "path"
-import type { Filter } from "mongodb"
+import type { Filter, ObjectId } from "mongodb"
 import { getCollection, isMongoConfigured, withoutMongoId } from "@/lib/db/mongodb"
 import { randomUUID } from "crypto"
 import {
@@ -23,9 +23,9 @@ const RECIPES_COLLECTION = "recipes"
 const RECIPE_MEAL_INSTANCES_COLLECTION = "recipe_meal_instances"
 const RECIPE_RATINGS_COLLECTION = "recipe_ratings"
 
-type RecipeDocument = RecipeRecord & { _id?: unknown }
-type RecipeMealInstanceDocument = RecipeMealInstance & { _id?: unknown }
-type RecipeRatingDocument = RecipeRating & { _id?: unknown }
+type RecipeDocument = RecipeRecord & { _id?: ObjectId }
+type RecipeMealInstanceDocument = RecipeMealInstance & { _id?: ObjectId }
+type RecipeRatingDocument = RecipeRating & { _id?: ObjectId }
 
 function asString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined


### PR DESCRIPTION
## Summary
- Add seeded sample recipe support with admin-only seed endpoint and optional force mode.
  - `POST /api/recipes/seed`
- Add shared meal serving utility to keep task creation and meal instantiation consistent.
  - `lib/recipe-serving.ts`
- Add repeat/adjust meal endpoint for recipe re-serves with history-aware context.
  - `POST /api/recipes/:id/repeat`
  - supports `sourceMealInstanceId`, `fromLatest`, `mealName`, `residentUserIds`, `createRatingTasks`, `servedBy`
- Add repository-level sample seeding and recipe count helper.
  - `seedSampleRecipes`, `countRecipes`
- Keep meal-level rating task assignments (`residentUserId` + `taskId`) for repeat/feedback tuning workflows.

## Files Added
- app/api/recipes/seed/route.ts
- app/api/recipes/[id]/repeat/route.ts
- app/api/recipes/[id]/route.ts
- app/api/recipes/[id]/serve/route.ts (refactored)
- app/api/recipes/[id]/ratings/route.ts (rating validation/task ownership hardening retained)
- app/api/recipes/route.ts
- lib/recipe-serving.ts
- lib/recipes.ts
- lib/repositories/recipe-repository.ts

## Validation
- Not run in this pass: `pnpm run lint`, `pnpm run build`, tests.
- Recommended checks before merge:
  - `pnpm run lint`
  - `pnpm run build`
  - Endpoint smoke for `seed`, `serve`, `repeat`, `ratings`
