### PR TITLE
fix: serialize Mongo connection initialization

### DIFF
--- a/lib/db/mongodb.ts
+++ b/lib/db/mongodb.ts
@@ -4,6 +4,8 @@ import { logger } from "@/lib/logger"
 let client: MongoClient | null = null
 let db: Db | null = null
 let activeConnectionKey: string | null = null
+let connectionPromise: Promise<Db> | null = null
+let pendingConnectionKey: string | null = null
 
 function getMongoUrl(): string {
   return process.env.MONGODB_URI || process.env.MONGO_URL || "mongodb://localhost:27017"
@@ -23,25 +25,50 @@ export async function getDatabase(): Promise<Db> {
   const connectionKey = `${mongoUrl}|${databaseName}`
   if (db && activeConnectionKey === connectionKey) return db
 
-  if (client) {
-    await client.close()
-    client = null
-    db = null
-    activeConnectionKey = null
+  if (connectionPromise) {
+    if (pendingConnectionKey === connectionKey) return connectionPromise
+
+    await connectionPromise.catch(() => undefined)
+    return getDatabase()
   }
 
+  const pending = (async (): Promise<Db> => {
+    if (client) {
+      await client.close()
+      client = null
+      db = null
+      activeConnectionKey = null
+    }
+
+    const nextClient = new MongoClient(mongoUrl)
+
+    try {
+      await nextClient.connect()
+      const nextDb = nextClient.db(databaseName)
+      client = nextClient
+      db = nextDb
+      activeConnectionKey = connectionKey
+      logger.info(`MongoDB connected to ${databaseName}`)
+      return nextDb
+    } catch (error) {
+      await nextClient.close().catch(() => undefined)
+      logger.error("MongoDB connection error", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      throw error
+    }
+  })()
+
+  connectionPromise = pending
+  pendingConnectionKey = connectionKey
+
   try {
-    client = new MongoClient(mongoUrl)
-    await client.connect()
-    db = client.db(databaseName)
-    activeConnectionKey = connectionKey
-    logger.info(`MongoDB connected to ${databaseName}`)
-    return db
-  } catch (error) {
-    logger.error("MongoDB connection error", {
-      error: error instanceof Error ? error.message : String(error),
-    })
-    throw error
+    return await pending
+  } finally {
+    if (connectionPromise === pending) {
+      connectionPromise = null
+      pendingConnectionKey = null
+    }
   }
 }
 
@@ -54,12 +81,19 @@ export async function getCollection<T extends object>(
 
 // Close connection (for cleanup)
 export async function closeConnection(): Promise<void> {
+  if (connectionPromise) {
+    await connectionPromise.catch(() => undefined)
+  }
+
   if (client) {
     await client.close()
     client = null
     db = null
     activeConnectionKey = null
   }
+
+  connectionPromise = null
+  pendingConnectionKey = null
 }
 
 export function withoutMongoId<T extends { _id?: unknown }>(doc: T): Omit<T, "_id"> {

--- a/tests/lib/mongodb-connection.test.ts
+++ b/tests/lib/mongodb-connection.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mongoMocks = vi.hoisted(() => {
+  const connectBehaviors: Array<() => Promise<void>> = []
+  const instances: MockMongoClient[] = []
+
+  class MockMongoClient {
+    readonly connect = vi.fn(async () => {
+      const behavior = connectBehaviors.shift()
+      if (behavior) await behavior()
+      return this
+    })
+
+    readonly close = vi.fn(async () => undefined)
+    readonly db = vi.fn((databaseName: string) => ({ databaseName }))
+
+    constructor(readonly url: string) {
+      instances.push(this)
+    }
+  }
+
+  return { connectBehaviors, instances, MockMongoClient }
+})
+
+vi.mock("mongodb", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("mongodb")>()
+  return { ...actual, MongoClient: mongoMocks.MockMongoClient }
+})
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+function createDeferred() {
+  let resolve!: () => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+describe("MongoDB connection lifecycle", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv("MONGODB_URI", "mongodb://example.test:27017")
+    vi.stubEnv("DB_NAME", "house_of_veritas")
+    mongoMocks.connectBehaviors.length = 0
+    mongoMocks.instances.length = 0
+  })
+
+  afterEach(async () => {
+    const { closeConnection } = await import("@/lib/db/mongodb")
+    await closeConnection()
+    vi.unstubAllEnvs()
+  })
+
+  it("shares one in-flight connection across concurrent callers", async () => {
+    const gate = createDeferred()
+    mongoMocks.connectBehaviors.push(() => gate.promise)
+    const { getDatabase } = await import("@/lib/db/mongodb")
+
+    const first = getDatabase()
+    const second = getDatabase()
+
+    expect(mongoMocks.instances).toHaveLength(1)
+    expect(mongoMocks.instances[0].connect).toHaveBeenCalledTimes(1)
+    expect(mongoMocks.instances[0].close).not.toHaveBeenCalled()
+
+    gate.resolve()
+    const [firstDatabase, secondDatabase] = await Promise.all([first, second])
+
+    expect(firstDatabase).toBe(secondDatabase)
+    expect(mongoMocks.instances).toHaveLength(1)
+    expect(mongoMocks.instances[0].close).not.toHaveBeenCalled()
+  })
+
+  it("clears a failed attempt so a later request can reconnect", async () => {
+    mongoMocks.connectBehaviors.push(async () => {
+      throw new Error("connection failed")
+    })
+    const { getDatabase } = await import("@/lib/db/mongodb")
+
+    const first = getDatabase()
+    const second = getDatabase()
+    const results = await Promise.allSettled([first, second])
+
+    expect(results.map((result) => result.status)).toEqual(["rejected", "rejected"])
+    expect(mongoMocks.instances).toHaveLength(1)
+    expect(mongoMocks.instances[0].close).toHaveBeenCalledTimes(1)
+
+    const database = await getDatabase()
+
+    expect(database).toEqual({ databaseName: "house_of_veritas" })
+    expect(mongoMocks.instances).toHaveLength(2)
+  })
+
+  it("replaces an established client when the connection settings change", async () => {
+    const { getDatabase } = await import("@/lib/db/mongodb")
+    await getDatabase()
+
+    vi.stubEnv("DB_NAME", "house_of_veritas_archive")
+    const database = await getDatabase()
+
+    expect(database).toEqual({ databaseName: "house_of_veritas_archive" })
+    expect(mongoMocks.instances).toHaveLength(2)
+    expect(mongoMocks.instances[0].close).toHaveBeenCalledTimes(1)
+    expect(mongoMocks.instances[1].db).toHaveBeenCalledWith("house_of_veritas_archive")
+  })
+})


### PR DESCRIPTION
## Summary

- share one in-flight MongoDB connection attempt across concurrent callers
- clear failed initialization state so later requests can reconnect
- preserve deliberate connection replacement when database settings change
- add deterministic regression coverage for concurrency, retry, and configuration changes

## Root cause

During a cold dashboard load, concurrent API requests entered `getDatabase()` while the first `MongoClient.connect()` was still pending. The second request saw a non-null client with no established database and closed it, causing the first request to fail with `Topology is closed` and `/api/projects?type=scope` to return 500.

## Impact

Concurrent cold-start API reads now await the same connection promise rather than closing one another. This removes the intermittent scopes/projects failure observed in production while retaining retry and cleanup behavior.

## Validation

- `pnpm test -- tests/lib/mongodb-connection.test.ts tests/lib/mongodb.test.ts` — 5 tests passed
- `pnpm test` — 59 files, 354 tests passed
- `pnpm run lint` — passed
- `pnpm run build` — passed, including TypeScript and 122 static pages
- `git diff --check` — passed

## Tracking

Baton: `bdbb1a12-01b3-42cc-a73d-5960e075ab79`

Production deployment and simultaneous cold-read verification remain post-merge gates.