### PR TITLE
fix: add Cosmos task sort index

### DIFF
--- a/docs/05-project/2026-07-24-task-cosmos-persistence.md
+++ b/docs/05-project/2026-07-24-task-cosmos-persistence.md
@@ -21,6 +21,8 @@ No new datastore or infrastructure is introduced.
 The production Cosmos account exposes the MongoDB 3.6 protocol (wire version 6). Keep the Node
 MongoDB driver on the latest 5.x release (`5.9.2`) unless the account is upgraded: driver 7.x
 requires MongoDB 4.2 / wire version 8 and fails topology selection before any query can run.
+The `tasks` collection also requires the compound `{ createdDate: -1, id: -1 }` index used by the
+default task-list sort; Cosmos does not serve that sort from the separate single-field indexes.
 
 ## Verification
 

--- a/lib/repositories/task-repository.ts
+++ b/lib/repositories/task-repository.ts
@@ -68,6 +68,7 @@ async function createMongoRepository(): Promise<TaskRepository> {
     collection.createIndex({ assignedTo: 1 }),
     collection.createIndex({ assignedToName: 1 }),
     collection.createIndex({ status: 1 }),
+    collection.createIndex({ createdDate: -1, id: -1 }),
   ])
 
   return {

--- a/tests/lib/task-repository-mongodb.test.ts
+++ b/tests/lib/task-repository-mongodb.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mongoMocks = vi.hoisted(() => ({
+  createIndex: vi.fn(),
+  getCollection: vi.fn(),
+}))
+
+vi.mock("@/lib/db/mongodb", () => ({
+  getCollection: mongoMocks.getCollection,
+}))
+
+import { getTaskRepository, resetTaskRepositoryForTests } from "@/lib/repositories/task-repository"
+
+describe("Mongo task repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetTaskRepositoryForTests()
+    mongoMocks.createIndex.mockResolvedValue("index")
+    mongoMocks.getCollection.mockResolvedValue({
+      createIndex: mongoMocks.createIndex,
+    })
+  })
+
+  it("creates the compound index required by the default Cosmos sort", async () => {
+    await getTaskRepository("mongodb")
+
+    expect(mongoMocks.createIndex).toHaveBeenCalledWith({ createdDate: -1, id: -1 })
+  })
+})


### PR DESCRIPTION
## Summary
- create the compound tasks index used by the default createdDate/id sort
- add a regression test for Mongo repository initialization
- document the Cosmos compound-index requirement

## Production evidence
After PR #133 deployed and the App Service restarted onto MongoDB driver 5.9.2, the wire-version error cleared. Fresh Application Insights exceptions then showed Cosmos rejecting the task-list sort because no corresponding composite index existed.

## Verification
- pnpm run lint
- pnpm exec tsc --noEmit
- pnpm exec vitest run tests/lib/task-repository.test.ts tests/lib/task-repository-mongodb.test.ts tests/lib/baserow-task-store.test.ts tests/lib/baserow.test.ts tests/api/tasks.test.ts (16 passed)
- pnpm test -- --run (56 files, 344 tests passed)
- CI-mode pnpm run build
- git diff --check