### PR TITLE
ci: add optional post-deploy API probes

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -177,3 +177,48 @@ jobs:
             echo "Web App health endpoint failed after 10 attempts"
             exit 1
           fi
+
+  post-deploy-api-probes:
+    name: "Optional Post-Deployment API Probes"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [deploy-webapp]
+    if: always() && needs.deploy-webapp.result == 'success'
+    continue-on-error: true
+    environment: production
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.30.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run advisory API probes
+        continue-on-error: true
+        env:
+          BASE_URL: "https://${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}.azurewebsites.net"
+          POST_DEPLOY_PROBE: "true"
+          POST_DEPLOY_ADMIN_SESSION: ${{ secrets.POST_DEPLOY_ADMIN_SESSION }}
+          POST_DEPLOY_ADMIN_SESSION_COOKIE_NAME: ${{ vars.POST_DEPLOY_ADMIN_SESSION_COOKIE_NAME || '__Secure-authjs.session-token' }}
+        run: |
+          if [ -z "$POST_DEPLOY_ADMIN_SESSION" ]; then
+            echo "## Optional post-deployment API probes" >> "$GITHUB_STEP_SUMMARY"
+            echo "Skipped: configure a short-lived POST_DEPLOY_ADMIN_SESSION environment secret to enable authenticated probes." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          pnpm run test:e2e -- tests/e2e/05-post-deploy-api-probes.spec.ts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -559,6 +559,51 @@ jobs:
             echo "🎉 Deployment verification complete!" >> $GITHUB_STEP_SUMMARY
           fi
 
+  post-deploy-api-probes:
+    name: "Optional Post-Deployment API Probes"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [deploy-webapp]
+    if: always() && needs.deploy-webapp.result == 'success'
+    continue-on-error: true
+    environment: ${{ inputs.environment || 'production' }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.30.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run advisory API probes
+        continue-on-error: true
+        env:
+          BASE_URL: "https://${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}.azurewebsites.net"
+          POST_DEPLOY_PROBE: "true"
+          POST_DEPLOY_ADMIN_SESSION: ${{ secrets.POST_DEPLOY_ADMIN_SESSION }}
+          POST_DEPLOY_ADMIN_SESSION_COOKIE_NAME: ${{ vars.POST_DEPLOY_ADMIN_SESSION_COOKIE_NAME || '__Secure-authjs.session-token' }}
+        run: |
+          if [ -z "$POST_DEPLOY_ADMIN_SESSION" ]; then
+            echo "## Optional post-deployment API probes" >> "$GITHUB_STEP_SUMMARY"
+            echo "Skipped: configure a short-lived POST_DEPLOY_ADMIN_SESSION environment secret to enable authenticated probes." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          pnpm run test:e2e -- tests/e2e/05-post-deploy-api-probes.spec.ts
+
   # ============================================
   # Job 8: Deployment Summary
   # ============================================
@@ -574,6 +619,7 @@ jobs:
         deploy-docuseal,
         deploy-baserow,
         post-deploy-verification,
+        post-deploy-api-probes,
       ]
     if: always()
 
