### PR TITLE
fix(deps): remediate brace-expansion OOM advisory

### DIFF
--- a/docs/05-project/2026-07-26-brace-expansion-remediation.md
+++ b/docs/05-project/2026-07-26-brace-expansion-remediation.md
@@ -1,0 +1,44 @@
+# Brace Expansion CVE Remediation
+
+## Scope
+
+- Baton task: `de6dac5d-116a-4bea-8333-9a1dadc042ae`
+- Advisory: `GHSA-mh99-v99m-4gvg` / `CVE-2026-14257`
+- Affected paths: ESLint tooling through `minimatch` 3.1.5 and 9.0.9
+
+## Decision
+
+Resolve both transitive `brace-expansion` ranges to 5.0.8, the first patched
+release. Keep the consumer versions selected by the current ESLint and
+TypeScript-ESLint toolchain, and use pnpm patches to adapt their legacy
+callable/default imports to the named `expand` export introduced by
+`brace-expansion` 5.
+
+A direct `brace-expansion` override without the consumer patches is unsafe:
+both minimatch generations would load an undefined or non-callable export.
+Forcing minimatch 10 would also cross an unsupported major-version boundary for
+the current ESLint plugin set.
+
+## Verification
+
+Run from the repository root:
+
+```text
+pnpm install --frozen-lockfile
+pnpm audit --json
+pnpm run lint
+pnpm test
+pnpm run build
+```
+
+The remediation was additionally checked with direct brace expansion calls
+through both installed minimatch generations. The live audit returned zero
+vulnerabilities, lint passed, all 351 tests passed, and the production build
+completed successfully.
+
+## Maintenance
+
+Remove the compatibility patches once the repository's supported ESLint plugin
+set no longer resolves minimatch versions that expect the legacy
+`brace-expansion` export shape. Until then, keep the patches and the 5.0.8
+overrides together.

--- a/package.json
+++ b/package.json
@@ -124,8 +124,8 @@
       "@opentelemetry/core": "2.10.0",
       "@opentelemetry/propagator-jaeger": "2.10.0",
       "axios": "1.18.1",
-      "brace-expansion@1": "1.1.16",
-      "brace-expansion@2": "2.1.2",
+      "brace-expansion@1": "5.0.8",
+      "brace-expansion@2": "5.0.8",
       "dompurify": "3.4.12",
       "esbuild": "0.28.1",
       "form-data": "4.0.6",
@@ -137,6 +137,10 @@
       "sharp": "0.35.3",
       "vite": "7.3.6",
       "ws": "8.21.0"
+    },
+    "patchedDependencies": {
+      "minimatch@3.1.5": "patches/minimatch@3.1.5.patch",
+      "minimatch@9.0.9": "patches/minimatch@9.0.9.patch"
     }
   }
 }

--- a/patches/minimatch@3.1.5.patch
+++ b/patches/minimatch@3.1.5.patch
@@ -1,0 +1,7 @@
+diff --git a/minimatch.js b/minimatch.js
+index 2e4a058a130dceebf83a7bd435f5d22b765ac836..742bb57ab24b06e9e8ec273457c043758c8641ca 100644
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -10 +10 @@ var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
+-var expand = require('brace-expansion')
++var expand = require('brace-expansion').expand

--- a/patches/minimatch@9.0.9.patch
+++ b/patches/minimatch@9.0.9.patch
@@ -1,0 +1,35 @@
+diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
+index c12dc5e6476874f9dbba429a19e445a4a688e1df..557ff6fa5918c5536d9c5160bac6623e0a7a864e 100644
+--- a/dist/commonjs/index.js
++++ b/dist/commonjs/index.js
+@@ -1,10 +1,7 @@
+ "use strict";
+-var __importDefault = (this && this.__importDefault) || function (mod) {
+-    return (mod && mod.__esModule) ? mod : { "default": mod };
+-};
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.unescape = exports.escape = exports.AST = exports.Minimatch = exports.match = exports.makeRe = exports.braceExpand = exports.defaults = exports.filter = exports.GLOBSTAR = exports.sep = exports.minimatch = void 0;
+-const brace_expansion_1 = __importDefault(require("brace-expansion"));
++const brace_expansion_1 = require("brace-expansion");
+ const assert_valid_pattern_js_1 = require("./assert-valid-pattern.js");
+ const ast_js_1 = require("./ast.js");
+ const escape_js_1 = require("./escape.js");
+@@ -157,7 +154,7 @@ const braceExpand = (pattern, options = {}) => {
+         // shortcut. no need to expand.
+         return [pattern];
+     }
+-    return (0, brace_expansion_1.default)(pattern);
++    return (0, brace_expansion_1.expand)(pattern);
+ };
+ exports.braceExpand = braceExpand;
+ exports.minimatch.braceExpand = exports.braceExpand;
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index 737c8095415235e69e4717b505d0ee4ea3c0b6fa..ad5aa644f7957fb39627327bdd6435f4007dca30 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -1,4 +1,4 @@
+-import expand from 'brace-expansion';
++import { expand } from 'brace-expansion';
+ import { assertValidPattern } from './assert-valid-pattern.js';
+ import { AST } from './ast.js';
+ import { escape } from './escape.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ overrides:
   '@opentelemetry/core': 2.10.0
   '@opentelemetry/propagator-jaeger': 2.10.0
   axios: 1.18.1
