### PR TITLE
Persist tasks in existing Cosmos store when Baserow is unavailable

### DIFF
--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,14 +1,32 @@
 import { NextResponse } from "next/server"
-import { getTasks, createTask, updateTask, getEmployee } from "@/lib/services/baserow"
+import {
+  getTasks,
+  createTask,
+  updateTask,
+  getEmployee,
+  getTaskDataSource,
+} from "@/lib/services/baserow"
 import { withDataSource } from "@/lib/api/response"
 import { withRole } from "@/lib/auth/rbac"
 import { logger } from "@/lib/logger"
-import {
-  canAccessTask,
-  getTaskAccessScope,
-  PERSONA_TO_ASSIGNED_ID,
-} from "@/lib/task-access"
+import { canAccessTask, getTaskAccessScope, PERSONA_TO_ASSIGNED_ID } from "@/lib/task-access"
 import { routeToInngest } from "@/lib/workflows"
+
+function withTaskDataSource<T extends Record<string, unknown>>(data: T) {
+  const dataSource = getTaskDataSource()
+  return withDataSource(
+    { ...data, dataSource },
+    {
+      configured: dataSource !== "empty",
+      message:
+        dataSource === "baserow"
+          ? "Connected to Baserow"
+          : dataSource === "mongodb"
+            ? "Connected to Cosmos MongoDB"
+            : "Task datastore not configured",
+    }
+  )
+}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -53,7 +71,7 @@ export async function GET(request: Request) {
       ).length,
     }
 
