### PR TITLE
Add admin Gate governance control plane

### DIFF
--- a/app/api/governance/gates/route.ts
+++ b/app/api/governance/gates/route.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from "crypto"
+import { NextResponse } from "next/server"
+import { ZodError } from "zod"
+import { withRole } from "@/lib/auth/rbac"
+import {
+  GATE_ZERO_DECISIONS,
+  GATE_ZERO_ID,
+  GATE_ZERO_PROTOCOL_VERSION,
+  gateDecisionRequestSchema,
+  getMissingActivationPrerequisites,
+  isAllowedTransition,
+  type GateDecisionEvent,
+  type GateDecisionProjection,
+} from "@/lib/governance/gate-definitions"
+import { logger } from "@/lib/logger"
+import {
+  GateGovernanceConflictError,
+  GateGovernanceIdempotencyError,
+  GateGovernanceStoreUnavailableError,
+  getGateGovernanceRepository,
+} from "@/lib/repositories/gate-governance-repository"
+
+function projectDecisions(events: GateDecisionEvent[]): GateDecisionProjection[] {
+  return GATE_ZERO_DECISIONS.map((definition) => {
+    const history = events.filter((event) => event.decisionId === definition.id)
+    const current = history.at(-1) ?? null
+    return {
+      definition,
+      current,
+      history,
+      missingPrerequisites: current ? getMissingActivationPrerequisites(current) : [],
+    }
+  })
+}
+
+function storeUnavailableResponse() {
+  return NextResponse.json({ error: "Gate governance datastore is unavailable" }, { status: 503 })
+}
+
+export const GET = withRole("admin")(async () => {
+  try {
+    const { repository, mode } = await getGateGovernanceRepository()
+    const events = await repository.list(GATE_ZERO_ID, GATE_ZERO_PROTOCOL_VERSION)
+    const decisions = projectDecisions(events)
+    return NextResponse.json({
+      data: {
+        gate: {
+          id: GATE_ZERO_ID,
+          name: "Under-sink leak Gate 0",
+          protocolVersion: GATE_ZERO_PROTOCOL_VERSION,
+        },
+        decisions,
+        storage: mode,
+      },
+      summary: {
+        total: decisions.length,
+        active: decisions.filter((decision) => decision.current?.status === "active").length,
+        approvedInPrinciple: decisions.filter(
+          (decision) => decision.current?.status === "approved_in_principle"
+        ).length,
+      },
+    })
+  } catch (error) {
+    if (error instanceof GateGovernanceStoreUnavailableError) return storeUnavailableResponse()
+    logger.error("Gate governance read failed", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Failed to load Gate decisions" }, { status: 500 })
+  }
+})
+
+export const POST = withRole("admin")(async (request, context) => {
+  try {
+    const parsed = gateDecisionRequestSchema.parse(await request.json())
+    const { repository, mode } = await getGateGovernanceRepository()
+    const events = await repository.list(parsed.gateId, parsed.protocolVersion)
+    if (events.some((event) => event.idempotencyKey === parsed.idempotencyKey)) {
+      const result = await repository.append({
+        request: parsed,
+        actorId: context.userId,
+        actorRole: "admin",
+      })
+      return NextResponse.json({
+        data: { event: result.event, storage: mode },
+        summary: { created: false },
+      })
+    }
+
+    const current = events
+      .filter((event) => event.decisionId === parsed.decisionId)
+      .sort((left, right) => left.version - right.version)
+      .at(-1)
+
+    if (!isAllowedTransition(current?.status ?? null, parsed.status)) {
+      return NextResponse.json(
+        { error: "Invalid Gate decision transition", currentStatus: current?.status ?? "pending" },
+        { status: 409 }
+      )
+    }
+
+    if (parsed.status === "active") {
+      const missingPrerequisites = getMissingActivationPrerequisites(parsed)
+      if (missingPrerequisites.length > 0) {
+        return NextResponse.json(
+          { error: "Activation prerequisites are incomplete", missingPrerequisites },
+          { status: 422 }
+        )
+      }
+    }
+
+    const result = await repository.append({
+      request: parsed,
+      actorId: context.userId,
+      actorRole: "admin",
+    })
+    return NextResponse.json(
+      {
+        data: { event: result.event, storage: mode },
+        summary: { created: result.created },
+      },
+      { status: result.created ? 201 : 200 }
+    )
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        {
+          error: "Invalid Gate decision",
+          issues: error.issues.map((issue) => issue.path.join(".")),
+        },
+        { status: 400 }
+      )
+    }
+    if (error instanceof GateGovernanceStoreUnavailableError) return storeUnavailableResponse()
+    if (error instanceof GateGovernanceConflictError) {
+      return NextResponse.json({ error: "Gate decision version changed" }, { status: 409 })
+    }
+    if (error instanceof GateGovernanceIdempotencyError) {
+      return NextResponse.json({ error: "Idempotency key was reused" }, { status: 409 })
+    }
+    logger.error("Gate governance mutation failed", {
+      traceId: randomUUID(),
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Failed to record Gate decision" }, { status: 500 })
+  }
+})

--- a/app/dashboard/hans/governance/page.tsx
+++ b/app/dashboard/hans/governance/page.tsx
@@ -1,0 +1,536 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import DashboardLayout from "@/components/dashboard-layout"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { ApiError, apiFetch } from "@/lib/api-client"
+import {
+  GATE_ZERO_ID,
+  GATE_ZERO_PROTOCOL_VERSION,
+  getAllowedTransitions,
+  type GateDecisionProjection,
+  type GateDecisionStatus,
+} from "@/lib/governance/gate-definitions"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  History,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+} from "lucide-react"
+
+interface GovernanceResponse {
+  data: {
+    gate: { id: string; name: string; protocolVersion: string }
+    decisions: GateDecisionProjection[]
+    storage: "mongodb" | "memory"
+  }
+  summary: { total: number; active: number; approvedInPrinciple: number }
+}
+
+interface GovernanceForm {
+  status: GateDecisionStatus
+  rationale: string
+  evidenceRefs: string
+  reviewerCandidateId: string
+  responsiblePartyId: string
+  privacyReviewerId: string
+  researchOwnerId: string
+  restrictedStoreApproved: boolean
+  authorizedResearcherIds: string
+  retentionDeletionDeadline: string
+  correctionDeletionOwnerId: string
+  incidentOwnerId: string
+}
+
+const EMPTY_FORM: GovernanceForm = {
+  status: "approved_in_principle",
+  rationale: "",
+  evidenceRefs: "",
+  reviewerCandidateId: "",
+  responsiblePartyId: "",
+  privacyReviewerId: "",
+  researchOwnerId: "",
+  restrictedStoreApproved: false,
+  authorizedResearcherIds: "",
+  retentionDeletionDeadline: "",
+  correctionDeletionOwnerId: "",
+  incidentOwnerId: "",
+}
+
+const STATUS_LABELS: Record<GateDecisionStatus, string> = {
+  approved_in_principle: "Approved in principle",
+  active: "Active",
+  rejected: "Rejected",
+  superseded: "Superseded",
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && typeof error.body === "object" && error.body !== null) {
+    const body = error.body as { error?: unknown; missingPrerequisites?: unknown }
+    if (typeof body.error === "string") {
+      if (Array.isArray(body.missingPrerequisites)) {
+        return `${body.error}: ${body.missingPrerequisites.join(", ")}`
+      }
+      return body.error
+    }
+  }
+  return "The governance request could not be completed."
+}
+
+function statusBadge(status: GateDecisionStatus | null) {
+  if (status === "active") return <Badge className="bg-emerald-600">Active</Badge>
+  if (status === "approved_in_principle") {
+    return <Badge className="bg-amber-600">Approved in principle</Badge>
+  }
+  if (status === "rejected") return <Badge variant="destructive">Rejected</Badge>
+  if (status === "superseded") return <Badge variant="secondary">Superseded</Badge>
+  return <Badge variant="outline">Pending</Badge>
+}
+
+export default function GovernancePage() {
+  const [response, setResponse] = useState<GovernanceResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<GateDecisionProjection | null>(null)
+  const [form, setForm] = useState<GovernanceForm>(EMPTY_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [mutationError, setMutationError] = useState<string | null>(null)
+  const [savedMessage, setSavedMessage] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      setResponse(
+        await apiFetch<GovernanceResponse>("/api/governance/gates", {
+          label: "GateGovernance",
+        })
+      )
+    } catch (error) {
+      setLoadError(getErrorMessage(error))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const availableStatuses = useMemo(
+    () => getAllowedTransitions(selected?.current?.status ?? null),
+    [selected]
+  )
+
+  const openDecision = (decision: GateDecisionProjection) => {
+    const nextStatuses = getAllowedTransitions(decision.current?.status ?? null)
+    setSelected(decision)
+    setMutationError(null)
+    setSavedMessage(null)
+    setForm({ ...EMPTY_FORM, status: nextStatuses[0] ?? "approved_in_principle" })
+  }
+
+  const closeDecision = () => {
+    if (submitting) return
+    setSelected(null)
+    setMutationError(null)
+  }
+
+  const submitDecision = async () => {
+    if (!selected) return
+    setSubmitting(true)
+    setMutationError(null)
+    try {
+      const evidenceRefs = form.evidenceRefs
+        .split("\n")
+        .map((value) => value.trim())
+        .filter(Boolean)
+      const authorizedResearcherIds = form.authorizedResearcherIds
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean)
+
+      await apiFetch("/api/governance/gates", {
+        method: "POST",
+        label: "GateGovernanceMutation",
+        body: {
+          gateId: GATE_ZERO_ID,
+          protocolVersion: GATE_ZERO_PROTOCOL_VERSION,
+          decisionId: selected.definition.id,
+          status: form.status,
+          rationale: form.rationale,
+          evidenceRefs,
+          expectedVersion: selected.current?.version ?? 0,
+          idempotencyKey: crypto.randomUUID(),
+          prerequisites:
+            selected.definition.id === "O5"
+              ? { reviewerCandidateId: form.reviewerCandidateId || undefined }
+              : selected.definition.id === "O6"
+                ? {
+                    responsiblePartyId: form.responsiblePartyId || undefined,
+                    privacyReviewerId: form.privacyReviewerId || undefined,
+                    researchOwnerId: form.researchOwnerId || undefined,
+                    restrictedStoreApproved: form.restrictedStoreApproved,
+                    authorizedResearcherIds,
+                    retentionDeletionDeadline: form.retentionDeletionDeadline || undefined,
+                    correctionDeletionOwnerId: form.correctionDeletionOwnerId || undefined,
+                    incidentOwnerId: form.incidentOwnerId || undefined,
+                  }
+                : undefined,
+        },
+      })
+      setSelected(null)
+      setSavedMessage(`${selected.definition.id} decision recorded.`)
+      await load()
+    } catch (error) {
+      setMutationError(getErrorMessage(error))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <DashboardLayout persona="hans">
+      <div className="relative z-10 space-y-6" data-testid="gate-governance-page">
+        <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+          <div>
+            <h1 className="text-foreground flex items-center gap-3 text-2xl font-bold sm:text-3xl">
+              <ShieldCheck className="text-primary h-8 w-8" />
+              Gate Governance
+            </h1>
+            <p className="text-muted-foreground mt-1 max-w-3xl">
+              Record bounded owner decisions and activate them only when their prerequisites pass.
+              Decisions never launch recruitment, messaging, payment, fieldwork, or Gate 1.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => void load()} disabled={loading}>
+            <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        </div>
+
+        <Card className="border-amber-500/30 bg-amber-500/5">
+          <CardContent className="flex gap-3 pt-6 text-sm">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+            <p>
+              Store only pseudonymous IDs and non-sensitive evidence references here. Names, contact
+              details, credentials, consent evidence, raw notes, and restricted-store details belong
+              outside the general application datastore.
+            </p>
+          </CardContent>
+        </Card>
+
+        {savedMessage && (
+          <div
+            className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-300"
+            role="status"
+          >
+            <CheckCircle2 className="h-4 w-4" />
+            {savedMessage}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16" role="status">
+            <Loader2 className="text-primary h-8 w-8 animate-spin" />
+            <span className="sr-only">Loading Gate decisions</span>
+          </div>
+        ) : loadError ? (
+          <Card className="border-destructive/40">
+            <CardContent className="space-y-4 pt-6">
+              <p className="text-destructive" role="alert">
+                {loadError}
+              </p>
+              <Button onClick={() => void load()}>Retry</Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <div className="grid gap-4 sm:grid-cols-3">
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Decisions</CardDescription>
+                  <CardTitle>{response?.summary.total ?? 0}</CardTitle>
+                </CardHeader>
+              </Card>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Approved in principle</CardDescription>
+                  <CardTitle>{response?.summary.approvedInPrinciple ?? 0}</CardTitle>
+                </CardHeader>
+              </Card>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Active</CardDescription>
+                  <CardTitle>{response?.summary.active ?? 0}</CardTitle>
+                </CardHeader>
+              </Card>
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-2">
+              {response?.data.decisions.map((decision) => (
+                <Card
+                  key={decision.definition.id}
+                  data-testid={`gate-decision-${decision.definition.id}`}
+                >
+                  <CardHeader>
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <CardTitle className="flex items-center gap-2">
+                          <span>{decision.definition.id}</span>
+                          <span>{decision.definition.title}</span>
+                        </CardTitle>
+                        <CardDescription className="mt-2">
+                          {decision.definition.description}
+                        </CardDescription>
+                      </div>
+                      {statusBadge(decision.current?.status ?? null)}
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {decision.definition.activationRequirements.length > 0 && (
+                      <div className="border-border bg-muted/30 rounded-lg border p-3 text-sm">
+                        <p className="mb-2 font-medium">Activation prerequisites</p>
+                        <ul className="text-muted-foreground list-disc space-y-1 pl-5">
+                          {decision.definition.activationRequirements.map((requirement) => (
+                            <li key={requirement}>{requirement}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                    {decision.current && (
+                      <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                        <Clock3 className="h-4 w-4" />
+                        Version {decision.current.version} recorded{" "}
+                        {new Date(decision.current.createdAt).toLocaleString("en-ZA")}
+                      </div>
+                    )}
+
+                    {decision.history.length > 0 && (
+                      <details className="border-border rounded-lg border p-3 text-sm">
+                        <summary className="flex cursor-pointer items-center gap-2 font-medium">
+                          <History className="h-4 w-4" />
+                          Immutable history ({decision.history.length})
+                        </summary>
+                        <ol className="mt-3 space-y-3">
+                          {[...decision.history].reverse().map((event) => (
+                            <li key={event.id} className="border-border border-l-2 pl-3">
+                              <p className="font-medium">
+                                v{event.version}: {STATUS_LABELS[event.status]}
+                              </p>
+                              <p className="text-muted-foreground">{event.rationale}</p>
+                            </li>
+                          ))}
+                        </ol>
+                      </details>
+                    )}
+
+                    <Button
+                      onClick={() => openDecision(decision)}
+                      disabled={
+                        getAllowedTransitions(decision.current?.status ?? null).length === 0
+                      }
+                      data-testid={`record-decision-${decision.definition.id}`}
+                    >
+                      Record decision
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </>
+        )}
+
+        <Dialog open={selected !== null} onOpenChange={(open) => !open && closeDecision()}>
+          <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>
+                {selected?.definition.id}: {selected?.definition.title}
+              </DialogTitle>
+              <DialogDescription>
+                The server records your authenticated admin account and rejects stale or incomplete
+                activation attempts.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-5 py-2">
+              <div className="space-y-2">
+                <Label htmlFor="gate-status">Decision status</Label>
+                <Select
+                  value={form.status}
+                  onValueChange={(value) =>
+                    setForm((current) => ({ ...current, status: value as GateDecisionStatus }))
+                  }
+                >
+                  <SelectTrigger id="gate-status" data-testid="gate-status-select">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableStatuses.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {STATUS_LABELS[status]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="gate-rationale">Rationale or constraint</Label>
+                <Textarea
+                  id="gate-rationale"
+                  value={form.rationale}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, rationale: event.target.value }))
+                  }
+                  maxLength={1000}
+                  required
+                  data-testid="gate-rationale"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="gate-evidence">Non-sensitive evidence references</Label>
+                <Textarea
+                  id="gate-evidence"
+                  value={form.evidenceRefs}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, evidenceRefs: event.target.value }))
+                  }
+                  placeholder="One reference per line"
+                />
+              </div>
+
+              {selected?.definition.id === "O5" && form.status === "active" && (
+                <div className="border-border space-y-2 rounded-lg border p-4">
+                  <Label htmlFor="reviewer-candidate-id">Pseudonymous reviewer candidate ID</Label>
+                  <Input
+                    id="reviewer-candidate-id"
+                    value={form.reviewerCandidateId}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        reviewerCandidateId: event.target.value,
+                      }))
+                    }
+                    placeholder="R1"
+                    data-testid="reviewer-candidate-id"
+                  />
+                </div>
+              )}
+
+              {selected?.definition.id === "O6" && form.status === "active" && (
+                <div className="border-border grid gap-4 rounded-lg border p-4 sm:grid-cols-2">
+                  {[
+                    ["responsiblePartyId", "Responsible party ID"],
+                    ["privacyReviewerId", "Privacy/legal reviewer ID"],
+                    ["researchOwnerId", "Research owner ID"],
+                    ["correctionDeletionOwnerId", "Correction/deletion owner ID"],
+                    ["incidentOwnerId", "Incident owner ID"],
+                  ].map(([field, label]) => (
+                    <div className="space-y-2" key={field}>
+                      <Label htmlFor={field}>{label}</Label>
+                      <Input
+                        id={field}
+                        value={form[field as keyof GovernanceForm] as string}
+                        onChange={(event) =>
+                          setForm((current) => ({ ...current, [field]: event.target.value }))
+                        }
+                      />
+                    </div>
+                  ))}
+                  <div className="space-y-2">
+                    <Label htmlFor="authorizedResearcherIds">Authorized researcher IDs</Label>
+                    <Input
+                      id="authorizedResearcherIds"
+                      value={form.authorizedResearcherIds}
+                      onChange={(event) =>
+                        setForm((current) => ({
+                          ...current,
+                          authorizedResearcherIds: event.target.value,
+                        }))
+                      }
+                      placeholder="researcher-1, researcher-2"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="retentionDeletionDeadline">Retention/deletion deadline</Label>
+                    <Input
+                      id="retentionDeletionDeadline"
+                      type="date"
+                      value={form.retentionDeletionDeadline}
+                      onChange={(event) =>
+                        setForm((current) => ({
+                          ...current,
+                          retentionDeletionDeadline: event.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+                  <label className="flex items-center gap-3 sm:col-span-2">
+                    <input
+                      type="checkbox"
+                      checked={form.restrictedStoreApproved}
+                      onChange={(event) =>
+                        setForm((current) => ({
+                          ...current,
+                          restrictedStoreApproved: event.target.checked,
+                        }))
+                      }
+                      className="h-4 w-4"
+                    />
+                    Restricted store approved (details held outside this application)
+                  </label>
+                </div>
+              )}
+
+              {mutationError && (
+                <p className="text-destructive text-sm" role="alert">
+                  {mutationError}
+                </p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={closeDecision} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button
+                onClick={() => void submitDecision()}
+                disabled={submitting || form.rationale.trim().length < 3}
+                data-testid="submit-gate-decision"
+              >
+                {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Record immutable event
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/docs/05-project/2026-07-26-gate-0-owner-decision-brief.md
+++ b/docs/05-project/2026-07-26-gate-0-owner-decision-brief.md
@@ -1,16 +1,36 @@
 # Gate 0 owner decision brief
 
 - Date: 2026-07-26
-- Status: Recommendation only; no owner approval, reviewer appointment, or fieldwork authorization
+- Status: O1-O4 and O7 approved; O5-O6 approved in principle with activation inputs pending; reviewer appointment and fieldwork authorization remain open
 - Baton task: `9bba1180-b6a4-49cb-b1fc-45bdcbb4cd3c`
 - Governing protocol: [Under-sink leak Gate 0 discovery package](2026-07-26-under-sink-leak-gate-0-discovery-package.md)
 
 ## Purpose
 
-This brief reduces the remaining Gate 0 owner decisions to a reviewable form. It
-does not approve the research, provide legal advice, appoint a plumbing reviewer,
-authorize participant contact, or permit collection of personal information or
-real household media.
+This brief records the owner's 2026-07-26 decisions and preserves the remaining
+Gate 0 activation boundaries. It does not provide legal advice, appoint a
+plumbing reviewer, authorize participant contact or fieldwork, or permit
+collection of personal information or real household media.
+
+## Decision update
+
+The owner approved O1-O4 and O7 as recommended. The owner also approved the O5
+qualified-reviewer requirement and eligibility profile in principle, but no
+reviewer is appointed until a pseudonymous candidate ID and current eligibility
+evidence are supplied and accepted. O6 is approved in principle, but that
+approval is not operational until the responsible party, privacy/legal reviewer,
+research owner, restricted store, authorized researcher IDs, retention/deletion
+deadline, correction/deletion owner, and incident owner are recorded.
+
+Recruitment, live alpha activity, fieldwork, and Gate 1 implementation therefore
+remain prohibited. The canonical statuses and constraints are recorded in the
+[evidence log](2026-07-26-under-sink-leak-gate-0-evidence-log.md).
+
+The bounded admin control-plane implementation is described in the
+[Gate governance admin control plane](2026-07-26-gate-governance-admin-control-plane.md).
+It does not seed these documented decisions into runtime storage automatically;
+an authenticated admin must record the corresponding immutable events after the
+feature is deployed and its durable datastore is verified.
 
 ## Recommended owner decisions
 

--- a/docs/05-project/2026-07-26-gate-governance-admin-control-plane.md
+++ b/docs/05-project/2026-07-26-gate-governance-admin-control-plane.md
@@ -1,0 +1,134 @@
+# Gate governance admin control plane
+
+- Date: 2026-07-26
+- Status: Implemented and locally verified; not deployed
+- Baton task: `5445ec3b-386f-4624-b005-fd3d74ae3a13`
+- Parent Gate 0 task: `9bba1180-b6a4-49cb-b1fc-45bdcbb4cd3c`
+
+## Purpose
+
+The Gate governance control plane gives an authenticated administrator a durable,
+auditable place to record bounded Gate decisions. It is separate from kiosk
+approvals because a governance decision must not trigger inventory, notification,
+payment, recruitment, fieldwork, or Gate progression side effects.
+
+The initial scope covers O1-O7 for the under-sink leak Gate 0 protocol. Existing
+decisions in the evidence log are not automatically seeded into application
+storage. After deployment and datastore verification, an administrator must
+record the corresponding events through the interface.
+
+## Runtime surface
+
+| Surface                      | Purpose                                    |
+| ---------------------------- | ------------------------------------------ |
+| `/dashboard/hans/governance` | Admin-only decision and history interface  |
+| `GET /api/governance/gates`  | Read the seven definitions and projections |
+| `POST /api/governance/gates` | Append one authenticated decision event    |
+| `gate_governance_events`     | MongoDB append-only event collection       |
+
+The navigation entry appears only for the admin role. The API independently
+enforces `withRole("admin")`; UI visibility is not treated as authorization.
+
+## Decision model
+
+The supported states are:
+
+```text
+pending
+  -> approved_in_principle
+  -> rejected
+
+approved_in_principle
+  -> active
+  -> rejected
+  -> superseded
+
+active
+  -> superseded
+
+rejected or superseded
+  -> approved_in_principle
+```
+
+Every event records the Gate and protocol version, decision ID, new state,
+rationale, non-sensitive evidence references, monotonically increasing version,
+idempotency key, server-derived actor ID and role, and timestamp. The API rejects
+unknown fields, client-supplied actor fields, invalid transitions, stale expected
+versions, and changed payloads that reuse an idempotency key.
+
+## Activation gates
+
+O5 cannot become active without:
+
+- a pseudonymous reviewer candidate ID; and
+- at least one current eligibility evidence reference.
+
+O6 cannot become active without non-sensitive IDs or approvals for:
+
+- the responsible party;
+- privacy/legal reviewer;
+- research owner;
+- restricted store approval;
+- authorized researchers;
+- retention/deletion deadline;
+- correction/deletion owner; and
+- incident owner.
+
+Names, contact details, credentials, registration artifacts, consent evidence,
+raw notes, and restricted-store details remain prohibited from the general
+application datastore. The interface stores references, not the restricted
+records themselves.
+
+## Storage modes
+
+- Production and ordinary development fail closed when MongoDB is not configured.
+- Vitest uses an isolated in-memory repository.
+- Playwright may use memory only when `E2E_TEST=1` is set explicitly.
+- No demo decisions or users are enabled by this feature.
+
+MongoDB creates unique indexes for event ID, idempotency key, and
+Gate/protocol/decision/version. The current decision is a projection of immutable
+history; previous events are never overwritten or deleted by the API.
+
+## Verification evidence
+
+Commands run on 2026-07-26:
+
+```powershell
+pnpm exec vitest run tests/lib/gate-governance.test.ts tests/api/gate-governance.test.ts tests/lib/nav-config.test.ts tests/components/gate-governance-page.test.tsx
+pnpm run lint
+pnpm test
+pnpm run build
+```
+
+Results:
+
+- focused tests: 18/18 passed;
+- lint: passed;
+- production build: passed and emitted both governance routes;
+- full Vitest: 381/383 passed; the two failures are the pre-existing Windows
+  CRLF workflow-parser assertions in
+  `tests/lib/deployment-workflow-contract.test.ts`;
+- authenticated admin browser: page rendered seven pending decisions, displayed
+  activation prerequisites, and recorded an O5 approval-in-principle event with
+  versioned immutable history;
+- operator browser: direct navigation to the admin URL redirected to
+  `/dashboard/charl`;
+- local browser console retained the pre-existing unconfigured
+  `/api/projects?type=scope` error; the governance API and interaction succeeded.
+
+## Deployment acceptance
+
+Before treating the admin surface as operational:
+
+1. merge and deploy through the normal PR path;
+2. confirm the production app resolves its MongoDB configuration;
+3. use an authentic admin session to load the page and record a reversible
+   approval-in-principle event;
+4. reload and confirm history persists across the request and application restart;
+5. confirm an operator receives API 403 and cannot remain on the page; and
+6. enter O1-O7 from the evidence log without adding restricted data.
+
+O5 and O6 remain inactive until their exact prerequisites are supplied and
+accepted. Deployment of this interface does not authorize live alpha activity,
+fieldwork, external contact, or Gate 1.

--- a/docs/05-project/2026-07-26-under-sink-leak-gate-0-evidence-log.md
+++ b/docs/05-project/2026-07-26-under-sink-leak-gate-0-evidence-log.md
@@ -1,7 +1,7 @@
 # Under-sink leak Gate 0 evidence log
 
 - Date created: 2026-07-26
-- Status: Empty template; no field evidence collected
+- Status: Owner decisions recorded for O1-O4 and O7; O5-O6 approved in principle but activation inputs remain incomplete; no field evidence collected
 - Baton task: `9bba1180-b6a4-49cb-b1fc-45bdcbb4cd3c`
 - Protocol: [Gate 0 discovery package](2026-07-26-under-sink-leak-gate-0-discovery-package.md)
 
@@ -34,19 +34,20 @@ restricted research store before fieldwork.
 | Alpha reviewer micro-trial  | `not started`                                                                 |
 | Alpha synthetic trial pack  | `AER-SYNTH-001-v1 internal structural dry-run passed; activation gate closed` |
 | Alpha operational E2E       | `alpha-review-e2e-v1 synthetic harness passed; live activation blocked`       |
+| Admin governance control    | `implemented locally; deployment and production decision entry pending`       |
 | Decision meeting owner/date | `pending`                                                                     |
 
 ## Owner decisions
 
-| ID  | Decision                                                              | Status  | Owner/date | Rationale or constraint |
-| --- | --------------------------------------------------------------------- | ------- | ---------- | ----------------------- |
-| O1  | Use `moat`, not `NOAT`                                                | Pending | —          | —                       |
-| O2  | South Africa first                                                    | Pending | —          | —                       |
-| O3  | Private staffed household/small private estate is the customer unit   | Pending | —          | —                       |
-| O4  | Photo-to-resolution is the first problem test                         | Pending | —          | —                       |
-| O5  | Qualified plumbing reviewer nominated and eligibility accepted        | Pending | —          | —                       |
-| O6  | Privacy/safety protocol approved                                      | Pending | —          | —                       |
-| O7  | Subscription-funded neutral comparison hypothesis accepted or revised | Pending | —          | —                       |
+| ID  | Decision                                                              | Status                | Owner/date         | Rationale or constraint                                                                                                                                                                                                                                 |
+| --- | --------------------------------------------------------------------- | --------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| O1  | Use `moat`, not `NOAT`                                                | Approved              | Owner / 2026-07-26 | Recommendation accepted.                                                                                                                                                                                                                                |
+| O2  | South Africa first                                                    | Approved              | Owner / 2026-07-26 | Recommendation accepted as the bounded first test market.                                                                                                                                                                                               |
+| O3  | Private staffed household/small private estate is the customer unit   | Approved              | Owner / 2026-07-26 | Recommendation accepted; broader property-management and community-estate units remain excluded.                                                                                                                                                        |
+| O4  | Photo-to-resolution is the first problem test                         | Approved              | Owner / 2026-07-26 | Recommendation accepted within the coordination-only boundary; no automated diagnosis, DIY repair, or automatic purchasing.                                                                                                                             |
+| O5  | Qualified plumbing reviewer nominated and eligibility accepted        | Approved in principle | Owner / 2026-07-26 | Independent qualified-reviewer requirement and eligibility profile accepted; activation remains blocked until a pseudonymous candidate ID and current eligibility evidence are supplied and accepted.                                                   |
+| O6  | Privacy/safety protocol approved                                      | Approved in principle | Owner / 2026-07-26 | Proposed protocol accepted, but it is not operational until the responsible party, privacy reviewer, research owner, restricted store, authorized researchers, retention/deletion deadline, correction/deletion owner, and incident owner are recorded. |
+| O7  | Subscription-funded neutral comparison hypothesis accepted or revised | Approved              | Owner / 2026-07-26 | Subscription-funded neutral comparison accepted; checkout, purchasing, affiliate ranking, and supplier steering remain excluded.                                                                                                                        |
 
 ## Threshold change register
 

--- a/lib/governance/gate-definitions.ts
+++ b/lib/governance/gate-definitions.ts
@@ -1,0 +1,184 @@
+import { z } from "zod"
+
+export const GATE_ZERO_ID = "under-sink-leak-gate-0"
+export const GATE_ZERO_PROTOCOL_VERSION = "v1-draft"
+
+export const GATE_DECISION_STATUSES = [
+  "approved_in_principle",
+  "active",
+  "rejected",
+  "superseded",
+] as const
+
+export type GateDecisionStatus = (typeof GATE_DECISION_STATUSES)[number]
+export type GateDecisionId = "O1" | "O2" | "O3" | "O4" | "O5" | "O6" | "O7"
+
+export interface GateDecisionDefinition {
+  id: GateDecisionId
+  title: string
+  description: string
+  activationRequirements: string[]
+}
+
+export const GATE_ZERO_DECISIONS: GateDecisionDefinition[] = [
+  {
+    id: "O1",
+    title: "Moat terminology",
+    description: "Use moat rather than NOAT.",
+    activationRequirements: [],
+  },
+  {
+    id: "O2",
+    title: "First test market",
+    description: "Bound the first test market to South Africa.",
+    activationRequirements: [],
+  },
+  {
+    id: "O3",
+    title: "Customer unit",
+    description: "Use a private staffed household or small private estate.",
+    activationRequirements: [],
+  },
+  {
+    id: "O4",
+    title: "First problem test",
+    description: "Test photo-to-resolution coordination without diagnosis or purchasing.",
+    activationRequirements: [],
+  },
+  {
+    id: "O5",
+    title: "Qualified plumbing reviewer",
+    description: "Appoint an independent reviewer only after current eligibility is accepted.",
+    activationRequirements: [
+      "Pseudonymous reviewer candidate ID",
+      "Current eligibility evidence reference",
+    ],
+  },
+  {
+    id: "O6",
+    title: "Privacy and safety protocol",
+    description: "Activate the protocol only after accountable owners and controls are recorded.",
+    activationRequirements: [
+      "Responsible party ID",
+      "Privacy/legal reviewer ID",
+      "Research owner ID",
+      "Approved restricted store",
+      "Authorized researcher IDs",
+      "Retention/deletion deadline",
+      "Correction/deletion owner ID",
+      "Incident owner ID",
+    ],
+  },
+  {
+    id: "O7",
+    title: "Neutral comparison model",
+    description: "Use subscription-funded neutral comparison with commerce and steering excluded.",
+    activationRequirements: [],
+  },
+]
+
+const referenceSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/, "Use a non-sensitive reference, not free-form data")
+
+const pseudonymousIdSchema = z
+  .string()
+  .trim()
+  .min(2)
+  .max(64)
+  .regex(/^[A-Za-z][A-Za-z0-9._-]*$/, "Use a pseudonymous ID without spaces or contact data")
+
+export const gateDecisionRequestSchema = z
+  .object({
+    gateId: z.literal(GATE_ZERO_ID),
+    protocolVersion: z.literal(GATE_ZERO_PROTOCOL_VERSION),
+    decisionId: z.enum(["O1", "O2", "O3", "O4", "O5", "O6", "O7"]),
+    status: z.enum(GATE_DECISION_STATUSES),
+    rationale: z.string().trim().min(3).max(1000),
+    evidenceRefs: z.array(referenceSchema).max(20).default([]),
+    expectedVersion: z.number().int().min(0),
+    idempotencyKey: z.string().uuid(),
+    prerequisites: z
+      .object({
+        reviewerCandidateId: pseudonymousIdSchema.optional(),
+        responsiblePartyId: pseudonymousIdSchema.optional(),
+        privacyReviewerId: pseudonymousIdSchema.optional(),
+        researchOwnerId: pseudonymousIdSchema.optional(),
+        restrictedStoreApproved: z.boolean().optional(),
+        authorizedResearcherIds: z.array(pseudonymousIdSchema).max(20).optional(),
+        retentionDeletionDeadline: z
+          .string()
+          .regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD")
+          .optional(),
+        correctionDeletionOwnerId: pseudonymousIdSchema.optional(),
+        incidentOwnerId: pseudonymousIdSchema.optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+export type GateDecisionRequest = z.infer<typeof gateDecisionRequestSchema>
+
+export interface GateDecisionEvent extends GateDecisionRequest {
+  id: string
+  version: number
+  actorId: string
+  actorRole: "admin"
+  createdAt: string
+  requestFingerprint: string
+}
+
+export interface GateDecisionProjection {
+  definition: GateDecisionDefinition
+  current: GateDecisionEvent | null
+  history: GateDecisionEvent[]
+  missingPrerequisites: string[]
+}
+
+export function getMissingActivationPrerequisites(
+  request: Pick<GateDecisionRequest, "decisionId" | "evidenceRefs" | "prerequisites">
+): string[] {
+  if (request.decisionId === "O5") {
+    const missing: string[] = []
+    if (!request.prerequisites?.reviewerCandidateId) missing.push("reviewerCandidateId")
+    if (request.evidenceRefs.length === 0) missing.push("evidenceRefs")
+    return missing
+  }
+
+  if (request.decisionId !== "O6") return []
+
+  const prerequisites = request.prerequisites
+  const missing: string[] = []
+  if (!prerequisites?.responsiblePartyId) missing.push("responsiblePartyId")
+  if (!prerequisites?.privacyReviewerId) missing.push("privacyReviewerId")
+  if (!prerequisites?.researchOwnerId) missing.push("researchOwnerId")
+  if (prerequisites?.restrictedStoreApproved !== true) missing.push("restrictedStoreApproved")
+  if (!prerequisites?.authorizedResearcherIds?.length) missing.push("authorizedResearcherIds")
+  if (!prerequisites?.retentionDeletionDeadline) missing.push("retentionDeletionDeadline")
+  if (!prerequisites?.correctionDeletionOwnerId) missing.push("correctionDeletionOwnerId")
+  if (!prerequisites?.incidentOwnerId) missing.push("incidentOwnerId")
+  return missing
+}
+
+export function isAllowedTransition(
+  previous: GateDecisionStatus | null,
+  next: GateDecisionStatus
+): boolean {
+  if (previous === null) return next === "approved_in_principle" || next === "rejected"
+  if (previous === "approved_in_principle") {
+    return next === "active" || next === "rejected" || next === "superseded"
+  }
+  if (previous === "active") return next === "superseded"
+  if (previous === "rejected" || previous === "superseded") {
+    return next === "approved_in_principle"
+  }
+  return false
+}
+
+export function getAllowedTransitions(previous: GateDecisionStatus | null): GateDecisionStatus[] {
+  return GATE_DECISION_STATUSES.filter((status) => isAllowedTransition(previous, status))
+}

--- a/lib/nav-config.ts
+++ b/lib/nav-config.ts
@@ -22,6 +22,7 @@ import {
   CheckSquare,
   FolderKanban,
   ChefHat,
+  ShieldCheck,
   type LucideIcon,
 } from "lucide-react"
 import {
@@ -137,6 +138,13 @@ const PAGE_DEFINITIONS: PageDef[] = [
   { name: "OCR Scanner", href: "/dashboard", icon: ScanLine, category: "Tools", adminOnly: true },
   { name: "Marketplace", href: "/dashboard", icon: Store, category: "Tools", adminOnly: true },
   { name: "Reports", href: "/dashboard", icon: BarChart3, category: "Admin", adminOnly: true },
+  {
+    name: "Governance",
+    href: "/dashboard/hans/governance",
+    icon: ShieldCheck,
+    category: "Admin",
+    adminOnly: true,
+  },
   { name: "Settings", href: "/dashboard", icon: Settings, category: "Admin" },
   { name: "Recipes", href: "/dashboard", icon: ChefHat, category: "Operations" },
 ]
@@ -157,6 +165,7 @@ const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
     "OCR Scanner": "/dashboard/hans/ocr",
     Marketplace: "/dashboard/hans/marketplace",
     Reports: "/dashboard/hans/reports",
+    Governance: "/dashboard/hans/governance",
     Settings: "/dashboard/hans/settings",
     Recipes: "/dashboard/hans/recipes",
     Work: "/dashboard/hans/projects",

--- a/lib/repositories/gate-governance-repository.ts
+++ b/lib/repositories/gate-governance-repository.ts
@@ -1,0 +1,193 @@
+import { createHash, randomUUID } from "crypto"
+import type { Collection } from "mongodb"
+import { getCollection, isMongoConfigured, withoutMongoId } from "@/lib/db/mongodb"
+import type { GateDecisionEvent, GateDecisionRequest } from "@/lib/governance/gate-definitions"
+
+const COLLECTION_NAME = "gate_governance_events"
+
+export class GateGovernanceConflictError extends Error {}
+export class GateGovernanceIdempotencyError extends Error {}
+export class GateGovernanceStoreUnavailableError extends Error {}
+
+export interface AppendGateDecisionInput {
+  request: GateDecisionRequest
+  actorId: string
+  actorRole: "admin"
+  createdAt?: string
+}
+
+export interface AppendGateDecisionResult {
+  event: GateDecisionEvent
+  created: boolean
+}
+
+export interface GateGovernanceRepository {
+  list(
+    gateId: GateDecisionEvent["gateId"],
+    protocolVersion: GateDecisionEvent["protocolVersion"]
+  ): Promise<GateDecisionEvent[]>
+  append(input: AppendGateDecisionInput): Promise<AppendGateDecisionResult>
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function fingerprintGateDecision(request: GateDecisionRequest): string {
+  return createHash("sha256").update(JSON.stringify(request)).digest("hex")
+}
+
+function createEvent(input: AppendGateDecisionInput): GateDecisionEvent {
+  return {
+    ...clone(input.request),
+    id: randomUUID(),
+    version: input.request.expectedVersion + 1,
+    actorId: input.actorId,
+    actorRole: input.actorRole,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    requestFingerprint: fingerprintGateDecision(input.request),
+  }
+}
+
+let memoryEvents: GateDecisionEvent[] = []
+
+const memoryRepository: GateGovernanceRepository = {
+  async list(gateId, protocolVersion) {
+    return memoryEvents
+      .filter((event) => event.gateId === gateId && event.protocolVersion === protocolVersion)
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+      .map(clone)
+  },
+  async append(input) {
+    const fingerprint = fingerprintGateDecision(input.request)
+    const idempotent = memoryEvents.find(
+      (event) => event.idempotencyKey === input.request.idempotencyKey
+    )
+    if (idempotent) {
+      if (idempotent.requestFingerprint !== fingerprint) {
+        throw new GateGovernanceIdempotencyError("Idempotency key was reused")
+      }
+      return { event: clone(idempotent), created: false }
+    }
+
+    const currentVersion = memoryEvents
+      .filter(
+        (event) =>
+          event.gateId === input.request.gateId &&
+          event.protocolVersion === input.request.protocolVersion &&
+          event.decisionId === input.request.decisionId
+      )
+      .reduce((maximum, event) => Math.max(maximum, event.version), 0)
+
+    if (currentVersion !== input.request.expectedVersion) {
+      throw new GateGovernanceConflictError("Decision version changed")
+    }
+
+    const event = createEvent(input)
+    memoryEvents.push(event)
+    return { event: clone(event), created: true }
+  },
+}
+
+async function createMongoRepository(): Promise<GateGovernanceRepository> {
+  const collection: Collection<GateDecisionEvent> =
+    await getCollection<GateDecisionEvent>(COLLECTION_NAME)
+  await Promise.all([
+    collection.createIndex({ id: 1 }, { unique: true }),
+    collection.createIndex({ idempotencyKey: 1 }, { unique: true }),
+    collection.createIndex(
+      { gateId: 1, protocolVersion: 1, decisionId: 1, version: 1 },
+      { unique: true }
+    ),
+  ])
+
+  return {
+    async list(gateId, protocolVersion) {
+      const documents = await collection
+        .find({ gateId, protocolVersion })
+        .sort({ createdAt: 1 })
+        .toArray()
+      return documents.map(withoutMongoId)
+    },
+    async append(input) {
+      const fingerprint = fingerprintGateDecision(input.request)
+      const idempotent = await collection.findOne({
+        idempotencyKey: input.request.idempotencyKey,
+      })
+      if (idempotent) {
+        if (idempotent.requestFingerprint !== fingerprint) {
+          throw new GateGovernanceIdempotencyError("Idempotency key was reused")
+        }
+        return { event: withoutMongoId(idempotent), created: false }
+      }
+
+      const current = await collection.findOne(
+        {
+          gateId: input.request.gateId,
+          protocolVersion: input.request.protocolVersion,
+          decisionId: input.request.decisionId,
+        },
+        { sort: { version: -1 } }
+      )
+      if ((current?.version ?? 0) !== input.request.expectedVersion) {
+        throw new GateGovernanceConflictError("Decision version changed")
+      }
+
+      const event = createEvent(input)
+      try {
+        await collection.insertOne(event)
+        return { event, created: true }
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          error.code === 11000
+        ) {
+          const retry = await collection.findOne({
+            idempotencyKey: input.request.idempotencyKey,
+          })
+          if (retry) {
+            if (retry.requestFingerprint !== fingerprint) {
+              throw new GateGovernanceIdempotencyError("Idempotency key was reused")
+            }
+            return { event: withoutMongoId(retry), created: false }
+          }
+          throw new GateGovernanceConflictError("Decision version changed")
+        }
+        throw error
+      }
+    },
+  }
+}
+
+let cachedRepository: GateGovernanceRepository | null = null
+let cachedMode: "mongodb" | "memory" | null = null
+
+export async function getGateGovernanceRepository(): Promise<{
+  repository: GateGovernanceRepository
+  mode: "mongodb" | "memory"
+}> {
+  if (cachedRepository && cachedMode) return { repository: cachedRepository, mode: cachedMode }
+
+  const testMode = process.env.NODE_ENV === "test" || process.env.E2E_TEST === "1"
+  if (testMode) {
+    cachedRepository = memoryRepository
+    cachedMode = "memory"
+    return { repository: cachedRepository, mode: cachedMode }
+  }
+
+  if (!isMongoConfigured()) {
+    throw new GateGovernanceStoreUnavailableError("Gate governance datastore is not configured")
+  }
+
+  cachedRepository = await createMongoRepository()
+  cachedMode = "mongodb"
+  return { repository: cachedRepository, mode: cachedMode }
+}
+
+export function resetGateGovernanceRepositoryForTests(): void {
+  memoryEvents = []
+  cachedRepository = null
+  cachedMode = null
+}

--- a/tests/api/gate-governance.test.ts
+++ b/tests/api/gate-governance.test.ts
@@ -1,0 +1,170 @@
+import { randomUUID } from "crypto"
+import { beforeEach, describe, expect, it } from "vitest"
+import { GET, POST } from "@/app/api/governance/gates/route"
+import {
+  GATE_ZERO_ID,
+  GATE_ZERO_PROTOCOL_VERSION,
+  type GateDecisionStatus,
+} from "@/lib/governance/gate-definitions"
+import { resetGateGovernanceRepositoryForTests } from "@/lib/repositories/gate-governance-repository"
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-role": "admin",
+  "x-user-email": "admin@example.test",
+  "Content-Type": "application/json",
+}
+
+const operatorHeaders = {
+  "x-user-id": "operator-1",
+  "x-user-role": "operator",
+  "x-user-email": "operator@example.test",
+}
+
+function decisionRequest(
+  decisionId: "O1" | "O2" | "O3" | "O4" | "O5" | "O6" | "O7",
+  status: GateDecisionStatus,
+  expectedVersion: number,
+  overrides: Record<string, unknown> = {}
+) {
+  return new Request("http://localhost/api/governance/gates", {
+    method: "POST",
+    headers: adminHeaders,
+    body: JSON.stringify({
+      gateId: GATE_ZERO_ID,
+      protocolVersion: GATE_ZERO_PROTOCOL_VERSION,
+      decisionId,
+      status,
+      rationale: "Owner accepted the bounded recommendation.",
+      evidenceRefs: [],
+      expectedVersion,
+      idempotencyKey: randomUUID(),
+      ...overrides,
+    }),
+  })
+}
+
+describe("/api/governance/gates", () => {
+  beforeEach(() => {
+    resetGateGovernanceRepositoryForTests()
+  })
+
+  it("requires an authenticated admin for reads", async () => {
+    expect(await GET(new Request("http://localhost/api/governance/gates"))).toMatchObject({
+      status: 401,
+    })
+    expect(
+      await GET(new Request("http://localhost/api/governance/gates", { headers: operatorHeaders }))
+    ).toMatchObject({ status: 403 })
+  })
+
+  it("returns the empty seven-decision projection to an admin", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/governance/gates", { headers: adminHeaders })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data.decisions).toHaveLength(7)
+    expect(body.data.decisions[0].current).toBeNull()
+    expect(body.summary).toEqual({ total: 7, active: 0, approvedInPrinciple: 0 })
+  })
+
+  it("records the authenticated actor and rejects client-supplied actor fields", async () => {
+    const invalid = await POST(
+      decisionRequest("O1", "approved_in_principle", 0, { actorId: "spoofed-admin" })
+    )
+    expect(invalid.status).toBe(400)
+
+    const response = await POST(decisionRequest("O1", "approved_in_principle", 0))
+    const body = await response.json()
+    expect(response.status).toBe(201)
+    expect(body.data.event).toMatchObject({ actorId: "admin-1", actorRole: "admin", version: 1 })
+  })
+
+  it("returns the original event for an identical idempotent retry", async () => {
+    const payload = {
+      gateId: GATE_ZERO_ID,
+      protocolVersion: GATE_ZERO_PROTOCOL_VERSION,
+      decisionId: "O2",
+      status: "approved_in_principle",
+      rationale: "Owner accepted the bounded recommendation.",
+      evidenceRefs: [],
+      expectedVersion: 0,
+      idempotencyKey: randomUUID(),
+    }
+    const makeRequest = () =>
+      new Request("http://localhost/api/governance/gates", {
+        method: "POST",
+        headers: adminHeaders,
+        body: JSON.stringify(payload),
+      })
+
+    const first = await POST(makeRequest())
+    const firstBody = await first.json()
+    const retry = await POST(makeRequest())
+    const retryBody = await retry.json()
+
+    expect(first.status).toBe(201)
+    expect(retry.status).toBe(200)
+    expect(retryBody.summary.created).toBe(false)
+    expect(retryBody.data.event.id).toBe(firstBody.data.event.id)
+  })
+
+  it("requires approval in principle before activation", async () => {
+    const response = await POST(decisionRequest("O3", "active", 0))
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({ currentStatus: "pending" })
+  })
+
+  it("fails O5 activation closed until candidate and evidence references are present", async () => {
+    expect(await POST(decisionRequest("O5", "approved_in_principle", 0))).toMatchObject({
+      status: 201,
+    })
+
+    const blocked = await POST(decisionRequest("O5", "active", 1))
+    expect(blocked.status).toBe(422)
+    expect(await blocked.json()).toMatchObject({
+      missingPrerequisites: ["reviewerCandidateId", "evidenceRefs"],
+    })
+
+    const activated = await POST(
+      decisionRequest("O5", "active", 1, {
+        evidenceRefs: ["restricted-reviewer-record:R1/eligibility-v1"],
+        prerequisites: { reviewerCandidateId: "R1" },
+      })
+    )
+    expect(activated.status).toBe(201)
+  })
+
+  it("fails O6 activation closed until every governance prerequisite is present", async () => {
+    expect(await POST(decisionRequest("O6", "approved_in_principle", 0))).toMatchObject({
+      status: 201,
+    })
+    const blocked = await POST(
+      decisionRequest("O6", "active", 1, {
+        prerequisites: { restrictedStoreApproved: true },
+      })
+    )
+    expect(blocked.status).toBe(422)
+    const body = await blocked.json()
+    expect(body.missingPrerequisites).toContain("responsiblePartyId")
+    expect(body.missingPrerequisites).toContain("incidentOwnerId")
+
+    const activated = await POST(
+      decisionRequest("O6", "active", 1, {
+        prerequisites: {
+          responsiblePartyId: "responsible-party-1",
+          privacyReviewerId: "privacy-reviewer-1",
+          researchOwnerId: "research-owner-1",
+          restrictedStoreApproved: true,
+          authorizedResearcherIds: ["researcher-1"],
+          retentionDeletionDeadline: "2026-12-31",
+          correctionDeletionOwnerId: "deletion-owner-1",
+          incidentOwnerId: "incident-owner-1",
+        },
+      })
+    )
+    expect(activated.status).toBe(201)
+  })
+})

--- a/tests/components/gate-governance-page.test.tsx
+++ b/tests/components/gate-governance-page.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import GovernancePage from "@/app/dashboard/hans/governance/page"
+import { GATE_ZERO_DECISIONS } from "@/lib/governance/gate-definitions"
+
+const apiFetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-client", () => ({
+  apiFetch: apiFetchMock,
+  ApiError: class ApiError extends Error {
+    body?: unknown
+  },
+}))
+
+vi.mock("@/components/dashboard-layout", () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+function governanceResponse() {
+  return {
+    data: {
+      gate: {
+        id: "under-sink-leak-gate-0",
+        name: "Under-sink leak Gate 0",
+        protocolVersion: "v1-draft",
+      },
+      decisions: GATE_ZERO_DECISIONS.map((definition) => ({
+        definition,
+        current: null,
+        history: [],
+        missingPrerequisites: [],
+      })),
+      storage: "memory",
+    },
+    summary: { total: 7, active: 0, approvedInPrinciple: 0 },
+  }
+}
+
+describe("Gate governance page", () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    apiFetchMock.mockResolvedValue(governanceResponse())
+  })
+
+  it("renders all Gate decisions and the restricted-data warning", async () => {
+    render(<GovernancePage />)
+
+    expect(await screen.findByRole("heading", { name: "Gate Governance" })).toBeInTheDocument()
+    expect(screen.getByText(/Store only pseudonymous IDs/)).toBeInTheDocument()
+    await waitFor(() => expect(screen.getAllByText("Pending")).toHaveLength(7))
+    expect(screen.getByTestId("gate-decision-O5")).toHaveTextContent("Qualified plumbing reviewer")
+  })
+
+  it("opens the immutable decision form with the safe initial transition", async () => {
+    const user = userEvent.setup()
+    render(<GovernancePage />)
+
+    await user.click(await screen.findByTestId("record-decision-O5"))
+
+    expect(screen.getByRole("dialog")).toHaveTextContent("O5: Qualified plumbing reviewer")
+    expect(screen.getByTestId("gate-status-select")).toHaveTextContent("Approved in principle")
+    expect(screen.queryByTestId("reviewer-candidate-id")).not.toBeInTheDocument()
+    expect(screen.getByTestId("submit-gate-decision")).toBeDisabled()
+  })
+})

--- a/tests/lib/gate-governance.test.ts
+++ b/tests/lib/gate-governance.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  GATE_ZERO_ID,
+  GATE_ZERO_PROTOCOL_VERSION,
+  getMissingActivationPrerequisites,
+  isAllowedTransition,
+  type GateDecisionRequest,
+} from "@/lib/governance/gate-definitions"
+import {
+  GateGovernanceConflictError,
+  GateGovernanceIdempotencyError,
+  GateGovernanceStoreUnavailableError,
+  getGateGovernanceRepository,
+  resetGateGovernanceRepositoryForTests,
+} from "@/lib/repositories/gate-governance-repository"
+
+function request(overrides: Partial<GateDecisionRequest> = {}): GateDecisionRequest {
+  return {
+    gateId: GATE_ZERO_ID,
+    protocolVersion: GATE_ZERO_PROTOCOL_VERSION,
+    decisionId: "O1",
+    status: "approved_in_principle",
+    rationale: "Owner accepted the bounded recommendation.",
+    evidenceRefs: [],
+    expectedVersion: 0,
+    idempotencyKey: "00000000-0000-4000-8000-000000000001",
+    ...overrides,
+  }
+}
+
+describe("Gate governance rules", () => {
+  it("requires approval in principle before activation", () => {
+    expect(isAllowedTransition(null, "active")).toBe(false)
+    expect(isAllowedTransition(null, "approved_in_principle")).toBe(true)
+    expect(isAllowedTransition("approved_in_principle", "active")).toBe(true)
+    expect(isAllowedTransition("active", "rejected")).toBe(false)
+    expect(isAllowedTransition("active", "superseded")).toBe(true)
+  })
+
+  it("fails O5 activation closed without a candidate and evidence reference", () => {
+    expect(
+      getMissingActivationPrerequisites(
+        request({ decisionId: "O5", status: "active", evidenceRefs: [] })
+      )
+    ).toEqual(["reviewerCandidateId", "evidenceRefs"])
+  })
+
+  it("fails O6 activation closed until every accountability field is present", () => {
+    expect(
+      getMissingActivationPrerequisites(
+        request({
+          decisionId: "O6",
+          status: "active",
+          prerequisites: { restrictedStoreApproved: true },
+        })
+      )
+    ).toEqual([
+      "responsiblePartyId",
+      "privacyReviewerId",
+      "researchOwnerId",
+      "authorizedResearcherIds",
+      "retentionDeletionDeadline",
+      "correctionDeletionOwnerId",
+      "incidentOwnerId",
+    ])
+  })
+})
+
+describe("Gate governance repository", () => {
+  beforeEach(() => {
+    resetGateGovernanceRepositoryForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    resetGateGovernanceRepositoryForTests()
+  })
+
+  it("fails closed outside explicit test modes when MongoDB is unconfigured", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("E2E_TEST", "")
+    vi.stubEnv("MONGODB_URI", "")
+    vi.stubEnv("MONGO_URL", "")
+
+    await expect(getGateGovernanceRepository()).rejects.toBeInstanceOf(
+      GateGovernanceStoreUnavailableError
+    )
+  })
+
+  it("appends immutable versions and derives the stored actor from the server input", async () => {
+    const { repository, mode } = await getGateGovernanceRepository()
+    expect(mode).toBe("memory")
+
+    const result = await repository.append({
+      request: request(),
+      actorId: "admin-1",
+      actorRole: "admin",
+      createdAt: "2026-07-26T12:00:00.000Z",
+    })
+
+    expect(result.created).toBe(true)
+    expect(result.event).toMatchObject({ version: 1, actorId: "admin-1", actorRole: "admin" })
+    expect(await repository.list(GATE_ZERO_ID, GATE_ZERO_PROTOCOL_VERSION)).toHaveLength(1)
+  })
+
+  it("returns the original event for an identical idempotent retry", async () => {
+    const { repository } = await getGateGovernanceRepository()
+    const input = { request: request(), actorId: "admin-1", actorRole: "admin" as const }
+    const first = await repository.append(input)
+    const retry = await repository.append(input)
+
+    expect(retry.created).toBe(false)
+    expect(retry.event.id).toBe(first.event.id)
+  })
+
+  it("rejects stale versions and idempotency-key reuse with a changed payload", async () => {
+    const { repository } = await getGateGovernanceRepository()
+    await repository.append({ request: request(), actorId: "admin-1", actorRole: "admin" })
+
+    await expect(
+      repository.append({
+        request: request({
+          decisionId: "O2",
+          idempotencyKey: "00000000-0000-4000-8000-000000000002",
+        }),
+        actorId: "admin-1",
+        actorRole: "admin",
+      })
+    ).resolves.toMatchObject({ created: true })
+
+    await expect(
+      repository.append({
+        request: request({
+          idempotencyKey: "00000000-0000-4000-8000-000000000003",
+        }),
+        actorId: "admin-1",
+        actorRole: "admin",
+      })
+    ).rejects.toBeInstanceOf(GateGovernanceConflictError)
+
+    await expect(
+      repository.append({
+        request: request({ rationale: "A different decision body." }),
+        actorId: "admin-1",
+        actorRole: "admin",
+      })
+    ).rejects.toBeInstanceOf(GateGovernanceIdempotencyError)
+  })
+})

--- a/tests/lib/nav-config.test.ts
+++ b/tests/lib/nav-config.test.ts
@@ -19,4 +19,17 @@ describe("nav-config inventory access", () => {
       expect(items).toContainEqual(expect.objectContaining({ name: "Inventory", href }))
     }
   })
+
+  it("shows governance only in the admin navigation", () => {
+    const adminItems = flatten(buildNavEntries("hans", "admin", []))
+    const operatorItems = flatten(buildNavEntries("charl", "operator", []))
+
+    expect(adminItems).toContainEqual(
+      expect.objectContaining({
+        name: "Governance",
+        href: "/dashboard/hans/governance",
+      })
+    )
+    expect(operatorItems).not.toContainEqual(expect.objectContaining({ name: "Governance" }))
+  })
 })