-  brace-expansion@1: 1.1.16
-  brace-expansion@2: 2.1.2
+  brace-expansion@1: 5.0.8
+  brace-expansion@2: 5.0.8
   dompurify: 3.4.12
   esbuild: 0.28.1
   form-data: 4.0.6
@@ -23,6 +23,14 @@ overrides:
   sharp: 0.35.3
   vite: 7.3.6
   ws: 8.21.0
+
+patchedDependencies:
+  minimatch@3.1.5:
+    hash: 559be1b176ae448cfe4938727ca1a9d39dc1f1dc922a7ab82c31e88d0a104ed5
+    path: patches/minimatch@3.1.5.patch
+  minimatch@9.0.9:
+    hash: 27088658bef1edafbfd528edfa4699b7d3809aa735f083ae73359fafe5ed9b5f
+    path: patches/minimatch@9.0.9.patch
 
 importers:
 
@@ -3332,8 +3340,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base64-arraybuffer@1.0.2:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
@@ -3347,11 +3356,9 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3466,9 +3473,6 @@ packages:
   comment-json@4.5.1:
     resolution: {integrity: sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg==}
     engines: {node: '>= 6'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -6595,7 +6599,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=559be1b176ae448cfe4938727ca1a9d39dc1f1dc922a7ab82c31e88d0a104ed5)
     transitivePeerDependencies:
       - supports-color
 
@@ -6616,7 +6620,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.3.0
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=559be1b176ae448cfe4938727ca1a9d39dc1f1dc922a7ab82c31e88d0a104ed5)
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -8941,7 +8945,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
-      minimatch: 9.0.9
+      minimatch: 9.0.9(patch_hash=27088658bef1edafbfd528edfa4699b7d3809aa735f083ae73359fafe5ed9b5f)
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -9246,7 +9250,7 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   base64-arraybuffer@1.0.2:
     optional: true
@@ -9255,14 +9259,9 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@5.0.8:
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -9384,8 +9383,6 @@ snapshots:
       array-timsort: 1.0.3
       core-util-is: 1.0.3
       esprima: 4.0.1
-
-  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -9868,7 +9865,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=559be1b176ae448cfe4938727ca1a9d39dc1f1dc922a7ab82c31e88d0a104ed5)
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -9896,7 +9893,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=559be1b176ae448cfe4938727ca1a9d39dc1f1dc922a7ab82c31e88d0a104ed5)
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -9924,7 +9921,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=559be1b176ae448cfe4938727ca1a9d39dc1f1dc922a7ab82c31e88d0a104ed5)
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -9978,7 +9975,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=559be1b176ae448cfe4938727ca1a9d39dc1f1dc922a7ab82c31e88d0a104ed5)
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -10801,13 +10798,13 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
-  minimatch@3.1.5:
+  minimatch@3.1.5(patch_hash=559be1b176ae448cfe4938727ca1a9d39dc1f1dc922a7ab82c31e88d0a104ed5):
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
-  minimatch@9.0.9:
+  minimatch@9.0.9(patch_hash=27088658bef1edafbfd528edfa4699b7d3809aa735f083ae73359fafe5ed9b5f):
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## What changed

- resolve both transitive `brace-expansion` ranges to patched 5.0.8
- add minimal pnpm patches so minimatch 3.1.5 and 9.0.9 use the named `expand` export
- record the compatibility decision and removal condition

## Why

`pnpm audit` reported GHSA-mh99-v99m-4gvg / CVE-2026-14257 through the ESLint toolchain. Version 5.0.8 is the only patched release, but it changes the export shape. A raw override would make both installed minimatch generations fail at runtime, while forcing minimatch 10 crosses unsupported ESLint-plugin peer ranges.

The compatibility patches preserve the current minimatch behavior while allowing the dependency graph to use the fixed release.

## Impact

This changes development/build tooling only. Application behavior, authentication, data handling, and deployment configuration are unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- direct brace-expansion compatibility checks through minimatch 3.1.5 and 9.0.9
- `pnpm audit --json` — zero vulnerabilities
- `pnpm run lint`
- `pnpm test` — 58 files, 351 tests passed
- `pnpm run build`

Baton: `de6dac5d-116a-4bea-8333-9a1dadc042ae`