### PR TITLE
test(discovery): exercise alpha review e2e

### DIFF
--- a/docs/05-project/2026-07-26-alpha-experience-reviewer-trial-pack.md
+++ b/docs/05-project/2026-07-26-alpha-experience-reviewer-trial-pack.md
@@ -7,6 +7,8 @@
 - Baton task: `9bba1180-b6a4-49cb-b1fc-45bdcbb4cd3c`
 - Governing boundary:
   [Independent domain reviewer sourcing and micro-trial](2026-07-26-independent-domain-reviewer-sourcing.md)
+- Operational proof:
+  [Alpha review operational E2E rehearsal](2026-07-26-alpha-review-operational-e2e.md)
 
 ## Purpose
 

--- a/docs/05-project/2026-07-26-alpha-review-operational-e2e.md
+++ b/docs/05-project/2026-07-26-alpha-review-operational-e2e.md
@@ -1,0 +1,143 @@
+# Alpha review operational E2E rehearsal
+
+- Date: 2026-07-26
+- Status: Synthetic operational E2E passed; live reviewer path not activated
+- Harness contract: `alpha-review-e2e-v1`
+- Trial pack: `AER-SYNTH-001-v1`
+- Baton task: `9bba1180-b6a4-49cb-b1fc-45bdcbb4cd3c`
+
+## Outcome
+
+The deterministic harness exercises the alpha-review operational path end to end:
+
+```text
+synthetic nomination
+  -> activation preflight
+  -> invitation preview
+  -> simulated consent acknowledgement
+  -> assigned-variant first exposure
+  -> minimized finding
+  -> no-reliance closeout
+  -> retention review scheduled
+```
+
+It does not impersonate a reviewer, generate participant or usability evidence,
+contact anyone, create a restricted record, access production, or authorize a
+Gate. Simulated escalation routes prove only that the workflow carries both route
+classes; they are not substitutes for the named, reachable domain-safety and
+privacy routes required by the live activation gate.
+
+## Replay
+
+Run the successful fixture:
+
+```powershell
+node scripts/verify-alpha-review-e2e.mjs tests/fixtures/alpha-review/synthetic-complete.json
+```
+
+Expected output:
+
+```json
+{
+  "candidateId": "AER-SIM-001",
+  "disposition": "revise_before_more_alpha",
+  "eventCount": 8,
+  "mode": "synthetic_harness",
+  "packVersion": "AER-SYNTH-001-v1",
+  "status": "passed",
+  "variant": "B"
+}
+```
+
+Run the regression suite:
+
+```powershell
+pnpm exec vitest run tests/lib/alpha-review-e2e-harness.test.ts
+```
+
+The suite also proves that a live-shaped run and a record containing an identifying
+field fail closed.
+
+## Harness contract
+
+### Inputs
+
+- versioned synthetic run document;
+- pseudonymous ID matching `AER-SIM-*`;
+- Variant A-D assigned in the invitation and used on first exposure;
+- external-effect flags, all `false`;
+- simulated domain-safety and privacy route preflights;
+- exact ordered event sequence; and
+- explicit false evidence claims.
+
+### Outputs
+
+Success emits one minimized JSON summary to standard output. Failure emits one
+generic contract error to standard error and exits nonzero. The harness performs
+no writes, network calls, messaging, posting, booking, payment, recording, or
+production access.
+
+### Fail-closed rules
+
+The run is rejected when it contains:
+
+- live mode or any external-effect flag set to `true`;
+- real/restricted data class;
+- identifying/contact, credential-number, recording, raw-note, address, or real
+  household keys;
+- unknown fields at the run, external-effect, route, evidence-claim, or event
+  levels;
+- missing, repeated, or reordered lifecycle events;
+- a variant introduced after invitation or a baseline shown before the variant;
+- Variant E as a live/session variant;
+- an unminimized finding or invalid disposition;
+- a created restricted record; or
+- any participant, usability, customer, market, safety, or Gate evidence claim.
+
+## Executed trace
+
+| Step | Fixture evidence                                           | Result |
+| ---- | ---------------------------------------------------------- | ------ |
+| 1    | `AER-SIM-001`, synthetic nomination, harness-only conflict | Pass   |
+| 2    | Both escalation route classes simulated and preflighted    | Pass   |
+| 3    | Variant B present in invitation preview                    | Pass   |
+| 4    | Consent acknowledgement simulated; no notes created        | Pass   |
+| 5    | Variant B used on first exposure; baseline not shown       | Pass   |
+| 6    | High, variant-specific minimized category captured         | Pass   |
+| 7    | `revise_before_more_alpha`; reliance `none`                | Pass   |
+| 8    | Review date scheduled; restricted record not created       | Pass   |
+
+Negative traces:
+
+- live-shaped fixture: rejected before workflow execution;
+- identifying-field fixture: rejected before workflow execution.
+
+## Trace envelope
+
+```text
+Trace ID: hov-alpha-review-e2e-20260726
+Mode: synthetic_harness
+Candidate ID: AER-SIM-001
+Pack/variant: AER-SYNTH-001-v1 / B
+External effects: none
+Participant/usability evidence: none
+Restricted record: not created
+Disposition: revise_before_more_alpha
+Live activation: blocked
+```
+
+## Remaining live E2E inputs
+
+An actual personal or recommended reviewer session still requires non-public owner
+decisions and records:
+
+1. nominated candidate identity/contact mapped to a pseudonymous candidate ID;
+2. relationship, recommendation-chain, conflict, and compensation disposition;
+3. direct opt-in language and note/recording choice;
+4. restricted store, record owner, deletion owner, and review date;
+5. facilitator;
+6. tested, reachable `DomainSafetyReviewer` escalation route; and
+7. tested, reachable privacy escalation route.
+
+Do not put those personal/contact details in Git or Baton. Completing this
+synthetic E2E does not approve O1-O7 or permit external outreach.

