### PR TITLE
Isolate empty task datastore test from CI Mongo

### DIFF
--- a/tests/lib/baserow.test.ts
+++ b/tests/lib/baserow.test.ts
@@ -7,6 +7,8 @@ describe("baserow service", () => {
   beforeEach(() => {
     vi.resetModules()
     process.env = { ...originalEnv }
+    delete process.env.MONGODB_URI
+    delete process.env.MONGO_URL
   })
 
   describe("isBaserowConfigured", () => {


### PR DESCRIPTION
## What changed

Explicitly clears `MONGODB_URI` and `MONGO_URL` in the Baserow service test setup before asserting the no-datastore empty fallback.

## Why

The merge-triggered deploy workflow sets `MONGODB_URI` and starts Mongo. After PR #130 correctly began using Mongo as the task fallback, the old empty-fallback test observed tasks created by other tests and failed. The main checklist passed because it does not set that environment variable.

This changes only test isolation; application behavior is unchanged.

## Validation

- workflow-specific reproduction with `MONGODB_URI` set: `tests/lib/baserow.test.ts` — 7 passed
- full suite: 55 files / 343 tests passed
- `pnpm run lint`
- `git diff --check`

Deployment recovery for failed run https://github.com/neuralliquid/house-of-veritas/actions/runs/30131081349. Baton: `a7021a7c-2410-4333-8a1f-4ace3dd85ffa`.