### PR TITLE
Complete bilingual recipe catalog and meal feedback

### DIFF
--- a/app/api/recipes/[id]/meals/route.ts
+++ b/app/api/recipes/[id]/meals/route.ts
@@ -38,86 +38,102 @@ function asLocaleText(value: unknown): string | undefined {
 }
 
 function toSet(values: string[]): Set<string> {
-  return new Set(values.map((value) => value.toLowerCase().trim()).filter((value) => value.length > 0))
+  return new Set(
+    values.map((value) => value.toLowerCase().trim()).filter((value) => value.length > 0)
+  )
 }
 
-export const GET = withRole("admin", "operator", "employee", "resident")(
-  async (_request, context) => {
-    try {
-      const params = await context.params
-      const id = params?.id
-      if (!id) return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+export const GET = withRole(
+  "admin",
+  "operator",
+  "employee",
+  "resident"
+)(async (_request, context) => {
+  try {
+    const params = await context.params
+    const id = params?.id
+    if (!id) return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
 
-      const recipe = await getRecipeById(id)
-      if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
-      if (!isRecipeAudienceMatch(recipe.audienceUserIds, context.userId) && context.role !== "admin") {
-        return NextResponse.json({ error: "You do not have access to this recipe" }, { status: 403 })
-      }
-      if (context.role !== "admin" && recipe.status !== "published") {
-        return NextResponse.json({ error: "Recipe is not published" }, { status: 403 })
-      }
-
-      const residentAliases = toSet(getExpandedAudienceAliases(context.userId))
-      const mealInstances = await listRecipeMealInstances(id)
-      const allRatings = await listRecipeRatings(id)
-
-      const groupedRatings = new Map<string, { total: number; count: number }>()
-      for (const rating of allRatings) {
-        const current = groupedRatings.get(rating.mealInstanceId) ?? { total: 0, count: 0 }
-        current.total += rating.score
-        current.count += 1
-        groupedRatings.set(rating.mealInstanceId, current)
-      }
-
-      const visibleMeals = mealInstances.filter((meal) => {
-        if (context.role === "admin") return true
-        const residentSet = toSet(meal.residentUserIds)
-        return [...residentAliases].some((alias) => residentSet.has(alias))
-      })
-
-      const items = visibleMeals.map((meal) => {
-        const mealRatings = groupedRatings.get(meal.id)
-        const mealResidentSet = toSet(meal.residentUserIds)
-        const summary: MealRatingSummary = {
-          mealInstanceId: meal.id,
-          totalRatings: mealRatings?.count ?? 0,
-          averageScore: mealRatings && mealRatings.count > 0 ? mealRatings.total / mealRatings.count : 0,
-        }
-        const assignedTask = meal.ratingTaskAssignments?.find((assignment) =>
-          residentAliases.has(assignment.residentUserId.toLowerCase())
-        )
-        const currentUserRating = allRatings.find((rating) => {
-          if (rating.mealInstanceId !== meal.id) return false
-          return residentAliases.has(rating.residentUserId.toLowerCase())
-        })
-        return {
-          id: meal.id,
-          mealName: asLocaleText(meal.mealName),
-          servedAt: meal.servedAt,
-          servedBy: asLocaleText(meal.servedBy),
-          residentUserIds: meal.residentUserIds,
-          ratingTaskId: assignedTask?.taskId,
-          ratingTaskCount: meal.ratingTaskIds.length,
-          canRate:
-            context.role === "admin" ||
-            [...residentAliases].some((alias) => mealResidentSet.has(alias)),
-          summary,
-          currentUserRating: currentUserRating
-            ? {
-                score: currentUserRating.score,
-                comment: currentUserRating.comment,
-                submittedAt: currentUserRating.submittedAt,
-              }
-            : null,
-        }
-      })
-
-      return NextResponse.json({ mealInstances: items })
-    } catch (error) {
-      logger.error("Failed to list meals for recipe", {
-        error: error instanceof Error ? error.message : String(error),
-      })
-      return NextResponse.json({ error: "Failed to list meals" }, { status: 500 })
+    const recipe = await getRecipeById(id)
+    if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+    if (
+      !isRecipeAudienceMatch(recipe.audienceUserIds, context.userId) &&
+      context.role !== "admin"
+    ) {
+      return NextResponse.json({ error: "You do not have access to this recipe" }, { status: 403 })
     }
+    if (context.role !== "admin" && recipe.status !== "published") {
+      return NextResponse.json({ error: "Recipe is not published" }, { status: 403 })
+    }
+
+    const residentAliases = toSet(getExpandedAudienceAliases(context.userId))
+    const mealInstances = await listRecipeMealInstances(id)
+    const allRatings = await listRecipeRatings(id)
+
+    const groupedRatings = new Map<string, { total: number; count: number }>()
+    for (const rating of allRatings) {
+      const current = groupedRatings.get(rating.mealInstanceId) ?? { total: 0, count: 0 }
+      current.total += rating.score
+      current.count += 1
+      groupedRatings.set(rating.mealInstanceId, current)
+    }
+
+    const visibleMeals = mealInstances.filter((meal) => {
+      if (context.role === "admin") return true
+      const residentSet = toSet(meal.residentUserIds)
+      return [...residentAliases].some((alias) => residentSet.has(alias))
+    })
+
+    const items = visibleMeals.map((meal) => {
+      const mealRatings = groupedRatings.get(meal.id)
+      const mealResidentSet = toSet(meal.residentUserIds)
+      const summary: MealRatingSummary = {
+        mealInstanceId: meal.id,
+        totalRatings: mealRatings?.count ?? 0,
+        averageScore:
+          mealRatings && mealRatings.count > 0 ? mealRatings.total / mealRatings.count : 0,
+      }
+      const assignedTask = meal.ratingTaskAssignments?.find((assignment) =>
+        residentAliases.has(assignment.residentUserId.toLowerCase())
+      )
+      const currentUserRating = allRatings.find((rating) => {
+        if (rating.mealInstanceId !== meal.id) return false
+        return residentAliases.has(rating.residentUserId.toLowerCase())
+      })
+      const visibleResidentUserIds =
+        context.role === "admin"
+          ? meal.residentUserIds
+          : meal.residentUserIds.filter((residentUserId) =>
+              residentAliases.has(residentUserId.toLowerCase().trim())
+            )
+      return {
+        id: meal.id,
+        mealName: asLocaleText(meal.mealName),
+        servedAt: meal.servedAt,
+        servedBy: asLocaleText(meal.servedBy),
+        residentUserIds: visibleResidentUserIds,
+        ratingTaskId: assignedTask?.taskId,
+        ratingTaskCount:
+          context.role === "admin" ? meal.ratingTaskIds.length : assignedTask ? 1 : 0,
+        canRate:
+          context.role === "admin" ||
+          [...residentAliases].some((alias) => mealResidentSet.has(alias)),
+        summary,
+        currentUserRating: currentUserRating
+          ? {
+              score: currentUserRating.score,
+              comment: currentUserRating.comment,
+              submittedAt: currentUserRating.submittedAt,
+            }
+          : null,
+      }
+    })
+
+    return NextResponse.json({ mealInstances: items })
+  } catch (error) {
+    logger.error("Failed to list meals for recipe", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Failed to list meals" }, { status: 500 })
   }
-)
+})

--- a/app/api/recipes/[id]/meals/route.ts
+++ b/app/api/recipes/[id]/meals/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from "next/server"
+import { getExpandedAudienceAliases, isRecipeAudienceMatch } from "@/lib/recipes"
+import { withRole } from "@/lib/auth/rbac"
+import {
+  getRecipeById,
+  listRecipeMealInstances,
+  listRecipeRatings,
+} from "@/lib/repositories/recipe-repository"
+import { logger } from "@/lib/logger"
+
+interface MealRatingSummary {
+  mealInstanceId: string
+  totalRatings: number
+  averageScore: number
+}
+
+interface MealInstanceWithRatingPayload {
+  id: string
+  mealName?: string
+  servedAt: string
+  servedBy?: string
+  residentUserIds: string[]
+  ratingTaskId?: number
+  ratingTaskCount: number
+  canRate: boolean
+  summary: MealRatingSummary
+  currentUserRating?: {
+    score: 1 | 2 | 3 | 4 | 5
+    comment?: string
+    submittedAt: string
+  } | null
+}
+
+function asLocaleText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function toSet(values: string[]): Set<string> {
+  return new Set(values.map((value) => value.toLowerCase().trim()).filter((value) => value.length > 0))
+}
+
+export const GET = withRole("admin", "operator", "employee", "resident")(
+  async (_request, context) => {
+    try {
+      const params = await context.params
+      const id = params?.id
+      if (!id) return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+
+      const recipe = await getRecipeById(id)
+      if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+      if (!isRecipeAudienceMatch(recipe.audienceUserIds, context.userId) && context.role !== "admin") {
+        return NextResponse.json({ error: "You do not have access to this recipe" }, { status: 403 })
+      }
+      if (context.role !== "admin" && recipe.status !== "published") {
+        return NextResponse.json({ error: "Recipe is not published" }, { status: 403 })
+      }
+
+      const residentAliases = toSet(getExpandedAudienceAliases(context.userId))
+      const mealInstances = await listRecipeMealInstances(id)
+      const allRatings = await listRecipeRatings(id)
+
+      const groupedRatings = new Map<string, { total: number; count: number }>()
+      for (const rating of allRatings) {
+        const current = groupedRatings.get(rating.mealInstanceId) ?? { total: 0, count: 0 }
+        current.total += rating.score
+        current.count += 1
+        groupedRatings.set(rating.mealInstanceId, current)
+      }
+
+      const visibleMeals = mealInstances.filter((meal) => {
+        if (context.role === "admin") return true
+        const residentSet = toSet(meal.residentUserIds)
+        return [...residentAliases].some((alias) => residentSet.has(alias))
+      })
+
+      const items = visibleMeals.map((meal) => {
+        const mealRatings = groupedRatings.get(meal.id)
+        const mealResidentSet = toSet(meal.residentUserIds)
+        const summary: MealRatingSummary = {
+          mealInstanceId: meal.id,
+          totalRatings: mealRatings?.count ?? 0,
+          averageScore: mealRatings && mealRatings.count > 0 ? mealRatings.total / mealRatings.count : 0,
+        }
+        const assignedTask = meal.ratingTaskAssignments?.find((assignment) =>
+          residentAliases.has(assignment.residentUserId.toLowerCase())
+        )
+        const currentUserRating = allRatings.find((rating) => {
+          if (rating.mealInstanceId !== meal.id) return false
+          return residentAliases.has(rating.residentUserId.toLowerCase())
+        })
+        return {
+          id: meal.id,
+          mealName: asLocaleText(meal.mealName),
+          servedAt: meal.servedAt,
+          servedBy: asLocaleText(meal.servedBy),
+          residentUserIds: meal.residentUserIds,
+          ratingTaskId: assignedTask?.taskId,
+          ratingTaskCount: meal.ratingTaskIds.length,
+          canRate:
+            context.role === "admin" ||
+            [...residentAliases].some((alias) => mealResidentSet.has(alias)),
+          summary,
+          currentUserRating: currentUserRating
+            ? {
+                score: currentUserRating.score,
+                comment: currentUserRating.comment,
+                submittedAt: currentUserRating.submittedAt,
+              }
+            : null,
+        }
+      })
+
+      return NextResponse.json({ mealInstances: items })
+    } catch (error) {
+      logger.error("Failed to list meals for recipe", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return NextResponse.json({ error: "Failed to list meals" }, { status: 500 })
+    }
+  }
+)

--- a/app/dashboard/[persona]/recipes/page.tsx
+++ b/app/dashboard/[persona]/recipes/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation"
+import DashboardLayout from "@/components/dashboard-layout"
+import RecipeCatalogClient from "@/components/recipes/recipe-catalog-client"
+
+const PERSONAS = ["hans", "charl", "lucky", "irma"] as const
+
+type Persona = (typeof PERSONAS)[number]
+
+function isPersona(value: string): value is Persona {
+  return PERSONAS.includes(value as Persona)
+}
+
+export default async function RecipeDashboardPage({
+  params,
+}: {
+  params: Promise<{ persona: string }>
+}) {
+  const { persona } = await params
+  const normalizedPersona = persona.toLowerCase()
+
+  if (!isPersona(normalizedPersona)) notFound()
+
+  return (
+    <DashboardLayout persona={normalizedPersona}>
+      <RecipeCatalogClient persona={normalizedPersona} />
+    </DashboardLayout>
+  )
+}

--- a/components/recipes/recipe-catalog-client.tsx
+++ b/components/recipes/recipe-catalog-client.tsx
@@ -1,0 +1,774 @@
+"use client"
+
+import { useAuth } from "@/lib/auth-context"
+import { apiFetch } from "@/lib/api-client"
+import { type RecipeIngredient, type RecipeRecord, type RecipeRatingSummary, type RecipeStep } from "@/lib/recipes"
+import { Clock4, ChefHat, Loader2, RefreshCw, Save, Send, Star, Utensils } from "lucide-react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+interface RecipeListItem extends RecipeRecord {
+  ratingSummary?: RecipeRatingSummary
+}
+
+interface RecipeListResponse {
+  recipes: RecipeListItem[]
+}
+
+interface SeedResponse {
+  seed?: {
+    inserted: number
+    skipped: number
+    existingCount: number
+    recipeIds: string[]
+    forced: boolean
+  }
+}
+
+interface MealSummary {
+  mealInstanceId: string
+  totalRatings: number
+  averageScore: number
+}
+
+interface MealRating {
+  score: 1 | 2 | 3 | 4 | 5
+  comment?: string
+  submittedAt: string
+}
+
+interface MealInstance {
+  id: string
+  mealName?: string
+  servedAt: string
+  servedBy?: string
+  residentUserIds: string[]
+  ratingTaskId?: number
+  ratingTaskCount: number
+  canRate: boolean
+  summary: MealSummary
+  currentUserRating?: MealRating | null
+}
+
+interface MealListResponse {
+  mealInstances: MealInstance[]
+}
+
+interface ServeResponse {
+  mealInstance: {
+    id: string
+    mealName?: string
+    servedAt: string
+  }
+  meal?: {
+    mealInstanceId?: string
+  }
+}
+
+type LanguageMode = "en" | "af" | "both"
+type Persona = "hans" | "charl" | "lucky" | "irma"
+
+const LANG_LABELS: Record<LanguageMode, string> = {
+  en: "EN",
+  af: "AF",
+  both: "EN + AF",
+}
+
+function toListText(value: string | undefined, fallback: string) {
+  return value?.trim().length ? value : fallback
+}
+
+function clampScore(value: number | null): value is 1 | 2 | 3 | 4 | 5 {
+  return value === 1 || value === 2 || value === 3 || value === 4 || value === 5
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value)
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  })
+}
+
+function recipeTitle(recipe: RecipeListItem, mode: LanguageMode): string {
+  if (mode === "af") return recipe.titleAf
+  if (mode === "en") return recipe.titleEn
+  return `${recipe.titleEn} / ${recipe.titleAf}`
+}
+
+function recipeSummary(recipe: RecipeListItem, mode: LanguageMode): string {
+  if (mode === "af") return toListText(recipe.summaryAf, "No summary available.")
+  if (mode === "en") return toListText(recipe.summaryEn, "No summary available.")
+  return `${toListText(recipe.summaryEn, "No summary available.")}\n${toListText(recipe.summaryAf, "")}`
+}
+
+function recipeSectionText(entity: RecipeStep | RecipeIngredient, mode: LanguageMode): string {
+  if (mode === "af") {
+    return "preparationNote" in entity
+      ? entity.preparationNote ?? ""
+      : (entity as RecipeStep).instructionAf ?? ""
+  }
+  if (mode === "en") {
+    return "preparationNote" in entity
+      ? entity.preparationNote ?? ""
+      : (entity as RecipeStep).instructionEn ?? ""
+  }
+  const enText =
+    "preparationNote" in entity ? entity.preparationNote ?? "" : (entity as RecipeStep).instructionEn ?? ""
+  const afText =
+    "preparationNote" in entity ? entity.preparationNote ?? "" : (entity as RecipeStep).instructionAf ?? ""
+  return `${enText}${enText ? " / " : ""}${afText}`
+}
+
+export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
+  const { user } = useAuth()
+
+  const [recipes, setRecipes] = useState<RecipeListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string>("")
+  const [selectedRecipeId, setSelectedRecipeId] = useState<string>("")
+  const [language, setLanguage] = useState<LanguageMode>("both")
+  const [mealInstances, setMealInstances] = useState<MealInstance[]>([])
+  const [mealsLoading, setMealsLoading] = useState(false)
+  const [ratingInputs, setRatingInputs] = useState<
+    Record<string, { score: number | null; comment: string; submitting: boolean; submittedMessage?: string }>
+  >({})
+  const [seedMessage, setSeedMessage] = useState<string>("")
+  const [serveInProgress, setServeInProgress] = useState(false)
+  const [serveMealName, setServeMealName] = useState("")
+  const [serveResidents, setServeResidents] = useState("")
+  const [serveMessage, setServeMessage] = useState("")
+
+  const isAdmin = user?.role === "admin"
+  const selectedRecipe = useMemo(
+    () => recipes.find((recipe) => recipe.id === selectedRecipeId) ?? null,
+    [recipes, selectedRecipeId]
+  )
+
+  const recipesApi = useMemo(
+    () => `/api/recipes?withStats=true${isAdmin ? "&includeDrafts=true" : ""}`,
+    [isAdmin]
+  )
+
+  const loadRecipes = useCallback(async () => {
+    setLoading(true)
+    setError("")
+    try {
+      const data = await apiFetch<RecipeListResponse>(recipesApi, {
+        label: "Recipes",
+      })
+      const next = data?.recipes ?? []
+      setRecipes(next)
+      setSelectedRecipeId((current) => (current && next.some((recipe) => recipe.id === current) ? current : (next[0]?.id ?? "")))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load recipes")
+    } finally {
+      setLoading(false)
+    }
+  }, [recipesApi])
+
+  const loadMeals = useCallback(async () => {
+    if (!selectedRecipe) return
+    setMealsLoading(true)
+    try {
+      const data = await apiFetch<MealListResponse>(`/api/recipes/${selectedRecipe.id}/meals`, {
+        label: "RecipeMeals",
+      })
+      const nextMeals = data?.mealInstances ?? []
+      setMealInstances(nextMeals)
+      setRatingInputs((state) => {
+        const next = { ...state }
+        for (const meal of nextMeals) {
+          const existing = next[meal.id]
+          next[meal.id] = {
+            score: existing?.score ?? meal.currentUserRating?.score ?? null,
+            comment: existing?.comment ?? meal.currentUserRating?.comment ?? "",
+            submitting: false,
+          }
+        }
+        return next
+      })
+    } catch (error) {
+      setMealInstances([])
+    } finally {
+      setMealsLoading(false)
+    }
+  }, [selectedRecipe])
+
+  useEffect(() => {
+    void loadRecipes()
+  }, [loadRecipes])
+
+  useEffect(() => {
+    void loadMeals()
+  }, [loadMeals])
+
+  useEffect(() => {
+    setServeMealName(selectedRecipe?.titleEn ?? "")
+    setServeResidents(selectedRecipe?.audienceUserIds.join(", ") ?? "")
+  }, [selectedRecipe])
+
+  const selectedIngredientChecklist = useMemo(() => {
+    const map: Record<string, boolean> = {}
+    if (!selectedRecipe) return map
+    for (const ingredient of selectedRecipe.ingredients) {
+      map[ingredient.id] = false
+    }
+    return map
+  }, [selectedRecipe])
+
+  const [checkedIngredients, setCheckedIngredients] = useState<Record<string, boolean>>({})
+
+  useEffect(() => {
+    setCheckedIngredients(selectedIngredientChecklist)
+  }, [selectedIngredientChecklist])
+
+  const handleSeed = async () => {
+    if (!isAdmin) return
+    setSeedMessage("Seeding recipes...")
+    try {
+      const result = await apiFetch<SeedResponse>("/api/recipes/seed", {
+        method: "POST",
+        label: "RecipeSeed",
+        body: { force: false },
+      })
+      const inserted = result?.seed?.inserted ?? 0
+      const skipped = result?.seed?.skipped ?? 0
+      const existing = result?.seed?.existingCount ?? 0
+      setSeedMessage(
+        `Seed complete. inserted ${inserted}, skipped ${skipped}. Existing recipes in datastore: ${existing}.`
+      )
+      await loadRecipes()
+    } catch (error) {
+      setSeedMessage(error instanceof Error ? error.message : "Recipe seed failed")
+    }
+  }
+
+  const submitRating = async (mealId: string) => {
+    const draft = ratingInputs[mealId]
+    if (!draft?.score || !selectedRecipe) return
+
+    setRatingInputs((state) => ({
+      ...state,
+      [mealId]: {
+        ...state[mealId],
+        submitting: true,
+        submittedMessage: undefined,
+      },
+    }))
+
+    const rating = draft.score
+    if (!clampScore(rating)) {
+      setRatingInputs((state) => ({
+        ...state,
+        [mealId]: {
+          ...state[mealId],
+          submitting: false,
+          submittedMessage: "Please select a score from 1 to 5.",
+        },
+      }))
+      return
+    }
+
+    const taskId = mealInstances.find((meal) => meal.id === mealId)?.ratingTaskId
+    try {
+      const response = await apiFetch<{ summary: MealSummary }>("/api/recipes/" + selectedRecipe.id + "/ratings", {
+        method: "POST",
+        label: "RecipeRating",
+        body: {
+          mealInstanceId: mealId,
+          score: rating,
+          comment: draft.comment.trim() || undefined,
+          ...(taskId ? { taskId } : {}),
+        },
+      })
+      setRatingInputs((state) => ({
+        ...state,
+        [mealId]: {
+          ...state[mealId],
+          submitting: false,
+          submittedMessage: `Saved. ${
+            response.summary?.totalRatings ? `Meal average ${response.summary.averageScore.toFixed(2)}` : "Rating saved."
+          }`,
+        },
+      }))
+      await loadMeals()
+      await loadRecipes()
+    } catch (error) {
+      setRatingInputs((state) => ({
+        ...state,
+        [mealId]: {
+          ...state[mealId],
+          submitting: false,
+          submittedMessage: error instanceof Error ? error.message : "Failed to save rating",
+        },
+      }))
+    }
+  }
+
+  const handleServe = async () => {
+    if (!selectedRecipe || !isAdmin) return
+    setServeInProgress(true)
+    setServeMessage("Creating serving record...")
+
+    const residentUserIds = serveResidents
+      .split(",")
+      .map((value) => value.trim().toLowerCase())
+      .filter((value) => value.length > 0)
+    try {
+      const response = await apiFetch<ServeResponse>(`/api/recipes/${selectedRecipe.id}/serve`, {
+        method: "POST",
+        label: "RecipeServe",
+        body: {
+          mealName: serveMealName.trim() || selectedRecipe.titleEn,
+          residentUserIds,
+          createRatingTasks: true,
+        },
+      })
+      const mealName = response?.mealInstance?.mealName || serveMealName.trim() || selectedRecipe.titleEn
+      setServeMessage(`Meal served: ${mealName}. Residents will receive rating tasks automatically.`)
+      await loadMeals()
+      await loadRecipes()
+    } catch (error) {
+      setServeMessage(error instanceof Error ? error.message : "Failed to serve recipe")
+    } finally {
+      setServeInProgress(false)
+    }
+  }
+
+  const toggleIngredient = (ingredientId: string) => {
+    setCheckedIngredients((state) => ({ ...state, [ingredientId]: !state[ingredientId] }))
+  }
+
+  if (loading && recipes.length === 0) {
+    return (
+      <div className="rounded-2xl border border-border bg-card p-10 text-center text-sm text-muted-foreground">
+        <Loader2 className="mx-auto mb-3 h-5 w-5 animate-spin" />
+        Loading recipes…
+      </div>
+    )
+  }
+
+  if (error && recipes.length === 0) {
+    return (
+      <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-6 text-sm text-destructive">
+        {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm uppercase tracking-wide text-muted-foreground">Kitchen recipes</p>
+          <h1 className="text-3xl font-semibold text-foreground">Meal planning & kitchen feedback</h1>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+            onClick={() => {
+              setLanguage("en")
+            }}
+            disabled={language === "en"}
+          >
+            EN
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+            onClick={() => {
+              setLanguage("af")
+            }}
+            disabled={language === "af"}
+          >
+            AF
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+            onClick={() => {
+              setLanguage("both")
+            }}
+            disabled={language === "both"}
+          >
+            EN + AF
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+            onClick={loadRecipes}
+            disabled={loading}
+          >
+            <RefreshCw className="h-4 w-4" />
+            Refresh
+          </button>
+          {isAdmin && (
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-lg border border-emerald-600/30 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-600 hover:bg-emerald-500/20"
+              onClick={handleSeed}
+            >
+              <Save className="h-4 w-4" />
+              Seed sample recipes
+            </button>
+          )}
+        </div>
+      </div>
+      {seedMessage && <p className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">{seedMessage}</p>}
+      <p className="text-sm text-muted-foreground">
+        Viewing in <span className="font-semibold">{LANG_LABELS[language]}</span> mode.
+      </p>
+
+      {recipes.length === 0 ? (
+        <div className="rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground">
+          No recipes are available yet.
+          {isAdmin ? ' Use "Seed sample recipes" to get started.' : ""}
+        </div>
+      ) : (
+        <div className="grid gap-6 xl:grid-cols-[380px_1fr]">
+          <aside className="space-y-3">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Recipe list</h2>
+            <div className="space-y-2">
+              {recipes.map((recipe) => {
+                const selected = recipe.id === selectedRecipeId
+                return (
+                  <button
+                    key={recipe.id}
+                    type="button"
+                    onClick={() => setSelectedRecipeId(recipe.id)}
+                    className={`w-full rounded-xl border p-3 text-left transition ${
+                      selected ? "border-primary/50 bg-primary/5" : "border-border hover:border-primary/30"
+                    }`}
+                  >
+                    <p className="font-medium text-foreground">{recipeTitle(recipe, language)}</p>
+                    <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                      {recipeSummary(recipe, language)}
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      <span className="inline-flex items-center gap-1">
+                        <Clock4 className="h-3.5 w-3.5" />
+                        {recipe.prepMinutes !== undefined ? `${recipe.prepMinutes}m prep` : "prep time N/A"}
+                      </span>
+                      <span className="inline-flex items-center gap-1">
+                        <Utensils className="h-3.5 w-3.5" />
+                        {recipe.cookMinutes !== undefined ? `${recipe.cookMinutes}m cook` : "cook time N/A"}
+                      </span>
+                    </div>
+                    {!!recipe.ratingSummary && (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        <Star className="mr-1 inline h-3.5 w-3.5 align-text-bottom text-amber-500" />
+                        {recipe.ratingSummary.totalRatings > 0
+                          ? `${recipe.ratingSummary.averageScore.toFixed(2)}/5`
+                          : "No ratings yet"}
+                      </p>
+                    )}
+                    {isAdmin && recipe.status === "draft" && (
+                      <p className="mt-1 text-xs uppercase text-amber-500">Draft</p>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          </aside>
+
+          <section className="space-y-6">
+            {selectedRecipe ? (
+              <article className="rounded-2xl border border-border bg-card">
+                <div className="border-b border-border p-5">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h2 className="text-2xl font-semibold">{recipeTitle(selectedRecipe, language)}</h2>
+                      <p className="mt-2 whitespace-pre-line text-sm text-muted-foreground">
+                        {recipeSummary(selectedRecipe, language)}
+                      </p>
+                    </div>
+                    <span className="text-sm text-muted-foreground">
+                      {selectedRecipe.category ? selectedRecipe.category : "General"}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    <ChefHat className="mr-2 inline h-4 w-4" />
+                    Served rating:{" "}
+                    {selectedRecipe.ratingSummary?.totalRatings
+                      ? `${selectedRecipe.ratingSummary.averageScore.toFixed(2)} (${selectedRecipe.ratingSummary.totalRatings})`
+                      : "No ratings yet"}
+                  </p>
+                </div>
+                <div className="grid gap-6 p-5 sm:grid-cols-2">
+                  <img
+                    src={selectedRecipe.image.url}
+                    alt={selectedRecipe.titleEn}
+                    className="h-56 w-full rounded-xl border border-border object-cover"
+                  />
+                  <div className="space-y-2 text-sm">
+                    <p className="text-muted-foreground">
+                      <span className="font-semibold text-foreground">Source:</span>{" "}
+                      {selectedRecipe.image.source}
+                    </p>
+                    <p className="text-muted-foreground">
+                      <span className="font-semibold text-foreground">License:</span>{" "}
+                      {selectedRecipe.image.license}
+                    </p>
+                    <p className="text-muted-foreground">
+                      <span className="font-semibold text-foreground">Attribution:</span>{" "}
+                      {selectedRecipe.image.attributionText}
+                    </p>
+                    <p className="text-muted-foreground">
+                      <span className="font-semibold text-foreground">Servings:</span>{" "}
+                      {selectedRecipe.servings ?? "N/A"}
+                    </p>
+                    <p className="text-muted-foreground">
+                      <span className="font-semibold text-foreground">Prep / Cook:</span>{" "}
+                      {selectedRecipe.prepMinutes ?? "N/A"} min / {selectedRecipe.cookMinutes ?? "N/A"} min
+                    </p>
+                    {selectedRecipe.image.author && (
+                      <p className="text-muted-foreground">
+                        <span className="font-semibold text-foreground">Image credit:</span>{" "}
+                        {selectedRecipe.image.author}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div className="space-y-4 border-t border-border p-5">
+                  <h3 className="text-lg font-semibold">Ingredients</h3>
+                  <ul className="space-y-2">
+                    {selectedRecipe.ingredients.map((ingredient) => {
+                      const label = recipeSectionText(ingredient, language, "instructions")
+                      return (
+                        <li key={ingredient.id} className="flex items-start gap-2 text-sm">
+                          <input
+                            type="checkbox"
+                            checked={Boolean(checkedIngredients[ingredient.id])}
+                            onChange={() => toggleIngredient(ingredient.id)}
+                            className="mt-1"
+                          />
+                          <span className="text-foreground">
+                            <span className="font-medium">{ingredient.name}</span>{" "}
+                            <span className="text-muted-foreground">
+                              {ingredient.quantity ? `${ingredient.quantity} ` : ""}
+                              {ingredient.unit ?? ""}
+                              {label ? ` · ${label}` : ""}
+                            </span>
+                          </span>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </div>
+                <div className="space-y-4 border-t border-border p-5">
+                  <h3 className="text-lg font-semibold">Steps</h3>
+                  <ol className="space-y-3">
+                    {[...selectedRecipe.steps]
+                      .sort((left, right) => left.order - right.order)
+                      .map((step) => {
+                        const text = modeText(step, language)
+                        return (
+                          <li key={step.id} className="rounded-lg border border-border p-3 text-sm">
+                            <p className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+                              Step {step.order}
+                            </p>
+                            <p className="text-foreground whitespace-pre-line">{text}</p>
+                            {step.timerMinutes !== undefined && (
+                              <p className="mt-2 text-xs text-muted-foreground">Timer: {step.timerMinutes} min</p>
+                            )}
+                          </li>
+                        )
+                      })}
+                  </ol>
+                </div>
+              </article>
+            ) : null}
+
+            <div className="grid gap-6 xl:grid-cols-2">
+              <section className="rounded-2xl border border-border bg-card">
+                <div className="border-b border-border p-4">
+                  <h3 className="font-semibold">Serve this recipe</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Creates resident rating tasks so everyone assigned can submit feedback.
+                  </p>
+                </div>
+                <div className="space-y-3 p-4">
+                  {isAdmin ? (
+                    <>
+                      <label className="block text-sm text-muted-foreground">
+                        Meal name
+                        <input
+                          value={serveMealName}
+                          onChange={(event) => setServeMealName(event.target.value)}
+                          className="mt-1 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                          placeholder="Optional meal title"
+                        />
+                      </label>
+                      <label className="block text-sm text-muted-foreground">
+                        Resident users (comma-separated)
+                        <input
+                          value={serveResidents}
+                          onChange={(event) => setServeResidents(event.target.value)}
+                          className="mt-1 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                          placeholder="irma, charl, lucky"
+                        />
+                      </label>
+                      <button
+                        type="button"
+                        onClick={handleServe}
+                        disabled={serveInProgress || !selectedRecipe}
+                        className="inline-flex items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                      >
+                        <Send className="h-4 w-4" />
+                        {serveInProgress ? "Sending..." : "Create meal & rating tasks"}
+                      </button>
+                      {serveMessage && <p className="text-sm text-muted-foreground">{serveMessage}</p>}
+                    </>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Only admins can create meal tasks from this screen.
+                    </p>
+                  )}
+                </div>
+              </section>
+
+              <section className="rounded-2xl border border-border bg-card">
+                <div className="border-b border-border p-4">
+                  <h3 className="font-semibold">Meal ratings</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Submit 1-5 score for each assigned meal so repeats can use recent feedback.
+                  </p>
+                </div>
+                <div className="space-y-4 p-4">
+                  {mealsLoading ? (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Loading meal history…
+                    </div>
+                  ) : mealInstances.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      No served meal instances for this recipe yet.
+                    </p>
+                  ) : (
+                    mealInstances.map((meal) => {
+                      const draft = ratingInputs[meal.id] ?? { score: null, comment: "", submitting: false }
+                      return (
+                        <div key={meal.id} className="rounded-lg border border-border p-3">
+                          <div className="mb-3 flex items-start justify-between gap-3">
+                            <div>
+                              <p className="font-medium text-foreground">
+                                {meal.mealName || selectedRecipe?.titleEn || "Meal"}
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                {formatDateTime(meal.servedAt)} · {meal.residentUserIds.join(", ")}{" "}
+                                {meal.servedBy ? `· served by ${meal.servedBy}` : ""}
+                              </p>
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                              <span className="inline-flex items-center gap-1">
+                                <Star className="h-3.5 w-3.5 text-amber-500" />
+                                {meal.summary.totalRatings > 0
+                                  ? `${meal.summary.averageScore.toFixed(2)} (${meal.summary.totalRatings})`
+                                  : "No ratings"}
+                              </span>
+                            </p>
+                          </div>
+                          {meal.currentUserRating ? (
+                            <p className="text-xs text-muted-foreground">
+                              Your last rating: {meal.currentUserRating.score}/5
+                              {meal.currentUserRating.submittedAt
+                                ? ` · ${formatDateTime(meal.currentUserRating.submittedAt)}`
+                                : ""}
+                            </p>
+                          ) : null}
+                          {meal.canRate ? (
+                            <div className="mt-3 space-y-2">
+                              <div className="flex flex-wrap gap-2">
+                                {[1, 2, 3, 4, 5].map((score) => (
+                                  <button
+                                    key={score}
+                                    type="button"
+                                    onClick={() =>
+                                      setRatingInputs((state) => ({
+                                        ...state,
+                                        [meal.id]: { ...state[meal.id], score },
+                                      }))
+                                    }
+                                    className={`rounded-md px-3 py-1.5 text-sm ${
+                                      draft.score === score
+                                        ? "bg-primary text-primary-foreground"
+                                        : "bg-muted text-muted-foreground hover:bg-muted/70"
+                                    }`}
+                                  >
+                                    {score}
+                                  </button>
+                                ))}
+                              </div>
+                              <label className="block text-xs text-muted-foreground">
+                                Comment
+                                <textarea
+                                  value={draft.comment}
+                                  onChange={(event) =>
+                                    setRatingInputs((state) => ({
+                                      ...state,
+                                      [meal.id]: { ...state[meal.id], comment: event.target.value },
+                                    }))
+                                  }
+                                  className="mt-1 block h-20 w-full rounded-md border border-border bg-background px-3 py-2 text-xs"
+                                  placeholder="Optional"
+                                />
+                              </label>
+                              <div className="flex items-center justify-between gap-3">
+                                <button
+                                  type="button"
+                                  onClick={() => void submitRating(meal.id)}
+                                  disabled={draft.score === null || draft.submitting}
+                                  className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-40"
+                                >
+                                  <Save className="h-4 w-4" />
+                                  {draft.submitting ? "Saving..." : "Save rating"}
+                                </button>
+                                {draft.submittedMessage && (
+                                  <span className="text-xs text-muted-foreground">{draft.submittedMessage}</span>
+                                )}
+                              </div>
+                              {meal.ratingTaskCount > 0 ? (
+                                <p className="text-xs text-muted-foreground">
+                                  {meal.ratingTaskCount} active rating task{meal.ratingTaskCount === 1 ? "" : "s"}
+                                  {meal.ratingTaskId ? `; your task: ${meal.ratingTaskId}` : ""}
+                                </p>
+                              ) : (
+                                <p className="text-xs text-muted-foreground">
+                                  No rating tasks were created for this serving.
+                                </p>
+                              )}
+                            </div>
+                          ) : (
+                            <p className="text-xs text-muted-foreground">
+                              You are not assigned to this meal instance.
+                            </p>
+                          )}
+                        </div>
+                      )
+                    })
+                  )}
+                </div>
+              </section>
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function modeText(entity: RecipeIngredient | RecipeStep, language: LanguageMode): string {
+  if (language === "af") {
+    return "preparationNote" in entity
+      ? entity.preparationNote ?? ""
+      : entity.instructionAf
+  }
+  if (language === "en") {
+    return "preparationNote" in entity
+      ? entity.preparationNote ?? ""
+      : entity.instructionEn
+  }
+  const enText = "preparationNote" in entity ? entity.preparationNote ?? "" : entity.instructionEn
+  const afText = "preparationNote" in entity ? entity.preparationNote ?? "" : entity.instructionAf
+  return `${toListText(enText, "")}${enText && afText ? " / " : ""}${afText}`
+}

--- a/components/recipes/recipe-catalog-client.tsx
+++ b/components/recipes/recipe-catalog-client.tsx
@@ -2,8 +2,14 @@
 
 import { useAuth } from "@/lib/auth-context"
 import { apiFetch } from "@/lib/api-client"
-import { type RecipeIngredient, type RecipeRecord, type RecipeRatingSummary, type RecipeStep } from "@/lib/recipes"
+import {
+  type RecipeIngredient,
+  type RecipeRecord,
+  type RecipeRatingSummary,
+  type RecipeStep,
+} from "@/lib/recipes"
 import { Clock4, ChefHat, Loader2, RefreshCw, Save, Send, Star, Utensils } from "lucide-react"
+import Image from "next/image"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
 interface RecipeListItem extends RecipeRecord {
@@ -102,20 +108,15 @@ function recipeSummary(recipe: RecipeListItem, mode: LanguageMode): string {
 }
 
 function recipeSectionText(entity: RecipeStep | RecipeIngredient, mode: LanguageMode): string {
+  if (!("instructionEn" in entity)) return entity.preparationNote ?? ""
   if (mode === "af") {
-    return "preparationNote" in entity
-      ? entity.preparationNote ?? ""
-      : (entity as RecipeStep).instructionAf ?? ""
+    return entity.instructionAf ?? ""
   }
   if (mode === "en") {
-    return "preparationNote" in entity
-      ? entity.preparationNote ?? ""
-      : (entity as RecipeStep).instructionEn ?? ""
+    return entity.instructionEn ?? ""
   }
-  const enText =
-    "preparationNote" in entity ? entity.preparationNote ?? "" : (entity as RecipeStep).instructionEn ?? ""
-  const afText =
-    "preparationNote" in entity ? entity.preparationNote ?? "" : (entity as RecipeStep).instructionAf ?? ""
+  const enText = entity.instructionEn ?? ""
+  const afText = entity.instructionAf ?? ""
   return `${enText}${enText ? " / " : ""}${afText}`
 }
 
@@ -129,8 +130,12 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
   const [language, setLanguage] = useState<LanguageMode>("both")
   const [mealInstances, setMealInstances] = useState<MealInstance[]>([])
   const [mealsLoading, setMealsLoading] = useState(false)
+  const [mealsError, setMealsError] = useState("")
   const [ratingInputs, setRatingInputs] = useState<
-    Record<string, { score: number | null; comment: string; submitting: boolean; submittedMessage?: string }>
+    Record<
+      string,
+      { score: number | null; comment: string; submitting: boolean; submittedMessage?: string }
+    >
   >({})
   const [seedMessage, setSeedMessage] = useState<string>("")
   const [serveInProgress, setServeInProgress] = useState(false)
@@ -158,7 +163,9 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
       })
       const next = data?.recipes ?? []
       setRecipes(next)
-      setSelectedRecipeId((current) => (current && next.some((recipe) => recipe.id === current) ? current : (next[0]?.id ?? "")))
+      setSelectedRecipeId((current) =>
+        current && next.some((recipe) => recipe.id === current) ? current : (next[0]?.id ?? "")
+      )
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load recipes")
     } finally {
@@ -169,6 +176,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
   const loadMeals = useCallback(async () => {
     if (!selectedRecipe) return
     setMealsLoading(true)
+    setMealsError("")
     try {
       const data = await apiFetch<MealListResponse>(`/api/recipes/${selectedRecipe.id}/meals`, {
         label: "RecipeMeals",
@@ -189,6 +197,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
       })
     } catch (error) {
       setMealInstances([])
+      setMealsError(error instanceof Error ? error.message : "Failed to load meal history")
     } finally {
       setMealsLoading(false)
     }
@@ -271,23 +280,28 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
 
     const taskId = mealInstances.find((meal) => meal.id === mealId)?.ratingTaskId
     try {
-      const response = await apiFetch<{ summary: MealSummary }>("/api/recipes/" + selectedRecipe.id + "/ratings", {
-        method: "POST",
-        label: "RecipeRating",
-        body: {
-          mealInstanceId: mealId,
-          score: rating,
-          comment: draft.comment.trim() || undefined,
-          ...(taskId ? { taskId } : {}),
-        },
-      })
+      const response = await apiFetch<{ summary: MealSummary }>(
+        "/api/recipes/" + selectedRecipe.id + "/ratings",
+        {
+          method: "POST",
+          label: "RecipeRating",
+          body: {
+            mealInstanceId: mealId,
+            score: rating,
+            comment: draft.comment.trim() || undefined,
+            ...(taskId ? { taskId } : {}),
+          },
+        }
+      )
       setRatingInputs((state) => ({
         ...state,
         [mealId]: {
           ...state[mealId],
           submitting: false,
           submittedMessage: `Saved. ${
-            response.summary?.totalRatings ? `Meal average ${response.summary.averageScore.toFixed(2)}` : "Rating saved."
+            response.summary?.totalRatings
+              ? `Meal average ${response.summary.averageScore.toFixed(2)}`
+              : "Rating saved."
           }`,
         },
       }))
@@ -324,8 +338,11 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
           createRatingTasks: true,
         },
       })
-      const mealName = response?.mealInstance?.mealName || serveMealName.trim() || selectedRecipe.titleEn
-      setServeMessage(`Meal served: ${mealName}. Residents will receive rating tasks automatically.`)
+      const mealName =
+        response?.mealInstance?.mealName || serveMealName.trim() || selectedRecipe.titleEn
+      setServeMessage(
+        `Meal served: ${mealName}. Residents will receive rating tasks automatically.`
+      )
       await loadMeals()
       await loadRecipes()
     } catch (error) {
@@ -341,7 +358,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
 
   if (loading && recipes.length === 0) {
     return (
-      <div className="rounded-2xl border border-border bg-card p-10 text-center text-sm text-muted-foreground">
+      <div className="border-border bg-card text-muted-foreground rounded-2xl border p-10 text-center text-sm">
         <Loader2 className="mx-auto mb-3 h-5 w-5 animate-spin" />
         Loading recipes…
       </div>
@@ -350,7 +367,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
 
   if (error && recipes.length === 0) {
     return (
-      <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-6 text-sm text-destructive">
+      <div className="border-destructive/40 bg-destructive/10 text-destructive rounded-2xl border p-6 text-sm">
         {error}
       </div>
     )
@@ -360,13 +377,15 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
     <div className="space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <p className="text-sm uppercase tracking-wide text-muted-foreground">Kitchen recipes</p>
-          <h1 className="text-3xl font-semibold text-foreground">Meal planning & kitchen feedback</h1>
+          <p className="text-muted-foreground text-sm tracking-wide uppercase">Kitchen recipes</p>
+          <h1 className="text-foreground text-3xl font-semibold">
+            Meal planning & kitchen feedback
+          </h1>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <button
             type="button"
-            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+            className="border-border bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
             onClick={() => {
               setLanguage("en")
             }}
@@ -376,7 +395,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
           </button>
           <button
             type="button"
-            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+            className="border-border bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
             onClick={() => {
               setLanguage("af")
             }}
@@ -386,7 +405,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
           </button>
           <button
             type="button"
-            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+            className="border-border bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
             onClick={() => {
               setLanguage("both")
             }}
@@ -396,7 +415,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
           </button>
           <button
             type="button"
-            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+            className="border-border bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
             onClick={loadRecipes}
             disabled={loading}
           >
@@ -415,20 +434,24 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
           )}
         </div>
       </div>
-      {seedMessage && <p className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">{seedMessage}</p>}
-      <p className="text-sm text-muted-foreground">
+      {seedMessage && (
+        <p className="bg-muted text-muted-foreground rounded-lg p-3 text-sm">{seedMessage}</p>
+      )}
+      <p className="text-muted-foreground text-sm">
         Viewing in <span className="font-semibold">{LANG_LABELS[language]}</span> mode.
       </p>
 
       {recipes.length === 0 ? (
-        <div className="rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground">
+        <div className="border-border bg-card text-muted-foreground rounded-xl border p-6 text-sm">
           No recipes are available yet.
           {isAdmin ? ' Use "Seed sample recipes" to get started.' : ""}
         </div>
       ) : (
         <div className="grid gap-6 xl:grid-cols-[380px_1fr]">
           <aside className="space-y-3">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Recipe list</h2>
+            <h2 className="text-muted-foreground text-sm font-semibold tracking-wide uppercase">
+              Recipe list
+            </h2>
             <div className="space-y-2">
               {recipes.map((recipe) => {
                 const selected = recipe.id === selectedRecipeId
@@ -438,25 +461,31 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
                     type="button"
                     onClick={() => setSelectedRecipeId(recipe.id)}
                     className={`w-full rounded-xl border p-3 text-left transition ${
-                      selected ? "border-primary/50 bg-primary/5" : "border-border hover:border-primary/30"
+                      selected
+                        ? "border-primary/50 bg-primary/5"
+                        : "border-border hover:border-primary/30"
                     }`}
                   >
-                    <p className="font-medium text-foreground">{recipeTitle(recipe, language)}</p>
-                    <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                    <p className="text-foreground font-medium">{recipeTitle(recipe, language)}</p>
+                    <p className="text-muted-foreground mt-1 line-clamp-2 text-xs">
                       {recipeSummary(recipe, language)}
                     </p>
-                    <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    <div className="text-muted-foreground mt-2 flex flex-wrap gap-2 text-xs">
                       <span className="inline-flex items-center gap-1">
                         <Clock4 className="h-3.5 w-3.5" />
-                        {recipe.prepMinutes !== undefined ? `${recipe.prepMinutes}m prep` : "prep time N/A"}
+                        {recipe.prepMinutes !== undefined
+                          ? `${recipe.prepMinutes}m prep`
+                          : "prep time N/A"}
                       </span>
                       <span className="inline-flex items-center gap-1">
                         <Utensils className="h-3.5 w-3.5" />
-                        {recipe.cookMinutes !== undefined ? `${recipe.cookMinutes}m cook` : "cook time N/A"}
+                        {recipe.cookMinutes !== undefined
+                          ? `${recipe.cookMinutes}m cook`
+                          : "cook time N/A"}
                       </span>
                     </div>
                     {!!recipe.ratingSummary && (
-                      <p className="mt-2 text-xs text-muted-foreground">
+                      <p className="text-muted-foreground mt-2 text-xs">
                         <Star className="mr-1 inline h-3.5 w-3.5 align-text-bottom text-amber-500" />
                         {recipe.ratingSummary.totalRatings > 0
                           ? `${recipe.ratingSummary.averageScore.toFixed(2)}/5`
@@ -464,7 +493,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
                       </p>
                     )}
                     {isAdmin && recipe.status === "draft" && (
-                      <p className="mt-1 text-xs uppercase text-amber-500">Draft</p>
+                      <p className="mt-1 text-xs text-amber-500 uppercase">Draft</p>
                     )}
                   </button>
                 )
@@ -474,20 +503,22 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
 
           <section className="space-y-6">
             {selectedRecipe ? (
-              <article className="rounded-2xl border border-border bg-card">
-                <div className="border-b border-border p-5">
+              <article className="border-border bg-card rounded-2xl border">
+                <div className="border-border border-b p-5">
                   <div className="flex items-start justify-between gap-4">
                     <div>
-                      <h2 className="text-2xl font-semibold">{recipeTitle(selectedRecipe, language)}</h2>
-                      <p className="mt-2 whitespace-pre-line text-sm text-muted-foreground">
+                      <h2 className="text-2xl font-semibold">
+                        {recipeTitle(selectedRecipe, language)}
+                      </h2>
+                      <p className="text-muted-foreground mt-2 text-sm whitespace-pre-line">
                         {recipeSummary(selectedRecipe, language)}
                       </p>
                     </div>
-                    <span className="text-sm text-muted-foreground">
+                    <span className="text-muted-foreground text-sm">
                       {selectedRecipe.category ? selectedRecipe.category : "General"}
                     </span>
                   </div>
-                  <p className="mt-2 text-sm text-muted-foreground">
+                  <p className="text-muted-foreground mt-2 text-sm">
                     <ChefHat className="mr-2 inline h-4 w-4" />
                     Served rating:{" "}
                     {selectedRecipe.ratingSummary?.totalRatings
@@ -496,45 +527,48 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
                   </p>
                 </div>
                 <div className="grid gap-6 p-5 sm:grid-cols-2">
-                  <img
+                  <Image
                     src={selectedRecipe.image.url}
                     alt={selectedRecipe.titleEn}
-                    className="h-56 w-full rounded-xl border border-border object-cover"
+                    width={800}
+                    height={450}
+                    className="border-border h-56 w-full rounded-xl border object-cover"
                   />
                   <div className="space-y-2 text-sm">
                     <p className="text-muted-foreground">
-                      <span className="font-semibold text-foreground">Source:</span>{" "}
+                      <span className="text-foreground font-semibold">Source:</span>{" "}
                       {selectedRecipe.image.source}
                     </p>
                     <p className="text-muted-foreground">
-                      <span className="font-semibold text-foreground">License:</span>{" "}
+                      <span className="text-foreground font-semibold">License:</span>{" "}
                       {selectedRecipe.image.license}
                     </p>
                     <p className="text-muted-foreground">
-                      <span className="font-semibold text-foreground">Attribution:</span>{" "}
+                      <span className="text-foreground font-semibold">Attribution:</span>{" "}
                       {selectedRecipe.image.attributionText}
                     </p>
                     <p className="text-muted-foreground">
-                      <span className="font-semibold text-foreground">Servings:</span>{" "}
+                      <span className="text-foreground font-semibold">Servings:</span>{" "}
                       {selectedRecipe.servings ?? "N/A"}
                     </p>
                     <p className="text-muted-foreground">
-                      <span className="font-semibold text-foreground">Prep / Cook:</span>{" "}
-                      {selectedRecipe.prepMinutes ?? "N/A"} min / {selectedRecipe.cookMinutes ?? "N/A"} min
+                      <span className="text-foreground font-semibold">Prep / Cook:</span>{" "}
+                      {selectedRecipe.prepMinutes ?? "N/A"} min /{" "}
+                      {selectedRecipe.cookMinutes ?? "N/A"} min
                     </p>
                     {selectedRecipe.image.author && (
                       <p className="text-muted-foreground">
-                        <span className="font-semibold text-foreground">Image credit:</span>{" "}
+                        <span className="text-foreground font-semibold">Image credit:</span>{" "}
                         {selectedRecipe.image.author}
                       </p>
                     )}
                   </div>
                 </div>
-                <div className="space-y-4 border-t border-border p-5">
+                <div className="border-border space-y-4 border-t p-5">
                   <h3 className="text-lg font-semibold">Ingredients</h3>
                   <ul className="space-y-2">
                     {selectedRecipe.ingredients.map((ingredient) => {
-                      const label = recipeSectionText(ingredient, language, "instructions")
+                      const label = recipeSectionText(ingredient, language)
                       return (
                         <li key={ingredient.id} className="flex items-start gap-2 text-sm">
                           <input
@@ -556,21 +590,23 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
                     })}
                   </ul>
                 </div>
-                <div className="space-y-4 border-t border-border p-5">
+                <div className="border-border space-y-4 border-t p-5">
                   <h3 className="text-lg font-semibold">Steps</h3>
                   <ol className="space-y-3">
                     {[...selectedRecipe.steps]
                       .sort((left, right) => left.order - right.order)
                       .map((step) => {
-                        const text = modeText(step, language)
+                        const text = recipeSectionText(step, language)
                         return (
-                          <li key={step.id} className="rounded-lg border border-border p-3 text-sm">
-                            <p className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+                          <li key={step.id} className="border-border rounded-lg border p-3 text-sm">
+                            <p className="text-muted-foreground mb-2 flex items-center gap-2 text-xs font-semibold uppercase">
                               Step {step.order}
                             </p>
                             <p className="text-foreground whitespace-pre-line">{text}</p>
                             {step.timerMinutes !== undefined && (
-                              <p className="mt-2 text-xs text-muted-foreground">Timer: {step.timerMinutes} min</p>
+                              <p className="text-muted-foreground mt-2 text-xs">
+                                Timer: {step.timerMinutes} min
+                              </p>
                             )}
                           </li>
                         )
@@ -581,31 +617,31 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
             ) : null}
 
             <div className="grid gap-6 xl:grid-cols-2">
-              <section className="rounded-2xl border border-border bg-card">
-                <div className="border-b border-border p-4">
+              <section className="border-border bg-card rounded-2xl border">
+                <div className="border-border border-b p-4">
                   <h3 className="font-semibold">Serve this recipe</h3>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-muted-foreground text-sm">
                     Creates resident rating tasks so everyone assigned can submit feedback.
                   </p>
                 </div>
                 <div className="space-y-3 p-4">
                   {isAdmin ? (
                     <>
-                      <label className="block text-sm text-muted-foreground">
+                      <label className="text-muted-foreground block text-sm">
                         Meal name
                         <input
                           value={serveMealName}
                           onChange={(event) => setServeMealName(event.target.value)}
-                          className="mt-1 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                          className="border-border bg-background mt-1 block w-full rounded-md border px-3 py-2 text-sm"
                           placeholder="Optional meal title"
                         />
                       </label>
-                      <label className="block text-sm text-muted-foreground">
+                      <label className="text-muted-foreground block text-sm">
                         Resident users (comma-separated)
                         <input
                           value={serveResidents}
                           onChange={(event) => setServeResidents(event.target.value)}
-                          className="mt-1 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                          className="border-border bg-background mt-1 block w-full rounded-md border px-3 py-2 text-sm"
                           placeholder="irma, charl, lucky"
                         />
                       </label>
@@ -613,53 +649,66 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
                         type="button"
                         onClick={handleServe}
                         disabled={serveInProgress || !selectedRecipe}
-                        className="inline-flex items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                        className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium disabled:opacity-50"
                       >
                         <Send className="h-4 w-4" />
                         {serveInProgress ? "Sending..." : "Create meal & rating tasks"}
                       </button>
-                      {serveMessage && <p className="text-sm text-muted-foreground">{serveMessage}</p>}
+                      {serveMessage && (
+                        <p className="text-muted-foreground text-sm">{serveMessage}</p>
+                      )}
                     </>
                   ) : (
-                    <p className="text-sm text-muted-foreground">
+                    <p className="text-muted-foreground text-sm">
                       Only admins can create meal tasks from this screen.
                     </p>
                   )}
                 </div>
               </section>
 
-              <section className="rounded-2xl border border-border bg-card">
-                <div className="border-b border-border p-4">
+              <section className="border-border bg-card rounded-2xl border">
+                <div className="border-border border-b p-4">
                   <h3 className="font-semibold">Meal ratings</h3>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-muted-foreground text-sm">
                     Submit 1-5 score for each assigned meal so repeats can use recent feedback.
                   </p>
                 </div>
                 <div className="space-y-4 p-4">
                   {mealsLoading ? (
-                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <div className="text-muted-foreground flex items-center gap-2 text-sm">
                       <Loader2 className="h-4 w-4 animate-spin" /> Loading meal history…
                     </div>
+                  ) : mealsError ? (
+                    <p
+                      className="bg-destructive/10 text-destructive rounded-lg p-3 text-sm"
+                      role="alert"
+                    >
+                      {mealsError}
+                    </p>
                   ) : mealInstances.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
+                    <p className="text-muted-foreground text-sm">
                       No served meal instances for this recipe yet.
                     </p>
                   ) : (
                     mealInstances.map((meal) => {
-                      const draft = ratingInputs[meal.id] ?? { score: null, comment: "", submitting: false }
+                      const draft = ratingInputs[meal.id] ?? {
+                        score: null,
+                        comment: "",
+                        submitting: false,
+                      }
                       return (
-                        <div key={meal.id} className="rounded-lg border border-border p-3">
+                        <div key={meal.id} className="border-border rounded-lg border p-3">
                           <div className="mb-3 flex items-start justify-between gap-3">
                             <div>
-                              <p className="font-medium text-foreground">
+                              <p className="text-foreground font-medium">
                                 {meal.mealName || selectedRecipe?.titleEn || "Meal"}
                               </p>
-                              <p className="text-xs text-muted-foreground">
+                              <p className="text-muted-foreground text-xs">
                                 {formatDateTime(meal.servedAt)} · {meal.residentUserIds.join(", ")}{" "}
                                 {meal.servedBy ? `· served by ${meal.servedBy}` : ""}
                               </p>
                             </div>
-                            <p className="text-xs text-muted-foreground">
+                            <p className="text-muted-foreground text-xs">
                               <span className="inline-flex items-center gap-1">
                                 <Star className="h-3.5 w-3.5 text-amber-500" />
                                 {meal.summary.totalRatings > 0
@@ -669,7 +718,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
                             </p>
                           </div>
                           {meal.currentUserRating ? (
-                            <p className="text-xs text-muted-foreground">
+                            <p className="text-muted-foreground text-xs">
                               Your last rating: {meal.currentUserRating.score}/5
                               {meal.currentUserRating.submittedAt
                                 ? ` · ${formatDateTime(meal.currentUserRating.submittedAt)}`
@@ -699,7 +748,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
                                   </button>
                                 ))}
                               </div>
-                              <label className="block text-xs text-muted-foreground">
+                              <label className="text-muted-foreground block text-xs">
                                 Comment
                                 <textarea
                                   value={draft.comment}
@@ -709,7 +758,7 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
                                       [meal.id]: { ...state[meal.id], comment: event.target.value },
                                     }))
                                   }
-                                  className="mt-1 block h-20 w-full rounded-md border border-border bg-background px-3 py-2 text-xs"
+                                  className="border-border bg-background mt-1 block h-20 w-full rounded-md border px-3 py-2 text-xs"
                                   placeholder="Optional"
                                 />
                               </label>
@@ -718,28 +767,31 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
                                   type="button"
                                   onClick={() => void submitRating(meal.id)}
                                   disabled={draft.score === null || draft.submitting}
-                                  className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-40"
+                                  className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-40"
                                 >
                                   <Save className="h-4 w-4" />
                                   {draft.submitting ? "Saving..." : "Save rating"}
                                 </button>
                                 {draft.submittedMessage && (
-                                  <span className="text-xs text-muted-foreground">{draft.submittedMessage}</span>
+                                  <span className="text-muted-foreground text-xs">
+                                    {draft.submittedMessage}
+                                  </span>
                                 )}
                               </div>
                               {meal.ratingTaskCount > 0 ? (
-                                <p className="text-xs text-muted-foreground">
-                                  {meal.ratingTaskCount} active rating task{meal.ratingTaskCount === 1 ? "" : "s"}
+                                <p className="text-muted-foreground text-xs">
+                                  {meal.ratingTaskCount} active rating task
+                                  {meal.ratingTaskCount === 1 ? "" : "s"}
                                   {meal.ratingTaskId ? `; your task: ${meal.ratingTaskId}` : ""}
                                 </p>
                               ) : (
-                                <p className="text-xs text-muted-foreground">
+                                <p className="text-muted-foreground text-xs">
                                   No rating tasks were created for this serving.
                                 </p>
                               )}
                             </div>
                           ) : (
-                            <p className="text-xs text-muted-foreground">
+                            <p className="text-muted-foreground text-xs">
                               You are not assigned to this meal instance.
                             </p>
                           )}
@@ -755,20 +807,4 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
       )}
     </div>
   )
-}
-
-function modeText(entity: RecipeIngredient | RecipeStep, language: LanguageMode): string {
-  if (language === "af") {
-    return "preparationNote" in entity
-      ? entity.preparationNote ?? ""
-      : entity.instructionAf
-  }
-  if (language === "en") {
-    return "preparationNote" in entity
-      ? entity.preparationNote ?? ""
-      : entity.instructionEn
-  }
-  const enText = "preparationNote" in entity ? entity.preparationNote ?? "" : entity.instructionEn
-  const afText = "preparationNote" in entity ? entity.preparationNote ?? "" : entity.instructionAf
-  return `${toListText(enText, "")}${enText && afText ? " / " : ""}${afText}`
 }

--- a/docs/05-project/2026-07-25-recipe-catalog-completion.md
+++ b/docs/05-project/2026-07-25-recipe-catalog-completion.md
@@ -1,0 +1,65 @@
+# Kitchen recipe catalog completion
+
+Date: 2026-07-25
+Baton task: `22fd1b92-c65a-4e94-8785-4ba94ad9b88b`
+Branch: `codex/complete-recipe-catalog`
+
+## Outcome
+
+The recipe catalog and meal-feedback surface left behind after PR #124 is now
+completed on a fresh `origin/main` branch. PR #124 merged only through commit
+`f76f742`; commit `98f36c8`, added to the old branch after that merge, never
+reached `main`.
+
+This continuation restores and hardens that missing work:
+
+- Hans and Irma receive persona-specific recipe navigation and a mobile-friendly
+  bilingual catalog/detail route.
+- Recipe cards and details include structured ingredients, ordered steps,
+  timing, reusable-image source, license, and attribution metadata.
+- Hans/admin can explicitly seed reviewed sample recipes and create meal/rating
+  tasks; sample data is not loaded automatically.
+- Assigned residents can view their served meal history and submit a rating.
+- Non-admin meal responses expose only the current user's assignment identifier
+  and rating-task count, not co-resident assignment details or comments.
+- Missing recipe storage produces a clean empty read state; writes still fail
+  explicitly and never fall back to local production persistence.
+- Meal-history load failures are visible in the UI instead of being silently
+  converted to an empty list.
+
+## Files
+
+- `app/api/recipes/[id]/meals/route.ts`
+- `app/dashboard/[persona]/recipes/page.tsx`
+- `components/recipes/recipe-catalog-client.tsx`
+- `lib/nav-config.ts`
+- `lib/recipes.ts`
+- `lib/repositories/recipe-repository.ts`
+- `tests/api/recipe-meals.test.ts`
+- `tests/lib/recipe-repository.test.ts`
+
+## Verification
+
+- `pnpm exec tsc --noEmit`
+- `pnpm run lint`
+- `pnpm test -- tests/api/recipe-meals.test.ts tests/lib/recipe-repository.test.ts`
+- `pnpm test`
+- `pnpm run build`
+- Authenticated local production browser checks:
+  - Hans/admin route and Recipes navigation render the clean empty state.
+  - Irma/resident route and Recipes navigation render without admin controls.
+  - A routed browser fixture renders bilingual title/summary, reusable-image
+    metadata, ingredient checklist, ordered steps, timer, and resident-only
+    serving controls.
+
+The browser console retained the pre-existing
+`/api/projects?type=scope` 500 when Mongo is unconfigured. The recipe API itself
+returned its expected empty state after the repository-mode fix.
+
+## Residual checks
+
+- CI must repeat lint, unit tests, production build, E2E, and pipeline summary.
+- Production behavior should be smoke-tested with an authenticated Hans and
+  Irma session against the configured Cosmos recipe collections after merge.
+- Do not seed sample recipes in production unless the owner explicitly chooses
+  that content and verifies its image licenses and translations.

--- a/lib/nav-config.ts
+++ b/lib/nav-config.ts
@@ -21,6 +21,7 @@ import {
   Store,
   CheckSquare,
   FolderKanban,
+  ChefHat,
   type LucideIcon,
 } from "lucide-react"
 import {
@@ -137,6 +138,7 @@ const PAGE_DEFINITIONS: PageDef[] = [
   { name: "Marketplace", href: "/dashboard", icon: Store, category: "Tools", adminOnly: true },
   { name: "Reports", href: "/dashboard", icon: BarChart3, category: "Admin", adminOnly: true },
   { name: "Settings", href: "/dashboard", icon: Settings, category: "Admin" },
+  { name: "Recipes", href: "/dashboard", icon: ChefHat, category: "Operations" },
 ]
 
 const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
@@ -156,6 +158,7 @@ const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
     Marketplace: "/dashboard/hans/marketplace",
     Reports: "/dashboard/hans/reports",
     Settings: "/dashboard/hans/settings",
+    Recipes: "/dashboard/hans/recipes",
     Work: "/dashboard/hans/projects",
   },
   charl: {
@@ -186,6 +189,7 @@ const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
     "Household Tasks": "/dashboard/irma/tasks",
     Inventory: "/dashboard/irma/inventory",
     "My Documents": "/dashboard/irma/documents",
+    Recipes: "/dashboard/irma/recipes",
     Settings: "/dashboard/irma/settings",
   },
 }

--- a/lib/recipes.ts
+++ b/lib/recipes.ts
@@ -179,7 +179,7 @@ export function resolveTaskRecipientPersona(userId: string): string | undefined 
 
 export const SAMPLE_RECIPES: RecipeCreatePayload[] = [
   {
-    status: "draft",
+    status: "published",
     audienceUserIds: ["hans", "irma"],
     titleEn: "Mushroom & Egg Fried Rice (Budget-Friendly)",
     summaryEn:
@@ -255,7 +255,7 @@ export const SAMPLE_RECIPES: RecipeCreatePayload[] = [
     ],
   },
   {
-    status: "draft",
+    status: "published",
     audienceUserIds: ["hans", "irma"],
     titleEn: "Sampioen-, Spek- en Uie-Sous vir Mieliepap",
     summaryEn:

--- a/lib/recipes.ts
+++ b/lib/recipes.ts
@@ -150,7 +150,10 @@ export function getExpandedAudienceAliases(userId: string): string[] {
 export function isRecipeAudienceMatch(audienceUserIds: string[], userId: string): boolean {
   const candidateIds = getExpandedAudienceAliases(userId)
   const normalizedAudience = audienceUserIds.map((value) => value.toLowerCase().trim())
-  return normalizedAudience.length === 0 || normalizedAudience.some((value) => candidateIds.includes(value))
+  return (
+    normalizedAudience.length === 0 ||
+    normalizedAudience.some((value) => candidateIds.includes(value))
+  )
 }
 
 export function normalizeRecipeAudienceUserIds(audienceUserIds: unknown): string[] {
@@ -224,7 +227,8 @@ export const SAMPLE_RECIPES: RecipeCreatePayload[] = [
       {
         order: 2,
         instructionEn: "Beat the eggs with a pinch of salt. Fry as a soft scramble and set aside.",
-        instructionAf: "Klop die eiers met 'n knippie sout. Braai dit as 'n sagte scramble en sit dit op die kant.",
+        instructionAf:
+          "Klop die eiers met 'n knippie sout. Braai dit as 'n sagte scramble en sit dit op die kant.",
       },
       {
         order: 3,
@@ -302,8 +306,7 @@ export const SAMPLE_RECIPES: RecipeCreatePayload[] = [
       {
         order: 2,
         instructionEn: "Remove the bacon and keep it; reserve the rendered bacon fat in the pan.",
-        instructionAf:
-          "Verwyder die spek en hou dit eenkant. Laat die spekvet vir die pan oor.",
+        instructionAf: "Verwyder die spek en hou dit eenkant. Laat die spekvet vir die pan oor.",
       },
       {
         order: 3,
@@ -345,7 +348,8 @@ export const SAMPLE_RECIPES: RecipeCreatePayload[] = [
       },
       {
         order: 9,
-        instructionEn: "Optionally fold in peas or spinach for extra nutrition. Serve with mieliepap.",
+        instructionEn:
+          "Optionally fold in peas or spinach for extra nutrition. Serve with mieliepap.",
         instructionAf:
           "Opsioneel: voeg ertjies of spinasie by vir meer voeding. Bedien saam met mieliepap.",
       },

--- a/lib/repositories/recipe-repository.ts
+++ b/lib/repositories/recipe-repository.ts
@@ -47,7 +47,11 @@ export interface SeedSampleRecipesResult {
   forced: boolean
 }
 
-function buildSeedRecipeRecord(payload: RecipeCreatePayload, ownerUserId: string, now: string): RecipeRecord {
+function buildSeedRecipeRecord(
+  payload: RecipeCreatePayload,
+  ownerUserId: string,
+  now: string
+): RecipeRecord {
   const recipeId = `recipe-${randomUUID()}`
   const audienceUserIds = normalizeRecipeAudienceUserIds(payload.audienceUserIds ?? [])
   const normalizedImage = payload.image
@@ -57,21 +61,20 @@ function buildSeedRecipeRecord(payload: RecipeCreatePayload, ownerUserId: string
     .map((ingredient, index) => ({
       id: asString((ingredient as { id?: unknown }).id) ?? `ing-${recipeId}-${index + 1}`,
       quantity: ingredient.quantity,
-      unit: asString((ingredient as { unit?: unknown })),
+      unit: asString(ingredient as { unit?: unknown }),
       name: asString((ingredient as { name?: unknown }).name) as string,
-      preparationNote: asString((ingredient as { preparationNote?: unknown })),
-      section: asString((ingredient as { section?: unknown })),
+      preparationNote: asString(ingredient as { preparationNote?: unknown }),
+      section: asString(ingredient as { section?: unknown }),
     }))
 
-  const steps = (Array.isArray(payload.steps) ? payload.steps : [])
-    .map((step, index) => ({
-      id: asString((step as { id?: unknown }).id) ?? `step-${recipeId}-${index + 1}`,
-      order: asNonNegativeInt((step as { order?: unknown }).order) || index + 1,
-      instructionEn: asString((step as { instructionEn?: unknown }).instructionEn) ?? "",
-      instructionAf: asString((step as { instructionAf?: unknown }).instructionAf) ?? "",
-      timerMinutes: asNonNegativeInt((step as { timerMinutes?: unknown })),
-      section: asString((step as { section?: unknown })),
-    }))
+  const steps = (Array.isArray(payload.steps) ? payload.steps : []).map((step, index) => ({
+    id: asString((step as { id?: unknown }).id) ?? `step-${recipeId}-${index + 1}`,
+    order: asNonNegativeInt((step as { order?: unknown }).order) || index + 1,
+    instructionEn: asString((step as { instructionEn?: unknown }).instructionEn) ?? "",
+    instructionAf: asString((step as { instructionAf?: unknown }).instructionAf) ?? "",
+    timerMinutes: asNonNegativeInt(step as { timerMinutes?: unknown }),
+    section: asString(step as { section?: unknown }),
+  }))
 
   return {
     id: recipeId,
@@ -102,14 +105,27 @@ function buildSeedRecipeRecord(payload: RecipeCreatePayload, ownerUserId: string
   }
 }
 
+function isProductionStoreUnavailable(): boolean {
+  return (
+    process.env.NODE_ENV === "production" &&
+    process.env.CI !== "true" &&
+    process.env.E2E_TEST !== "1" &&
+    !isMongoConfigured()
+  )
+}
+
 function requireProductionStore(): void {
-  if (process.env.NODE_ENV === "production" && process.env.CI !== "true" && !isMongoConfigured()) {
+  if (isProductionStoreUnavailable()) {
     throw new Error("Recipe datastore is not configured. Set MONGODB_URI for production.")
   }
 }
 
 function isUsingMemoryStore(): boolean {
-  return process.env.E2E_TEST === "1" || process.env.CI === "true" || !isMongoConfigured()
+  return (
+    process.env.E2E_TEST === "1" ||
+    process.env.CI === "true" ||
+    (process.env.NODE_ENV !== "production" && !isMongoConfigured())
+  )
 }
 
 async function readJsonList<T>(filePath: string): Promise<T[]> {
@@ -175,7 +191,10 @@ export interface RecipeListFilter {
   audienceUserIds?: string[]
 }
 
-function filterRecipesInMemory(recipes: RecipeRecord[], filters?: RecipeListFilter): RecipeRecord[] {
+function filterRecipesInMemory(
+  recipes: RecipeRecord[],
+  filters?: RecipeListFilter
+): RecipeRecord[] {
   let results = [...recipes]
   if (!filters) return results
 
@@ -190,7 +209,9 @@ function filterRecipesInMemory(recipes: RecipeRecord[], filters?: RecipeListFilt
   }
 
   if (filters.audienceUserIds && filters.audienceUserIds.length > 0) {
-    const audienceLookup = new Set(filters.audienceUserIds.map((value) => value.toLowerCase().trim()))
+    const audienceLookup = new Set(
+      filters.audienceUserIds.map((value) => value.toLowerCase().trim())
+    )
     results = results.filter((recipe) =>
       recipe.audienceUserIds.some((userId) => audienceLookup.has(userId.toLowerCase().trim()))
     )
@@ -200,6 +221,7 @@ function filterRecipesInMemory(recipes: RecipeRecord[], filters?: RecipeListFilt
 }
 
 export async function listRecipes(filters?: RecipeListFilter): Promise<RecipeRecord[]> {
+  if (isProductionStoreUnavailable()) return []
   requireProductionStore()
   if (isUsingMemoryStore()) {
     const items = await readRecipes()
@@ -228,6 +250,7 @@ export async function listRecipes(filters?: RecipeListFilter): Promise<RecipeRec
 }
 
 export async function countRecipes(): Promise<number> {
+  if (isProductionStoreUnavailable()) return 0
   requireProductionStore()
   if (isUsingMemoryStore()) {
     const recipes = await readRecipes()
@@ -239,6 +262,7 @@ export async function countRecipes(): Promise<number> {
 }
 
 export async function getRecipeById(id: string): Promise<RecipeRecord | null> {
+  if (isProductionStoreUnavailable()) return null
   requireProductionStore()
   if (isUsingMemoryStore()) {
     const recipes = await readRecipes()
@@ -335,25 +359,31 @@ export async function replaceRecipe(updated: RecipeRecord): Promise<RecipeRecord
 }
 
 export async function listRecipeMealInstances(recipeId: string): Promise<RecipeMealInstance[]> {
+  if (isProductionStoreUnavailable()) return []
   requireProductionStore()
   if (isUsingMemoryStore()) {
     const instances = await readMealInstances()
     return sortByServedAtDescending(instances.filter((instance) => instance.recipeId === recipeId))
   }
 
-  const collection = await getCollection<RecipeMealInstanceDocument>(RECIPE_MEAL_INSTANCES_COLLECTION)
+  const collection = await getCollection<RecipeMealInstanceDocument>(
+    RECIPE_MEAL_INSTANCES_COLLECTION
+  )
   const instances = await collection.find({ recipeId }).sort({ servedAt: -1 }).toArray()
   return instances.map((instance) => withoutMongoId(instance))
 }
 
 export async function getRecipeMealInstanceById(id: string): Promise<RecipeMealInstance | null> {
+  if (isProductionStoreUnavailable()) return null
   requireProductionStore()
   if (isUsingMemoryStore()) {
     const instances = await readMealInstances()
     return instances.find((instance) => instance.id === id) ?? null
   }
 
-  const collection = await getCollection<RecipeMealInstanceDocument>(RECIPE_MEAL_INSTANCES_COLLECTION)
+  const collection = await getCollection<RecipeMealInstanceDocument>(
+    RECIPE_MEAL_INSTANCES_COLLECTION
+  )
   const instance = await collection.findOne({ id } as Filter<RecipeMealInstanceDocument>)
   if (!instance) return null
   return withoutMongoId(instance)
@@ -386,6 +416,7 @@ export async function createRecipeMealInstance(
 }
 
 export async function listRecipeRatings(recipeId: string): Promise<RecipeRating[]> {
+  if (isProductionStoreUnavailable()) return []
   requireProductionStore()
   if (isUsingMemoryStore()) {
     return sortBySubmittedAtDescending(
@@ -403,6 +434,7 @@ export async function getRecipeRating(
   mealInstanceId: string,
   residentUserId: string
 ): Promise<RecipeRating | null> {
+  if (isProductionStoreUnavailable()) return null
   requireProductionStore()
   if (isUsingMemoryStore()) {
     return (
@@ -499,7 +531,9 @@ export async function getRecipeRatingSummaries(
   recipeIds: string[]
 ): Promise<Record<string, RecipeRatingSummary>> {
   const uniqueRecipeIds = [...new Set(recipeIds)]
-  const summary = await Promise.all(uniqueRecipeIds.map((recipeId) => getRecipeRatingSummary(recipeId)))
+  const summary = await Promise.all(
+    uniqueRecipeIds.map((recipeId) => getRecipeRatingSummary(recipeId))
+  )
   return summary.reduce<Record<string, RecipeRatingSummary>>((acc, item) => {
     acc[item.recipeId] = item
     return acc

--- a/tests/api/recipe-meals.test.ts
+++ b/tests/api/recipe-meals.test.ts
@@ -1,0 +1,162 @@
+import { GET } from "@/app/api/recipes/[id]/meals/route"
+import {
+  getRecipeById,
+  listRecipeMealInstances,
+  listRecipeRatings,
+} from "@/lib/repositories/recipe-repository"
+import type { RecipeMealInstance, RecipeRating, RecipeRecord } from "@/lib/recipes"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/repositories/recipe-repository", () => ({
+  getRecipeById: vi.fn(),
+  listRecipeMealInstances: vi.fn(),
+  listRecipeRatings: vi.fn(),
+}))
+
+const routeContext = { params: Promise.resolve({ id: "recipe-1" }) }
+
+const recipe: RecipeRecord = {
+  id: "recipe-1",
+  ownerUserId: "hans",
+  status: "published",
+  audienceUserIds: ["hans", "irma"],
+  titleEn: "Household supper",
+  titleAf: "Huishoudelike aandete",
+  summaryEn: "A practical supper.",
+  summaryAf: "'n Praktiese aandete.",
+  ingredients: [],
+  steps: [],
+  image: {
+    url: "https://images.example/recipe.jpg",
+    source: "Example",
+    license: "CC BY 4.0",
+    attributionText: "Example Author, CC BY 4.0",
+    retrievedAt: "2026-07-25",
+  },
+  createdAt: "2026-07-25T08:00:00.000Z",
+  updatedAt: "2026-07-25T08:00:00.000Z",
+}
+
+const meal: RecipeMealInstance = {
+  id: "meal-1",
+  recipeId: recipe.id,
+  recipeTitleEn: recipe.titleEn,
+  recipeTitleAf: recipe.titleAf,
+  mealName: "Friday supper",
+  residentUserIds: ["irma", "charl"],
+  ratingTaskIds: [41, 42],
+  ratingTaskAssignments: [
+    { residentUserId: "irma", taskId: 41 },
+    { residentUserId: "charl", taskId: 42 },
+  ],
+  servedAt: "2026-07-25T18:00:00.000Z",
+  servedBy: "hans",
+  createdBy: "hans",
+  createdAt: "2026-07-25T18:00:00.000Z",
+  updatedAt: "2026-07-25T18:00:00.000Z",
+}
+
+const ratings: RecipeRating[] = [
+  {
+    id: "rating-1",
+    recipeId: recipe.id,
+    mealInstanceId: meal.id,
+    residentUserId: "irma",
+    score: 5,
+    comment: "Baie lekker.",
+    submittedBy: "irma",
+    submittedAt: "2026-07-25T19:00:00.000Z",
+    taskId: 41,
+  },
+  {
+    id: "rating-2",
+    recipeId: recipe.id,
+    mealInstanceId: meal.id,
+    residentUserId: "charl",
+    score: 3,
+    comment: "Needed more seasoning.",
+    submittedBy: "charl",
+    submittedAt: "2026-07-25T19:05:00.000Z",
+    taskId: 42,
+  },
+]
+
+function requestFor(userId: string, role: string) {
+  return new Request("http://localhost/api/recipes/recipe-1/meals", {
+    headers: {
+      "x-user-id": userId,
+      "x-user-role": role,
+      "x-user-email": `${userId}@example.com`,
+    },
+  })
+}
+
+describe("GET /api/recipes/[id]/meals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getRecipeById).mockResolvedValue(recipe)
+    vi.mocked(listRecipeMealInstances).mockResolvedValue([meal])
+    vi.mocked(listRecipeRatings).mockResolvedValue(ratings)
+  })
+
+  it("returns only the authenticated resident's assignment details and rating", async () => {
+    const response = await GET(requestFor("irma", "resident"), routeContext)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mealInstances).toEqual([
+      expect.objectContaining({
+        id: "meal-1",
+        residentUserIds: ["irma"],
+        ratingTaskId: 41,
+        ratingTaskCount: 1,
+        canRate: true,
+        summary: {
+          mealInstanceId: "meal-1",
+          totalRatings: 2,
+          averageScore: 4,
+        },
+        currentUserRating: expect.objectContaining({
+          score: 5,
+          comment: "Baie lekker.",
+        }),
+      }),
+    ])
+    expect(JSON.stringify(body)).not.toContain("Needed more seasoning.")
+    expect(JSON.stringify(body)).not.toContain("charl")
+  })
+
+  it("rejects a user outside the recipe audience before reading meal history", async () => {
+    const response = await GET(requestFor("lucky", "employee"), routeContext)
+
+    expect(response.status).toBe(403)
+    expect(listRecipeMealInstances).not.toHaveBeenCalled()
+    expect(listRecipeRatings).not.toHaveBeenCalled()
+  })
+
+  it("rejects unpublished recipes for non-admin users", async () => {
+    vi.mocked(getRecipeById).mockResolvedValue({ ...recipe, status: "draft" })
+
+    const response = await GET(requestFor("irma", "resident"), routeContext)
+
+    expect(response.status).toBe(403)
+    expect(listRecipeMealInstances).not.toHaveBeenCalled()
+  })
+
+  it("lets an admin review all assignments without exposing rating comments", async () => {
+    vi.mocked(getRecipeById).mockResolvedValue({ ...recipe, status: "draft" })
+
+    const response = await GET(requestFor("hans", "admin"), routeContext)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mealInstances[0]).toMatchObject({
+      residentUserIds: ["irma", "charl"],
+      ratingTaskCount: 2,
+      canRate: true,
+      currentUserRating: null,
+    })
+    expect(JSON.stringify(body)).not.toContain("Baie lekker.")
+    expect(JSON.stringify(body)).not.toContain("Needed more seasoning.")
+  })
+})

--- a/tests/lib/recipe-repository.test.ts
+++ b/tests/lib/recipe-repository.test.ts
@@ -1,0 +1,64 @@
+import {
+  countRecipes,
+  createRecipe,
+  getRecipeById,
+  getRecipeMealInstanceById,
+  getRecipeRating,
+  listRecipeMealInstances,
+  listRecipeRatings,
+  listRecipes,
+} from "@/lib/repositories/recipe-repository"
+import type { RecipeRecord } from "@/lib/recipes"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const recipe: RecipeRecord = {
+  id: "recipe-1",
+  ownerUserId: "hans",
+  status: "draft",
+  audienceUserIds: ["hans", "irma"],
+  titleEn: "Household supper",
+  titleAf: "Huishoudelike aandete",
+  summaryEn: "A practical supper.",
+  summaryAf: "'n Praktiese aandete.",
+  ingredients: [],
+  steps: [],
+  image: {
+    url: "https://images.example/recipe.jpg",
+    source: "Example",
+    license: "CC BY 4.0",
+    attributionText: "Example Author, CC BY 4.0",
+    retrievedAt: "2026-07-25",
+  },
+  createdAt: "2026-07-25T08:00:00.000Z",
+  updatedAt: "2026-07-25T08:00:00.000Z",
+}
+
+describe("recipe repository clean production defaults", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("CI", "")
+    vi.stubEnv("E2E_TEST", "")
+    vi.stubEnv("MONGODB_URI", "")
+    vi.stubEnv("MONGO_URL", "")
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("returns explicit empty read results when the production datastore is unconfigured", async () => {
+    await expect(listRecipes()).resolves.toEqual([])
+    await expect(countRecipes()).resolves.toBe(0)
+    await expect(getRecipeById("recipe-1")).resolves.toBeNull()
+    await expect(listRecipeMealInstances("recipe-1")).resolves.toEqual([])
+    await expect(getRecipeMealInstanceById("meal-1")).resolves.toBeNull()
+    await expect(listRecipeRatings("recipe-1")).resolves.toEqual([])
+    await expect(getRecipeRating("recipe-1", "meal-1", "irma")).resolves.toBeNull()
+  })
+
+  it("rejects writes instead of persisting production data to a local fallback", async () => {
+    await expect(createRecipe(recipe)).rejects.toThrow(
+      "Recipe datastore is not configured. Set MONGODB_URI for production."
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- recover the recipe catalog and meal-feedback commit that was added after PR #124 had already merged
- add Hans and Irma recipe navigation, bilingual recipe details, reusable-image attribution, serving controls, and resident ratings
- enforce recipe/meal audience boundaries and avoid exposing co-resident assignment details to non-admin users
- preserve clean production defaults: unconfigured recipe reads return empty while writes fail explicitly instead of using local persistence
- add API and repository regression coverage plus a durable closeout note

## Root cause

PR #124 merged through `f76f742`, but the catalog commit `98f36c8` was pushed to the old branch afterward and never reached `main`. The abandoned commit also contained TypeScript errors, no route tests, a silent meal-history failure, and a production-mode empty-state 500.

## Validation

- `pnpm exec prettier --check` on all changed files
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- focused recipe tests: 6 passed
- full Vitest suite: 58 files, 351 tests passed
- `pnpm run build`
- authenticated local production browser checks for Hans/admin and Irma/resident; empty and populated routed-fixture states verified

## Known pre-existing warning

The shared dashboard layout still logs `/api/projects?type=scope` as 500 when Mongo is unconfigured. The recipe API itself returns the intended empty state.