@@ -596,6 +642,7 @@ jobs:
           echo "| DocuSeal | ${{ needs.deploy-docuseal.result == 'success' && '✅' || needs.deploy-docuseal.result == 'skipped' && '⏭️' || '❌' }} ${{ needs.deploy-docuseal.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Baserow | ${{ needs.deploy-baserow.result == 'success' && '✅' || needs.deploy-baserow.result == 'skipped' && '⏭️' || '❌' }} ${{ needs.deploy-baserow.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Verification | ${{ needs.post-deploy-verification.result == 'success' && '✅' || '❌' }} ${{ needs.post-deploy-verification.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Advisory API probes | ${{ needs.post-deploy-api-probes.result == 'success' && '✅' || needs.post-deploy-api-probes.result == 'skipped' && '⏭️' || '⚠️' }} ${{ needs.post-deploy-api-probes.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Overall status

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,9 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
+  // Post-deploy probes target an already deployed application. Do not build or
+  // start a local server when BASE_URL points at that deployment.
+  webServer: process.env.POST_DEPLOY_PROBE === "true" ? undefined : {
     // Serve a production build so route compilation cannot consume an E2E
     // assertion timeout. This also keeps the suite on the same runtime path
     // used by deployment rather than relying on the dev server's bundler.

--- a/tests/e2e/05-post-deploy-api-probes.spec.ts
+++ b/tests/e2e/05-post-deploy-api-probes.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test"
+
+const sessionToken = process.env.POST_DEPLOY_ADMIN_SESSION
+const sessionCookieName =
+  process.env.POST_DEPLOY_ADMIN_SESSION_COOKIE_NAME ?? "__Secure-authjs.session-token"
+const baseUrl = process.env.BASE_URL
+
+test.describe("Post-deployment API probes", () => {
+  test.skip(
+    process.env.POST_DEPLOY_PROBE !== "true" || !baseUrl || !sessionToken,
+    "Requires POST_DEPLOY_PROBE, BASE_URL, and a short-lived admin session token."
+  )
+
+  test.beforeEach(async ({ context }) => {
+    const hostname = new URL(baseUrl!).hostname
+    await context.addCookies([
+      {
+        name: sessionCookieName,
+        value: sessionToken!,
+        domain: hostname,
+        path: "/",
+        httpOnly: true,
+        secure: true,
+        sameSite: "Lax",
+      },
+    ])
+  })
+
+  test("loads scope projects", async ({ page }) => {
+    const response = await page.request.get("/api/projects?type=scope")
+
+    expect(response.status()).toBe(200)
+    const body = await response.json()
+    expect(Array.isArray(body.projects)).toBe(true)
+    expect(body.projects.every((project: { type?: string }) => project.type === "major")).toBe(true)
+  })
+
+  test("resolves each sampled management user by its served ID", async ({ page }) => {
+    const usersResponse = await page.request.get("/api/users")
+
+    expect(usersResponse.status()).toBe(200)
+    const body = await usersResponse.json()
+    expect(Array.isArray(body.users)).toBe(true)
+
+    const users = body.users as Array<{ id?: string }>
+    test.skip(users.length === 0, "No management users are configured in this environment.")
+
+    for (const user of users.slice(0, 5)) {
+      expect(typeof user.id).toBe("string")
+      const response = await page.request.get(`/api/users/${encodeURIComponent(user.id!)}`)
+      expect(response.status()).toBe(200)
+    }
+  })
+})


### PR DESCRIPTION
## What changed
- Adds an authenticated, read-only Playwright probe for `/api/projects?type=scope` and management-user ID resolution.
- Runs the probe after production web deployment in both automatic and manual deployment workflows.
- Keeps the probe advisory: missing credentials produce an explicit skip and probe failures do not fail deployment.

## Why
Production telemetry showed a scope request returning 500 and user updates targeting a missing `irma` ID. These checks make recurrence visible after deployment without mutating production data.

## Configuration
Set the production environment secret `POST_DEPLOY_ADMIN_SESSION` to a short-lived Auth.js admin session token. Optionally set `POST_DEPLOY_ADMIN_SESSION_COOKIE_NAME` (defaults to `__Secure-authjs.session-token`). Rotate the session token when it expires.

## Validation
- `pnpm run test:e2e -- tests/e2e/05-post-deploy-api-probes.spec.ts` passed with 2 expected skips when no production session is configured.
- `pnpm run lint` passed.
- `pnpm run build` is blocked by an unrelated existing type error in `lib/recipe-serving.ts:67` (`readonly ["hans", "irma"]` is passed where `string[]` is required).
- Isolated worktree could not rerun Prettier because it has no installed dependencies; the source lint completed before isolation.