### PR TITLE
fix: resolve Cosmos-backed tasks for guidance

### DIFF
--- a/docs/05-project/2026-07-24-task-cosmos-persistence.md
+++ b/docs/05-project/2026-07-24-task-cosmos-persistence.md
@@ -12,6 +12,7 @@ though production already had a configured Cosmos Mongo connection for guidance 
 Keep Baserow as the task source when its tasks table is configured. Otherwise:
 
 - use the existing `MONGODB_URI` / `DB_NAME` connection and a `tasks` collection;
+- route both list/mutation operations and individual task authorization lookups through it;
 - preserve the existing empty/demo behavior when neither Baserow nor Mongo is configured;
 - report `dataSource: "mongodb"` and `configured: true` from the tasks API;
 - keep task IDs numeric for compatibility with existing UI, workflow, and access contracts.

--- a/lib/repositories/task-repository.ts
+++ b/lib/repositories/task-repository.ts
@@ -10,6 +10,7 @@ export interface TaskFilters {
 }
 
 export interface TaskRepository {
+  get(id: number): Promise<Task | null>
   list(filters?: TaskFilters): Promise<Task[]>
   create(task: Omit<Task, "id">): Promise<Task>
   update(id: number, updates: Partial<Task>): Promise<Task | null>
@@ -41,6 +42,9 @@ function createTaskId(): number {
 }
 
 const memoryRepository: TaskRepository = {
+  async get(id) {
+    return clone(memoryTasks.find((task) => task.id === id) ?? null)
+  },
   async list(filters) {
     return memoryTasks.filter((task) => matchesFilters(task, filters)).map(clone)
   },
@@ -72,6 +76,12 @@ async function createMongoRepository(): Promise<TaskRepository> {
   ])
 
   return {
+    async get(id) {
+      const document = await collection.findOne({ id })
+      if (!document) return null
+      const { _id: _ignored, ...task } = document
+      return clone(task)
+    },
     async list(filters) {
       const query: Filter<TaskDocument> = {}
       if (filters?.assignedTo !== undefined) query.assignedTo = filters.assignedTo

--- a/lib/services/baserow.ts
+++ b/lib/services/baserow.ts
@@ -387,6 +387,9 @@ export async function createEmployee(emp: Omit<Employee, "id">): Promise<Employe
 export async function getTask(id: number): Promise<Task | null> {
   const tableIds = getTableIds()
   if (!isBaserowConfigured() || !tableIds.tasks) {
+    if (isMongoConfigured()) {
+      return (await getTaskRepository("mongodb")).get(id)
+    }
     return getMockTasks().find((task) => task.id === id) ?? null
   }
 

--- a/tests/lib/baserow-task-store.test.ts
+++ b/tests/lib/baserow-task-store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const taskRepository = vi.hoisted(() => ({
+  get: vi.fn(),
   list: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),
@@ -16,6 +17,7 @@ vi.mock("@/lib/repositories/task-repository", () => ({
 
 import {
   createTask,
+  getTask,
   getTaskDataSource,
   getTasks,
   getTasksPaginated,
@@ -41,6 +43,13 @@ describe("Baserow task service Mongo fallback", () => {
 
   it("reports MongoDB as the configured task data source", () => {
     expect(getTaskDataSource()).toBe("mongodb")
+  })
+
+  it("delegates individual task lookup to the persistent repository", async () => {
+    taskRepository.get.mockResolvedValue(storedTask)
+
+    await expect(getTask(storedTask.id)).resolves.toEqual(storedTask)
+    expect(taskRepository.get).toHaveBeenCalledWith(storedTask.id)
   })
 
   it("delegates task lists and pagination to the persistent repository", async () => {

--- a/tests/lib/task-repository.test.ts
+++ b/tests/lib/task-repository.test.ts
@@ -19,6 +19,8 @@ describe("task repository", () => {
 
     expect(created.id).toEqual(expect.any(Number))
     expect(created.createdDate).toEqual(expect.any(String))
+    await expect(repository.get(created.id)).resolves.toEqual(created)
+    await expect(repository.get(999)).resolves.toBeNull()
     await expect(repository.list({ assignedTo: 4 })).resolves.toEqual([created])
     await expect(repository.list({ assignedToName: "irma" })).resolves.toEqual([created])
     await expect(repository.list({ assignedTo: 1 })).resolves.toEqual([])


### PR DESCRIPTION
## Summary
- add individual task lookup to the persistent task repository
- route getTask through Cosmos when Baserow tasks are unconfigured
- cover repository and service lookup behavior

## Production evidence
The authenticated Irma-surface flow created and reloaded task 122101340177319 from Cosmos successfully. POST /api/guidance/analyze then returned 404 Task not found because task authorization called getTask, whose empty-mode branch still checked only mock/demo tasks.

## Verification
- pnpm run lint
- pnpm exec tsc --noEmit
- focused repository/access/guidance tests (18 passed)
- pnpm test -- --run (56 files, 345 tests passed)
- CI-mode pnpm run build
- git diff --check