-    return withDataSource({ tasks, summary })
+    return withTaskDataSource({ tasks, summary })
   } catch (error) {
     logger.error("Error fetching tasks", {
       error: error instanceof Error ? error.message : String(error),
@@ -98,7 +116,7 @@ export const POST = withRole(
       })
     }
 
-    return withDataSource({ task })
+    return withTaskDataSource({ task })
   } catch (error) {
     logger.error("Error creating task", {
       error: error instanceof Error ? error.message : String(error),
@@ -157,7 +175,7 @@ export const PATCH = withRole(
       return NextResponse.json({ error: "Task not found" }, { status: 404 })
     }
 
-    return withDataSource({ task })
+    return withTaskDataSource({ task })
   } catch (error) {
     logger.error("Error updating task", {
       error: error instanceof Error ? error.message : String(error),

--- a/docs/05-project/2026-07-24-task-cosmos-persistence.md
+++ b/docs/05-project/2026-07-24-task-cosmos-persistence.md
@@ -1,0 +1,33 @@
+# Task Persistence on the Existing Cosmos Store
+
+## Context
+
+The authenticated production verification for PR #129 found that task creation was not durable
+when Baserow was unconfigured. `POST /api/tasks` returned a generated task object, but the immediate
+`GET /api/tasks` returned an empty list. That made task-guidance attach and reopen impossible even
+though production already had a configured Cosmos Mongo connection for guidance and inventory.
+
+## Decision
+
+Keep Baserow as the task source when its tasks table is configured. Otherwise:
+
+- use the existing `MONGODB_URI` / `DB_NAME` connection and a `tasks` collection;
+- preserve the existing empty/demo behavior when neither Baserow nor Mongo is configured;
+- report `dataSource: "mongodb"` and `configured: true` from the tasks API;
+- keep task IDs numeric for compatibility with existing UI, workflow, and access contracts.
+
+No new datastore or infrastructure is introduced.
+
+## Verification
+
+Run:
+
+```text
+pnpm run lint
+node .\node_modules\vitest\vitest.mjs run tests/lib/task-repository.test.ts tests/lib/baserow-task-store.test.ts tests/api/tasks.test.ts tests/lib/baserow.test.ts
+node .\node_modules\typescript\bin\tsc --noEmit --incremental false
+pnpm run build
+```
+
+After deployment, create one clearly labeled Irma task, refresh the resident task list, attach
+visual guidance, close and reopen the dialog, and then remove the verification artifacts.

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from "next/server"
 import { isBaserowConfigured } from "@/lib/services/baserow"
 
+interface DataSourceOptions {
+  configured?: boolean
+  message?: string
+}
+
 /** Wraps data with Baserow connection status for consistent API responses */
-export function withDataSource<T extends Record<string, unknown>>(data: T) {
-  const dataSourceMessage = isBaserowConfigured()
-    ? "Connected to Baserow"
-    : "Baserow not configured"
+export function withDataSource<T extends Record<string, unknown>>(
+  data: T,
+  options?: DataSourceOptions
+) {
+  const configured = options?.configured ?? isBaserowConfigured()
+  const dataSourceMessage =
+    options?.message ?? (configured ? "Connected to Baserow" : "Baserow not configured")
   return NextResponse.json({
     ...data,
-    configured: isBaserowConfigured(),
+    configured,
     message: (data.message as string) ?? dataSourceMessage,
   })
 }

--- a/lib/repositories/task-repository.ts
+++ b/lib/repositories/task-repository.ts
@@ -1,0 +1,121 @@
+import { randomBytes } from "crypto"
+import type { Collection, Filter, ObjectId } from "mongodb"
+import { getCollection } from "@/lib/db/mongodb"
+import type { Task } from "@/lib/services/baserow"
+
+export interface TaskFilters {
+  assignedTo?: number
+  assignedToName?: string
+  status?: string
+}
+
+export interface TaskRepository {
+  list(filters?: TaskFilters): Promise<Task[]>
+  create(task: Omit<Task, "id">): Promise<Task>
+  update(id: number, updates: Partial<Task>): Promise<Task | null>
+}
+
+type TaskDocument = Task & { _id?: ObjectId }
+
+const memoryTasks: Task[] = []
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function matchesFilters(task: Task, filters?: TaskFilters): boolean {
+  if (!filters) return true
+  if (filters.assignedTo !== undefined && task.assignedTo !== filters.assignedTo) return false
+  if (
+    filters.assignedTo === undefined &&
+    filters.assignedToName &&
+    (task.assignedToName ?? "").toLowerCase() !== filters.assignedToName.toLowerCase()
+  ) {
+    return false
+  }
+  return !filters.status || task.status === filters.status
+}
+
+function createTaskId(): number {
+  return randomBytes(6).readUIntBE(0, 6)
+}
+
+const memoryRepository: TaskRepository = {
+  async list(filters) {
+    return memoryTasks.filter((task) => matchesFilters(task, filters)).map(clone)
+  },
+  async create(task) {
+    const created: Task = {
+      ...clone(task),
+      id: createTaskId(),
+      createdDate: task.createdDate ?? new Date().toISOString(),
+    }
+    memoryTasks.push(created)
+    return clone(created)
+  },
+  async update(id, updates) {
+    const index = memoryTasks.findIndex((task) => task.id === id)
+    if (index === -1) return null
+    memoryTasks[index] = { ...memoryTasks[index], ...clone(updates), id }
+    return clone(memoryTasks[index])
+  },
+}
+
+async function createMongoRepository(): Promise<TaskRepository> {
+  const collection: Collection<TaskDocument> = await getCollection<TaskDocument>("tasks")
+  await Promise.all([
+    collection.createIndex({ id: 1 }, { unique: true }),
+    collection.createIndex({ assignedTo: 1 }),
+    collection.createIndex({ assignedToName: 1 }),
+    collection.createIndex({ status: 1 }),
+  ])
+
+  return {
+    async list(filters) {
+      const query: Filter<TaskDocument> = {}
+      if (filters?.assignedTo !== undefined) query.assignedTo = filters.assignedTo
+      if (filters?.status) query.status = filters.status as Task["status"]
+
+      let documents = await collection.find(query).sort({ createdDate: -1, id: -1 }).toArray()
+      if (filters?.assignedTo === undefined && filters?.assignedToName) {
+        const assignedToName = filters.assignedToName.toLowerCase()
+        documents = documents.filter(
+          (task) => (task.assignedToName ?? "").toLowerCase() === assignedToName
+        )
+      }
+      return documents.map(({ _id: _ignored, ...task }) => clone(task))
+    },
+    async create(task) {
+      const created: Task = {
+        ...clone(task),
+        id: createTaskId(),
+        createdDate: task.createdDate ?? new Date().toISOString(),
+      }
+      await collection.insertOne(created)
+      return clone(created)
+    },
+    async update(id, updates) {
+      const document = await collection.findOneAndUpdate(
+        { id },
+        { $set: clone(updates) },
+        { returnDocument: "after" }
+      )
+      if (!document) return null
+      const { _id: _ignored, ...task } = document
+      return clone(task)
+    },
+  }
+}
+
+let cachedMongoRepository: TaskRepository | null = null
+
+export async function getTaskRepository(mode: "mongodb" | "memory"): Promise<TaskRepository> {
+  if (mode === "memory") return memoryRepository
+  cachedMongoRepository ??= await createMongoRepository()
+  return cachedMongoRepository
+}
+
+export function resetTaskRepositoryForTests(): void {
+  memoryTasks.splice(0, memoryTasks.length)
+  cachedMongoRepository = null
+}

--- a/lib/services/baserow.ts
+++ b/lib/services/baserow.ts
@@ -3,6 +3,8 @@
 
 import { logger } from "@/lib/logger"
 import { toISODateString } from "@/lib/utils"
+import { isMongoConfigured } from "@/lib/db/mongodb"
+import { getTaskRepository } from "@/lib/repositories/task-repository"
 
 interface BaserowConfig {
   apiUrl: string
@@ -194,6 +196,15 @@ const getTableIds = (): TableIds => ({
 export const isBaserowConfigured = (): boolean => {
   const config = getConfig()
   return !!config.apiToken && !!config.databaseId
+}
+
+export type TaskDataSource = "baserow" | "mongodb" | "empty"
+
+export function getTaskDataSource(): TaskDataSource {
+  const tableIds = getTableIds()
+  if (isBaserowConfigured() && !!tableIds.tasks) return "baserow"
+  if (isMongoConfigured()) return "mongodb"
+  return "empty"
 }
 
 export function isIncidentsTableConfigured(): boolean {
@@ -393,6 +404,9 @@ export async function getTasks(filters?: {
   const tableIds = getTableIds()
 
   if (!isBaserowConfigured() || !tableIds.tasks) {
+    if (isMongoConfigured()) {
+      return (await getTaskRepository("mongodb")).list(filters)
+    }
     let tasks = getMockTasks()
     if (filters?.assignedTo) {
       tasks = tasks.filter((t) => t.assignedTo === filters.assignedTo)
@@ -431,6 +445,11 @@ export async function getTasksPaginated(
   const tableIds = getTableIds()
 
   if (!isBaserowConfigured() || !tableIds.tasks) {
+    if (isMongoConfigured()) {
+      const items = await (await getTaskRepository("mongodb")).list(filters)
+      const start = Math.max(0, page - 1) * size
+      return { items: items.slice(start, start + size), count: items.length }
+    }
     let items = getMockTasks()
     if (filters?.assignedTo) items = items.filter((t) => t.assignedTo === filters.assignedTo)
     if (filters?.status) items = items.filter((t) => t.status === filters.status)
@@ -460,6 +479,9 @@ export async function createTask(task: Omit<Task, "id">): Promise<Task | null> {
   const tableIds = getTableIds()
 
   if (!isBaserowConfigured() || !tableIds.tasks) {
+    if (isMongoConfigured()) {
+      return (await getTaskRepository("mongodb")).create(task)
+    }
     return { ...task, id: Date.now() } as Task
   }
 
@@ -478,6 +500,9 @@ export async function updateTask(id: number, updates: Partial<Task>): Promise<Ta
   const tableIds = getTableIds()
 
   if (!isBaserowConfigured() || !tableIds.tasks) {
+    if (isMongoConfigured()) {
+      return (await getTaskRepository("mongodb")).update(id, updates)
+    }
     const mockTask = getMockTasks().find((t) => t.id === id)
     return mockTask ? { ...mockTask, ...updates } : null
   }

--- a/tests/lib/baserow-task-store.test.ts
+++ b/tests/lib/baserow-task-store.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const taskRepository = vi.hoisted(() => ({
+  list: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock("@/lib/db/mongodb", () => ({
+  isMongoConfigured: () => true,
+}))
+
+vi.mock("@/lib/repositories/task-repository", () => ({
+  getTaskRepository: vi.fn(async () => taskRepository),
+}))
+
+import {
+  createTask,
+  getTaskDataSource,
+  getTasks,
+  getTasksPaginated,
+  updateTask,
+  type Task,
+} from "@/lib/services/baserow"
+
+const storedTask: Task = {
+  id: 123,
+  title: "Stored task",
+  assignedTo: 4,
+  priority: "Medium",
+  status: "Not Started",
+}
+
+describe("Baserow task service Mongo fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv("BASEROW_API_TOKEN", "")
+    vi.stubEnv("BASEROW_DATABASE_ID", "")
+    vi.stubEnv("BASEROW_TABLE_TASKS", "")
+  })
+
+  it("reports MongoDB as the configured task data source", () => {
+    expect(getTaskDataSource()).toBe("mongodb")
+  })
+
+  it("delegates task lists and pagination to the persistent repository", async () => {
+    taskRepository.list.mockResolvedValue([storedTask])
+
+    await expect(getTasks({ assignedTo: 4 })).resolves.toEqual([storedTask])
+    expect(taskRepository.list).toHaveBeenCalledWith({ assignedTo: 4 })
+
+    await expect(getTasksPaginated(2, 1, { status: "Not Started" })).resolves.toEqual({
+      items: [],
+      count: 1,
+    })
+    expect(taskRepository.list).toHaveBeenCalledWith({ status: "Not Started" })
+  })
+
+  it("delegates task creates and updates to the persistent repository", async () => {
+    const taskInput = {
+      title: storedTask.title,
+      assignedTo: storedTask.assignedTo,
+      priority: storedTask.priority,
+      status: storedTask.status,
+    }
+    taskRepository.create.mockResolvedValue(storedTask)
+    taskRepository.update.mockResolvedValue({ ...storedTask, status: "In Progress" })
+
+    await expect(createTask(taskInput)).resolves.toEqual(storedTask)
+    expect(taskRepository.create).toHaveBeenCalledWith(taskInput)
+
+    await expect(updateTask(storedTask.id, { status: "In Progress" })).resolves.toMatchObject({
+      id: storedTask.id,
+      status: "In Progress",
+    })
+    expect(taskRepository.update).toHaveBeenCalledWith(storedTask.id, {
+      status: "In Progress",
+    })
+  })
+})

--- a/tests/lib/task-repository.test.ts
+++ b/tests/lib/task-repository.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { getTaskRepository, resetTaskRepositoryForTests } from "@/lib/repositories/task-repository"
+
+describe("task repository", () => {
+  beforeEach(() => {
+    resetTaskRepositoryForTests()
+  })
+
+  it("persists task create, filtered list, and update through the repository contract", async () => {
+    const repository = await getTaskRepository("memory")
+    const created = await repository.create({
+      title: "Resident guidance proof",
+      description: "Persist this task for guidance.",
+      assignedTo: 4,
+      assignedToName: "Irma",
+      priority: "Medium",
+      status: "Not Started",
+    })
+
+    expect(created.id).toEqual(expect.any(Number))
+    expect(created.createdDate).toEqual(expect.any(String))
+    await expect(repository.list({ assignedTo: 4 })).resolves.toEqual([created])
+    await expect(repository.list({ assignedToName: "irma" })).resolves.toEqual([created])
+    await expect(repository.list({ assignedTo: 1 })).resolves.toEqual([])
+
+    const updated = await repository.update(created.id, { status: "In Progress" })
+    expect(updated).toMatchObject({ id: created.id, status: "In Progress" })
+    await expect(repository.list({ status: "In Progress" })).resolves.toEqual([updated])
+  })
+
+  it("returns null when updating an unknown task", async () => {
+    const repository = await getTaskRepository("memory")
+    await expect(repository.update(999, { status: "Completed" })).resolves.toBeNull()
+  })
+})


### PR DESCRIPTION
## What changed

- keeps Baserow as the task source when its tasks table is configured
- otherwise persists task list/create/update operations in the existing `MONGODB_URI` / `DB_NAME` Cosmos Mongo database
- preserves explicit empty/demo behavior when neither persistent source is configured
- reports `dataSource: "mongodb"` and `configured: true` from `/api/tasks` when Cosmos is active
- adds repository-contract and Baserow-service fallback tests
- records the datastore decision and production replay path under `docs/05-project/`

## Why

The authenticated PR #129 production follow-up reproduced a false-success task create: `POST /api/tasks` returned HTTP 200 with a generated task object, but the immediate `GET /api/tasks` returned `tasks: []` because Baserow is unconfigured. The Irma task card therefore disappeared before visual guidance could be attached or reopened, even though production already has Cosmos Mongo configured for guidance and inventory.

This change uses that existing datastore; it does not enable demo data or introduce new infrastructure.

## Validation

- `pnpm run lint`
- `node .\node_modules\vitest\vitest.mjs run tests/lib/task-repository.test.ts tests/lib/baserow-task-store.test.ts tests/api/tasks.test.ts tests/lib/baserow.test.ts` — 15 passed
- `node .\node_modules\typescript\bin\tsc --noEmit --incremental false`
- `pnpm run build`
- Prettier check and `git diff --check`

## Deployment note

Keep this PR in draft until production deployment is explicitly approved. After deployment, repeat the authenticated Irma task create → refresh → visual guidance → attach → close/reopen proof and clean the temporary records.

Baton: `a7021a7c-2410-4333-8a1f-4ace3dd85ffa`; follow-up evidence task: `7bbf0537-ba6f-478a-9afd-f0c0a748e7ff`.