--- a/docs/05-project/2026-07-26-under-sink-leak-gate-0-evidence-log.md
+++ b/docs/05-project/2026-07-26-under-sink-leak-gate-0-evidence-log.md
@@ -33,6 +33,7 @@ restricted research store before fieldwork.
 | Alpha reviewer capability   | `pending owner approval`                                                      |
 | Alpha reviewer micro-trial  | `not started`                                                                 |
 | Alpha synthetic trial pack  | `AER-SYNTH-001-v1 internal structural dry-run passed; activation gate closed` |
+| Alpha operational E2E       | `alpha-review-e2e-v1 synthetic harness passed; live activation blocked`       |
 | Decision meeting owner/date | `pending`                                                                     |
 
 ## Owner decisions

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:install": "npx playwright install chromium",
+    "verify:alpha-review-e2e": "node scripts/verify-alpha-review-e2e.mjs tests/fixtures/alpha-review/synthetic-complete.json",
     "inngest:dev": "npx --ignore-scripts=false @inngest/cli@1.17.1 dev",
     "verify": "npm run build && npm run lint && npm run format:check && npm test",
     "spell": "cspell \"**/*\"",

--- a/scripts/verify-alpha-review-e2e.mjs
+++ b/scripts/verify-alpha-review-e2e.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+
+const REQUIRED_EVENTS = [
+  "nomination_proposed",
+  "activation_preflight",
+  "invitation_previewed",
+  "consent_simulated",
+  "session_started",
+  "finding_recorded",
+  "session_closed",
+  "retention_scheduled",
+]
+
+const PROHIBITED_KEYS = new Set([
+  "address",
+  "candidateName",
+  "contactDetails",
+  "credentialNumber",
+  "email",
+  "phone",
+  "rawNotes",
+  "recording",
+  "realHouseholdId",
+])
+
+const ALLOWED_VARIANTS = new Set(["A", "B", "C", "D"])
+const ALLOWED_DISPOSITIONS = new Set([
+  "revise_before_more_alpha",
+  "run_next_variant",
+  "close_without_reliance",
+])
+
+const TOP_LEVEL_KEYS = [
+  "candidateId",
+  "dataClass",
+  "events",
+  "evidenceClaims",
+  "externalEffects",
+  "mode",
+  "packVersion",
+  "schemaVersion",
+  "simulatedEscalationRoutes",
+  "variant",
+]
+
+const EVENT_KEYS = {
+  nomination_proposed: ["conflictDisposition", "source", "type"],
+  activation_preflight: ["result", "type"],
+  invitation_previewed: ["delivery", "type", "variant"],
+  consent_simulated: ["notes", "result", "type"],
+  session_started: ["baselineShown", "firstExposure", "type", "variant"],
+  finding_recorded: ["behaviorCategory", "reproducibility", "severity", "type"],
+  session_closed: ["disposition", "reliance", "type"],
+  retention_scheduled: ["restrictedRecord", "reviewDue", "type"],
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function assertExactKeys(value, expectedKeys, path) {
+  assert(value && typeof value === "object" && !Array.isArray(value), `${path} must be an object`)
+  const actual = Object.keys(value).sort()
+  const expected = [...expectedKeys].sort()
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${path} contains missing or unknown fields`
+  )
+}
+
+function assertNoProhibitedKeys(value, path = "$") {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoProhibitedKeys(item, `${path}[${index}]`))
+    return
+  }
+
+  if (value === null || typeof value !== "object") {
+    return
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    assert(!PROHIBITED_KEYS.has(key), `prohibited key ${path}.${key}`)
+    assertNoProhibitedKeys(nested, `${path}.${key}`)
+  }
+}
+
+function eventIndex(events, type) {
+  return events.findIndex((event) => event.type === type)
+}
+
+export function validateAlphaReviewE2e(run) {
+  assert(run && typeof run === "object" && !Array.isArray(run), "run must be an object")
+  assertNoProhibitedKeys(run)
+  assertExactKeys(run, TOP_LEVEL_KEYS, "run")
+
+  assert(run.schemaVersion === "alpha-review-e2e-v1", "unsupported schemaVersion")
+  assert(run.mode === "synthetic_harness", "mode must be synthetic_harness")
+  assert(
+    /^AER-SIM-[A-Z0-9-]+$/.test(run.candidateId),
+    "candidateId must be synthetic and pseudonymous"
+  )
+  assert(run.packVersion === "AER-SYNTH-001-v1", "unexpected trial pack version")
+  assert(ALLOWED_VARIANTS.has(run.variant), "variant must be A, B, C, or D")
+  assert(run.dataClass === "synthetic", "dataClass must be synthetic")
+
+  const effects = run.externalEffects
+  const effectKeys = ["contacted", "invited", "recorded", "paid", "posted", "productionAccess"]
+  assertExactKeys(effects, effectKeys, "externalEffects")
+  for (const key of effectKeys) {
+    assert(effects[key] === false, `external effect ${key} must be false`)
+  }
+
+  const routes = run.simulatedEscalationRoutes
+  assertExactKeys(routes, ["domainSafety", "privacy"], "simulatedEscalationRoutes")
+  for (const key of ["domainSafety", "privacy"]) {
+    assertExactKeys(routes[key], ["preflight", "routeClass"], `simulatedEscalationRoutes.${key}`)
+    assert(
+      routes[key]?.routeClass === "simulated_not_live",
+      `${key} route must be simulated_not_live`
+    )
+    assert(routes[key]?.preflight === "passed", `${key} simulated preflight must pass`)
+  }
+
+  assert(Array.isArray(run.events), "events must be an array")
+  assert(
+    run.events.length === REQUIRED_EVENTS.length,
+    "events must contain the exact required sequence"
+  )
+  assert(
+    new Set(run.events.map((event) => event.type)).size === run.events.length,
+    "event types must not repeat"
+  )
+
+  REQUIRED_EVENTS.forEach((type, expectedIndex) => {
+    assert(
+      eventIndex(run.events, type) === expectedIndex,
+      `event ${type} is missing or out of order`
+    )
+    assertExactKeys(run.events[expectedIndex], EVENT_KEYS[type], `events[${expectedIndex}]`)
+  })
+
+  const invitation = run.events[eventIndex(run.events, "invitation_previewed")]
+  const session = run.events[eventIndex(run.events, "session_started")]
+  assert(invitation.variant === run.variant, "variant must be present in the invitation preview")
+  assert(invitation.delivery === "preview_only", "invitation must remain preview_only")
+  assert(session.variant === run.variant, "session first exposure must use the assigned variant")
+  assert(session.firstExposure === true, "session must record variant-first exposure")
+  assert(session.baselineShown === false, "baseline must not prime the simulated run")
+
+  const finding = run.events[eventIndex(run.events, "finding_recorded")]
+  assert(
+    ["critical", "high", "medium", "low"].includes(finding.severity),
+    "finding severity is invalid"
+  )
+  assert(
+    ["single", "variant_specific", "repeated"].includes(finding.reproducibility),
+    "finding reproducibility is invalid"
+  )
+  assert(
+    /^[a-z][a-z0-9_]{2,64}$/.test(finding.behaviorCategory),
+    "finding must use a minimized category slug"
+  )
+
+  const closed = run.events[eventIndex(run.events, "session_closed")]
+  assert(ALLOWED_DISPOSITIONS.has(closed.disposition), "session disposition is invalid")
+  assert(closed.reliance === "none", "synthetic harness output must have no reliance")
+
+  const retention = run.events[eventIndex(run.events, "retention_scheduled")]
+  assert(/^\d{4}-\d{2}-\d{2}$/.test(retention.reviewDue), "retention reviewDue must be YYYY-MM-DD")
+  assert(
+    retention.restrictedRecord === "simulated_not_created",
+    "no restricted record may be created"
+  )
+
+  const claims = run.evidenceClaims
+  const claimKeys = ["participant", "usability", "customer", "market", "safety", "gateAdvancement"]
+  assertExactKeys(claims, claimKeys, "evidenceClaims")
+  for (const key of claimKeys) {
+    assert(claims[key] === false, `evidence claim ${key} must be false`)
+  }
+
+  return {
+    candidateId: run.candidateId,
+    disposition: closed.disposition,
+    eventCount: run.events.length,
+    mode: run.mode,
+    packVersion: run.packVersion,
+    status: "passed",
+    variant: run.variant,
+  }
+}
+
+async function main() {
+  const fixturePath = process.argv[2]
+  assert(fixturePath, "usage: node scripts/verify-alpha-review-e2e.mjs <run.json>")
+
+  const absolutePath = resolve(process.cwd(), fixturePath)
+  const run = JSON.parse(await readFile(absolutePath, "utf8"))
+  const result = validateAlphaReviewE2e(run)
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+}
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+
+if (isDirectRun) {
+  main().catch((error) => {
+    process.stderr.write(`alpha-review-e2e failed: ${error.message}\n`)
+    process.exitCode = 1
+  })
+}

--- a/tests/fixtures/alpha-review/synthetic-complete.json
+++ b/tests/fixtures/alpha-review/synthetic-complete.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": "alpha-review-e2e-v1",
+  "mode": "synthetic_harness",
+  "candidateId": "AER-SIM-001",
+  "packVersion": "AER-SYNTH-001-v1",
+  "variant": "B",
+  "dataClass": "synthetic",
+  "externalEffects": {
+    "contacted": false,
+    "invited": false,
+    "recorded": false,
+    "paid": false,
+    "posted": false,
+    "productionAccess": false
+  },
+  "simulatedEscalationRoutes": {
+    "domainSafety": {
+      "routeClass": "simulated_not_live",
+      "preflight": "passed"
+    },
+    "privacy": {
+      "routeClass": "simulated_not_live",
+      "preflight": "passed"
+    }
+  },
+  "events": [
+    {
+      "type": "nomination_proposed",
+      "source": "synthetic_fixture",
+      "conflictDisposition": "accepted_for_harness_only"
+    },
+    {
+      "type": "activation_preflight",
+      "result": "synthetic_only"
+    },
+    {
+      "type": "invitation_previewed",
+      "delivery": "preview_only",
+      "variant": "B"
+    },
+    {
+      "type": "consent_simulated",
+      "notes": "none_created",
+      "result": "fixture_acknowledged"
+    },
+    {
+      "type": "session_started",
+      "variant": "B",
+      "firstExposure": true,
+      "baselineShown": false
+    },
+    {
+      "type": "finding_recorded",
+      "severity": "high",
+      "reproducibility": "variant_specific",
+      "behaviorCategory": "ordering_interpreted_as_endorsement"
+    },
+    {
+      "type": "session_closed",
+      "disposition": "revise_before_more_alpha",
+      "reliance": "none"
+    },
+    {
+      "type": "retention_scheduled",
+      "reviewDue": "2026-08-25",
+      "restrictedRecord": "simulated_not_created"
+    }
+  ],
+  "evidenceClaims": {
+    "participant": false,
+    "usability": false,
+    "customer": false,
+    "market": false,
+    "safety": false,
+    "gateAdvancement": false
+  }
+}

--- a/tests/fixtures/alpha-review/unsafe-live-shaped.json
+++ b/tests/fixtures/alpha-review/unsafe-live-shaped.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "alpha-review-e2e-v1",
+  "mode": "live",
+  "candidateId": "AER-SIM-UNSAFE",
+  "packVersion": "AER-SYNTH-001-v1",
+  "variant": "B",
+  "dataClass": "restricted",
+  "externalEffects": {
+    "contacted": true,
+    "invited": true,
+    "recorded": false,
+    "paid": false,
+    "posted": false,
+    "productionAccess": false
+  },
+  "simulatedEscalationRoutes": {},
+  "events": [],
+  "evidenceClaims": {
+    "participant": true,
+    "usability": true,
+    "customer": false,
+    "market": false,
+    "safety": false,
+    "gateAdvancement": false
+  }
+}

--- a/tests/fixtures/alpha-review/unsafe-pii-shaped.json
+++ b/tests/fixtures/alpha-review/unsafe-pii-shaped.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "alpha-review-e2e-v1",
+  "mode": "synthetic_harness",
+  "candidateId": "AER-SIM-PII",
+  "candidateName": "Forbidden Example",
+  "packVersion": "AER-SYNTH-001-v1",
+  "variant": "A",
+  "dataClass": "synthetic",
+  "externalEffects": {
+    "contacted": false,
+    "invited": false,
+    "recorded": false,
+    "paid": false,
+    "posted": false,
+    "productionAccess": false
+  },
+  "simulatedEscalationRoutes": {},
+  "events": [],
+  "evidenceClaims": {
+    "participant": false,
+    "usability": false,
+    "customer": false,
+    "market": false,
+    "safety": false,
+    "gateAdvancement": false
+  }
+}

--- a/tests/lib/alpha-review-e2e-harness.test.ts
+++ b/tests/lib/alpha-review-e2e-harness.test.ts
@@ -1,0 +1,47 @@
+import { spawnSync } from "node:child_process"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const verifier = resolve(process.cwd(), "scripts/verify-alpha-review-e2e.mjs")
+
+function runFixture(name: string) {
+  return spawnSync(
+    process.execPath,
+    [verifier, resolve(process.cwd(), "tests/fixtures/alpha-review", name)],
+    { encoding: "utf8" }
+  )
+}
+
+describe("alpha review operational E2E harness", () => {
+  it("completes the exact synthetic workflow without external effects or evidence claims", () => {
+    const result = runFixture("synthetic-complete.json")
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(JSON.parse(result.stdout)).toEqual({
+      candidateId: "AER-SIM-001",
+      disposition: "revise_before_more_alpha",
+      eventCount: 8,
+      mode: "synthetic_harness",
+      packVersion: "AER-SYNTH-001-v1",
+      status: "passed",
+      variant: "B",
+    })
+  })
+
+  it("fails closed when a run attempts live effects or evidence claims", () => {
+    const result = runFixture("unsafe-live-shaped.json")
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toContain("mode must be synthetic_harness")
+  })
+
+  it("rejects identifying fields before processing the workflow", () => {
+    const result = runFixture("unsafe-pii-shaped.json")
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toContain("prohibited key $.candidateName")
+  })
+})


### PR DESCRIPTION
Summary: adds a read-only alpha-review-e2e-v1 harness covering synthetic nomination through no-reliance closeout and retention; includes one successful lifecycle fixture plus fail-closed live-shaped and identifying-field regressions; records replay and remaining live activation inputs. Validation: direct E2E trace passed; new Vitest suite 3/3 passed; lint passed; production build passed; focused Prettier passed. Local full unit baseline was 364/366 because deployment-workflow-contract.test.ts has two existing Windows CRLF parsing failures in untouched code; Linux CI is authoritative. Boundaries: no real reviewer, outreach, PI, restricted record, production access, spend, evidence claim, or Gate advancement.