### PR TITLE
Allow manual recovery of web deployments

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -4,6 +4,7 @@ name: "Deploy on Merge"
 # (terraform-apply.yml). Functions deploy only when function code changes
 # (deploy-functions.yml). This workflow deploys the web app when app code changes.
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## What changed

Adds `workflow_dispatch` to the existing **Deploy on Merge** workflow.

## Why

PR #130 merged application code but its deploy run stopped at a workflow-specific test-environment failure. PR #131 fixed the test, but its tests-only diff is intentionally outside the deploy workflow's push path filters, so current `main` has no safe way to deploy without another application-code change.

This one-line trigger provides an explicit recovery path while preserving the existing automatic path-filtered deployment behavior. Because the workflow file itself is already an allowed push path, merging this PR will also deploy current `main` once all quality/build gates pass.

## Validation

- YAML diff is one key under the existing `on` mapping
- `git diff --check`
- PR #131 full suite: 55 files / 343 tests passed
- GitHub deployment checklist and deploy workflow will independently validate this branch

Recovery chain:
- failed deploy run: https://github.com/neuralliquid/house-of-veritas/actions/runs/30131081349
- application PR: #130
- test-isolation PR: #131
- Baton: `a7021a7c-2410-4333-8a1f-4ace3dd85ffa`.