### PR DESCRIPTION
## What changed

- add an admin-only Gate Governance page and navigation entry
- add strict GET/POST Gate decision APIs protected by server-side admin RBAC
- persist immutable decision events in the existing MongoDB authority
- enforce optimistic versions, idempotent retries, and allowed state transitions
- keep O5 and O6 activation fail-closed until their exact prerequisite references are complete
- update the Gate 0 decision record and add an operational control-plane note
- add repository, API, component, and navigation coverage

## Why

Gate 0 owner decisions were being recorded in documentation and Baton, but there was no durable application control plane that could distinguish approval in principle from operational activation. Reusing kiosk approvals would introduce the wrong data model and external side effects.

This implementation records governance decisions without triggering recruitment, messaging, payment, fieldwork, purchasing, or Gate progression.

## Security and data boundaries

- actor identity is derived from the authenticated admin session
- unknown and client-supplied actor fields are rejected
- production and ordinary development fail closed when MongoDB is unavailable
- memory storage is limited to Vitest and explicit E2E mode
- only pseudonymous IDs and non-sensitive evidence references belong in the collection
- no documented decisions are silently seeded into runtime state
- O5/O6 remain inactive until their prerequisites are supplied and accepted

## Validation

- focused Vitest: 18/18 passed
- `pnpm run lint`: passed
- `pnpm exec tsc --noEmit`: passed
- `pnpm run build`: passed
- changed-file Prettier and `git diff --check`: passed
- full Vitest: 381/383; only the documented Windows CRLF workflow-parser assertions in `tests/lib/deployment-workflow-contract.test.ts` failed
- real browser admin flow: seven decisions rendered and a test-only O5 approval-in-principle event persisted in memory with immutable version history
- real browser operator boundary: direct navigation redirected to `/dashboard/charl`

## Deployment acceptance still required

After merge/deploy, verify production MongoDB resolution, authentic admin persistence across reload and application restart, and operator API/page denial before entering O1-O7. O5/O6 activation and all live alpha/external effects remain blocked.