### PR TITLE
Add synthetic PIRB reviewer testing surface

### DIFF
--- a/app/api/reviewer-trials/domain-safety/route.ts
+++ b/app/api/reviewer-trials/domain-safety/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server"
+import { withRole } from "@/lib/auth/rbac"
+import { logger } from "@/lib/logger"
+import {
+  DOMAIN_SAFETY_CRITICAL_GATES,
+  DOMAIN_SAFETY_FINDING_CATEGORIES,
+  DOMAIN_SAFETY_PROFILE_VERSION,
+  DOMAIN_SAFETY_QUALITY_DIMENSIONS,
+  DOMAIN_SAFETY_SCENARIO_STEPS,
+  DOMAIN_SAFETY_SYNTHETIC_CANDIDATE_ID,
+  DOMAIN_SAFETY_TRIAL_PACK_VERSION,
+  DOMAIN_SAFETY_TRIAL_SCHEMA_VERSION,
+  DOMAIN_SAFETY_VARIANTS,
+  domainSafetyTrialSubmissionSchema,
+  evaluateDomainSafetyTrial,
+  findProhibitedDomainTrialKey,
+} from "@/lib/reviewer-trials/domain-safety-trial"
+
+export const GET = withRole("admin")(async () => {
+  return NextResponse.json({
+    data: {
+      schemaVersion: DOMAIN_SAFETY_TRIAL_SCHEMA_VERSION,
+      packVersion: DOMAIN_SAFETY_TRIAL_PACK_VERSION,
+      profileVersion: DOMAIN_SAFETY_PROFILE_VERSION,
+      candidateId: DOMAIN_SAFETY_SYNTHETIC_CANDIDATE_ID,
+      variants: DOMAIN_SAFETY_VARIANTS,
+      scenarioSteps: DOMAIN_SAFETY_SCENARIO_STEPS,
+      criticalGates: DOMAIN_SAFETY_CRITICAL_GATES,
+      qualityDimensions: DOMAIN_SAFETY_QUALITY_DIMENSIONS,
+      findingCategories: DOMAIN_SAFETY_FINDING_CATEGORIES,
+      provider: {
+        id: "pirb",
+        name: "Plumbing Industry Registration Board",
+        integrationStatus: "manual_preview_only",
+        verificationPerformed: false,
+        officialUrl: "https://www.pirb.co.za/",
+      },
+    },
+    summary: {
+      mode: "synthetic_rehearsal",
+      persisted: false,
+      externalEffects: false,
+      pirbEligibility: "not_evaluated",
+      o5Activation: false,
+    },
+  })
+})
+
+export const POST = withRole("admin")(async (request) => {
+  try {
+    const body: unknown = await request.json()
+    const prohibitedKey = findProhibitedDomainTrialKey(body)
+    if (prohibitedKey) {
+      return NextResponse.json(
+        { error: "Restricted reviewer data is prohibited", prohibitedKey },
+        { status: 400 }
+      )
+    }
+
+    const parsed = domainSafetyTrialSubmissionSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid synthetic reviewer rehearsal",
+          issues: parsed.error.issues.map((issue) => issue.path.join(".")),
+        },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json({
+      data: { evaluation: evaluateDomainSafetyTrial(parsed.data) },
+      summary: {
+        accepted: true,
+        persisted: false,
+        externalEffects: false,
+        pirbEligibility: "not_evaluated",
+        o5Activation: false,
+      },
+    })
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+    logger.error("Synthetic domain reviewer rehearsal failed", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Failed to evaluate synthetic rehearsal" }, { status: 500 })
+  }
+})

--- a/app/dashboard/hans/reviewer-lab/page.tsx
+++ b/app/dashboard/hans/reviewer-lab/page.tsx
@@ -1,0 +1,561 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import DashboardLayout from "@/components/dashboard-layout"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { ApiError, apiFetch } from "@/lib/api-client"
+import type {
+  DomainSafetyCriticalGateId,
+  DomainSafetyQualityId,
+  DomainSafetyTrialEvaluation,
+  DomainSafetyVariant,
+} from "@/lib/reviewer-trials/domain-safety-trial"
+import {
+  AlertTriangle,
+  Beaker,
+  CheckCircle2,
+  ExternalLink,
+  FlaskConical,
+  Loader2,
+  RefreshCw,
+  ShieldAlert,
+} from "lucide-react"
+
+type GateResult = "pass" | "fail" | "not_tested"
+type QualityResult = "clear" | "friction" | "failure" | "not_tested"
+type FindingSeverity = "none" | "critical" | "high" | "medium" | "low"
+
+interface LabDefinitionResponse {
+  data: {
+    schemaVersion: "domain-reviewer-lab-v1"
+    packVersion: "DSR-SYNTH-001-v1"
+    profileVersion: "za-domestic-drainage-v1"
+    candidateId: "DSR-SIM-001"
+    variants: Array<{ id: DomainSafetyVariant; title: string; description: string }>
+    scenarioSteps: Array<{ id: string; title: string; body: string }>
+    criticalGates: Array<{
+      id: DomainSafetyCriticalGateId
+      label: string
+      description: string
+    }>
+    qualityDimensions: Array<{ id: DomainSafetyQualityId; label: string }>
+    findingCategories: string[]
+    provider: {
+      id: "pirb"
+      name: string
+      integrationStatus: "manual_preview_only"
+      verificationPerformed: false
+      officialUrl: string
+    }
+  }
+  summary: {
+    mode: "synthetic_rehearsal"
+    persisted: false
+    externalEffects: false
+    pirbEligibility: "not_evaluated"
+    o5Activation: false
+  }
+}
+
+interface EvaluationResponse {
+  data: { evaluation: DomainSafetyTrialEvaluation }
+  summary: { accepted: boolean; persisted: false; externalEffects: false }
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError && typeof error.body === "object" && error.body !== null) {
+    const body = error.body as { error?: unknown }
+    if (typeof body.error === "string") return body.error
+  }
+  return "The synthetic rehearsal could not be evaluated."
+}
+
+function resultClasses(result: GateResult | QualityResult) {
+  if (result === "pass" || result === "clear") return "border-emerald-500/30 bg-emerald-500/5"
+  if (result === "fail" || result === "failure") return "border-red-500/30 bg-red-500/5"
+  if (result === "friction") return "border-amber-500/30 bg-amber-500/5"
+  return "border-border"
+}
+
+export default function ReviewerLabPage() {
+  const [definition, setDefinition] = useState<LabDefinitionResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [variant, setVariant] = useState<DomainSafetyVariant>("A")
+  const [criticalGates, setCriticalGates] = useState<Record<string, GateResult>>({})
+  const [qualityDimensions, setQualityDimensions] = useState<Record<string, QualityResult>>({})
+  const [findingSeverity, setFindingSeverity] = useState<FindingSeverity>("none")
+  const [findingCategory, setFindingCategory] = useState("unsafe_authority_inference")
+  const [findingStep, setFindingStep] = useState("classify")
+  const [reproducibility, setReproducibility] = useState<
+    "single" | "variant_specific" | "repeated"
+  >("variant_specific")
+  const [acknowledgements, setAcknowledgements] = useState([false, false, false])
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [evaluation, setEvaluation] = useState<DomainSafetyTrialEvaluation | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const response = await apiFetch<LabDefinitionResponse>("/api/reviewer-trials/domain-safety", {
+        label: "DomainReviewerLab",
+      })
+      setDefinition(response)
+      setCriticalGates(
+        Object.fromEntries(response.data.criticalGates.map(({ id }) => [id, "not_tested"]))
+      )
+      setQualityDimensions(
+        Object.fromEntries(response.data.qualityDimensions.map(({ id }) => [id, "not_tested"]))
+      )
+      setFindingCategory(response.data.findingCategories[0] ?? "unsafe_authority_inference")
+      setFindingStep(response.data.scenarioSteps[0]?.id ?? "classify")
+    } catch (error) {
+      setLoadError(getErrorMessage(error))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const selectedVariant = useMemo(
+    () => definition?.data.variants.find((item) => item.id === variant),
+    [definition, variant]
+  )
+  const canSubmit = acknowledgements.every(Boolean) && definition !== null && !submitting
+
+  const submitRehearsal = async () => {
+    if (!definition) return
+    setSubmitting(true)
+    setSubmitError(null)
+    setEvaluation(null)
+    try {
+      const response = await apiFetch<EvaluationResponse>("/api/reviewer-trials/domain-safety", {
+        method: "POST",
+        label: "DomainReviewerLabEvaluation",
+        body: {
+          schemaVersion: definition.data.schemaVersion,
+          mode: "synthetic_rehearsal",
+          candidateId: definition.data.candidateId,
+          packVersion: definition.data.packVersion,
+          profileVersion: definition.data.profileVersion,
+          variant,
+          dataClass: "synthetic",
+          pirbVerification: { mode: "manual_preview_only", status: "not_performed" },
+          externalEffects: {
+            contacted: false,
+            invited: false,
+            recorded: false,
+            paid: false,
+            posted: false,
+            productionAccess: false,
+            registryCall: false,
+          },
+          criticalGates,
+          qualityDimensions,
+          finding:
+            findingSeverity === "none"
+              ? null
+              : {
+                  scenarioStep: findingStep,
+                  category: findingCategory,
+                  severity: findingSeverity,
+                  reproducibility,
+                },
+        },
+      })
+      setEvaluation(response.data.evaluation)
+    } catch (error) {
+      setSubmitError(getErrorMessage(error))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <DashboardLayout persona="hans">
+      <div className="relative z-10 space-y-6" data-testid="domain-reviewer-lab-page">
+        <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+          <div>
+            <h1 className="text-foreground flex items-center gap-3 text-2xl font-bold sm:text-3xl">
+              <FlaskConical className="text-primary h-8 w-8" />
+              Domain Reviewer Lab
+            </h1>
+            <p className="text-muted-foreground mt-1 max-w-3xl">
+              Rehearse the synthetic South African plumbing-review contract before any PIRB
+              verification, candidate contact, or Gate activation.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => void load()} disabled={loading}>
+            <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            Reset rehearsal
+          </Button>
+        </div>
+
+        <Card className="border-amber-500/30 bg-amber-500/5">
+          <CardContent className="flex gap-3 pt-6 text-sm">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+            <div>
+              <p className="font-medium">Internal synthetic testing only</p>
+              <p className="text-muted-foreground mt-1">
+                Do not enter a name, contact detail, PIRB number, credential artifact, raw note,
+                recording, address, or real household evidence. This surface stores nothing and
+                cannot appoint a reviewer or activate O5.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16" role="status">
+            <Loader2 className="text-primary h-8 w-8 animate-spin" />
+            <span className="sr-only">Loading synthetic reviewer lab</span>
+          </div>
+        ) : loadError ? (
+          <Card className="border-destructive/40">
+            <CardContent className="space-y-4 pt-6">
+              <p className="text-destructive" role="alert">
+                {loadError}
+              </p>
+              <Button onClick={() => void load()}>Retry</Button>
+            </CardContent>
+          </Card>
+        ) : definition ? (
+          <>
+            <div className="grid gap-4 lg:grid-cols-3">
+              <Card>
+                <CardHeader>
+                  <CardDescription>Trial pack</CardDescription>
+                  <CardTitle className="text-lg">{definition.data.packVersion}</CardTitle>
+                </CardHeader>
+                <CardContent className="text-muted-foreground text-sm">
+                  Profile {definition.data.profileVersion}; fixed synthetic candidate{" "}
+                  {definition.data.candidateId}.
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardDescription>PIRB integration</CardDescription>
+                  <CardTitle className="text-lg">Manual preview only</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm">
+                  <p className="text-muted-foreground">
+                    No registry request or verification has been performed.
+                  </p>
+                  <a
+                    href={definition.data.provider.officialUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-primary inline-flex items-center gap-1 underline"
+                  >
+                    Official PIRB site <ExternalLink className="h-3 w-3" />
+                  </a>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardDescription>Runtime effects</CardDescription>
+                  <CardTitle className="text-lg">None</CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-wrap gap-2">
+                  <Badge variant="outline">Ephemeral</Badge>
+                  <Badge variant="outline">No contact</Badge>
+                  <Badge variant="outline">No O5 activation</Badge>
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Beaker className="h-5 w-5" /> Choose the first-exposure variant
+                </CardTitle>
+                <CardDescription>
+                  The assigned variant is shown before the scenario; the baseline must not prime the
+                  rehearsal.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-3 md:grid-cols-3">
+                {definition.data.variants.map((item) => (
+                  <button
+                    type="button"
+                    key={item.id}
+                    onClick={() => {
+                      setVariant(item.id)
+                      setEvaluation(null)
+                    }}
+                    className={`rounded-lg border p-4 text-left transition-colors ${
+                      variant === item.id
+                        ? "border-primary bg-primary/10"
+                        : "border-border hover:bg-muted/50"
+                    }`}
+                    aria-pressed={variant === item.id}
+                    data-testid={`reviewer-variant-${item.id}`}
+                  >
+                    <span className="font-semibold">
+                      Variant {item.id}: {item.title}
+                    </span>
+                    <span className="text-muted-foreground mt-2 block text-sm">
+                      {item.description}
+                    </span>
+                  </button>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card className="border-primary/30">
+              <CardHeader>
+                <CardDescription>Assigned injection</CardDescription>
+                <CardTitle>{selectedVariant?.title}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p>{selectedVariant?.description}</p>
+              </CardContent>
+            </Card>
+
+            <div className="grid gap-4 xl:grid-cols-2">
+              {definition.data.scenarioSteps.map((step, index) => (
+                <Card key={step.id} data-testid={`reviewer-step-${step.id}`}>
+                  <CardHeader>
+                    <CardDescription>Step {index + 1}</CardDescription>
+                    <CardTitle className="text-lg">{step.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="text-muted-foreground text-sm">{step.body}</CardContent>
+                </Card>
+              ))}
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Critical-gate rehearsal</CardTitle>
+                <CardDescription>
+                  These are simulated workflow outcomes, not candidate evidence or eligibility.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {definition.data.criticalGates.map((gate) => {
+                  const result = criticalGates[gate.id] ?? "not_tested"
+                  return (
+                    <div
+                      key={gate.id}
+                      className={`grid gap-3 rounded-lg border p-4 md:grid-cols-[1fr_180px] ${resultClasses(result)}`}
+                    >
+                      <div>
+                        <p className="font-medium">{gate.label}</p>
+                        <p className="text-muted-foreground text-sm">{gate.description}</p>
+                      </div>
+                      <label className="text-sm">
+                        <span className="sr-only">{gate.label} result</span>
+                        <select
+                          value={result}
+                          onChange={(event) =>
+                            setCriticalGates((current) => ({
+                              ...current,
+                              [gate.id]: event.target.value as GateResult,
+                            }))
+                          }
+                          className="border-input bg-background h-10 w-full rounded-md border px-3"
+                          data-testid={`critical-gate-${gate.id}`}
+                        >
+                          <option value="not_tested">Not tested</option>
+                          <option value="pass">Pass</option>
+                          <option value="fail">Fail</option>
+                        </select>
+                      </label>
+                    </div>
+                  )
+                })}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Quality dimensions</CardTitle>
+                <CardDescription>
+                  Capture bounded categories only; do not enter raw notes.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-3 md:grid-cols-2">
+                {definition.data.qualityDimensions.map((dimension) => {
+                  const result = qualityDimensions[dimension.id] ?? "not_tested"
+                  return (
+                    <label
+                      key={dimension.id}
+                      className={`rounded-lg border p-4 ${resultClasses(result)}`}
+                    >
+                      <span className="mb-2 block font-medium">{dimension.label}</span>
+                      <select
+                        value={result}
+                        onChange={(event) =>
+                          setQualityDimensions((current) => ({
+                            ...current,
+                            [dimension.id]: event.target.value as QualityResult,
+                          }))
+                        }
+                        className="border-input bg-background h-10 w-full rounded-md border px-3"
+                      >
+                        <option value="not_tested">Not tested</option>
+                        <option value="clear">Clear</option>
+                        <option value="friction">Friction</option>
+                        <option value="failure">Failure</option>
+                      </select>
+                    </label>
+                  )
+                })}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Optional minimized finding</CardTitle>
+                <CardDescription>
+                  Select categories only. The surface intentionally has no free-text field.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 md:grid-cols-4">
+                <label className="text-sm">
+                  <span className="mb-2 block font-medium">Severity</span>
+                  <select
+                    value={findingSeverity}
+                    onChange={(event) => setFindingSeverity(event.target.value as FindingSeverity)}
+                    className="border-input bg-background h-10 w-full rounded-md border px-3"
+                    data-testid="finding-severity"
+                  >
+                    <option value="none">No finding</option>
+                    <option value="critical">Critical</option>
+                    <option value="high">High</option>
+                    <option value="medium">Medium</option>
+                    <option value="low">Low</option>
+                  </select>
+                </label>
+                <label className="text-sm">
+                  <span className="mb-2 block font-medium">Step</span>
+                  <select
+                    value={findingStep}
+                    onChange={(event) => setFindingStep(event.target.value)}
+                    className="border-input bg-background h-10 w-full rounded-md border px-3"
+                    disabled={findingSeverity === "none"}
+                  >
+                    {definition.data.scenarioSteps.map((step) => (
+                      <option key={step.id} value={step.id}>
+                        {step.title}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="text-sm">
+                  <span className="mb-2 block font-medium">Category</span>
+                  <select
+                    value={findingCategory}
+                    onChange={(event) => setFindingCategory(event.target.value)}
+                    className="border-input bg-background h-10 w-full rounded-md border px-3"
+                    disabled={findingSeverity === "none"}
+                  >
+                    {definition.data.findingCategories.map((category) => (
+                      <option key={category} value={category}>
+                        {category.replaceAll("_", " ")}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="text-sm">
+                  <span className="mb-2 block font-medium">Reproducibility</span>
+                  <select
+                    value={reproducibility}
+                    onChange={(event) =>
+                      setReproducibility(
+                        event.target.value as "single" | "variant_specific" | "repeated"
+                      )
+                    }
+                    className="border-input bg-background h-10 w-full rounded-md border px-3"
+                    disabled={findingSeverity === "none"}
+                  >
+                    <option value="single">Single</option>
+                    <option value="variant_specific">Variant specific</option>
+                    <option value="repeated">Repeated</option>
+                  </select>
+                </label>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Fail-closed acknowledgements</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {[
+                  "Every person, provider, location, observation, and attachment in this rehearsal is fictional.",
+                  "No registry call, candidate contact, invitation, recording, payment, posting, production access, or persistence will occur.",
+                  "The result is not participant, usability, market, safety, PIRB eligibility, or Gate evidence.",
+                ].map((label, index) => (
+                  <label key={label} className="flex items-start gap-3 text-sm">
+                    <input
+                      type="checkbox"
+                      className="mt-0.5 h-4 w-4"
+                      checked={acknowledgements[index]}
+                      onChange={(event) =>
+                        setAcknowledgements((current) =>
+                          current.map((value, itemIndex) =>
+                            itemIndex === index ? event.target.checked : value
+                          )
+                        )
+                      }
+                      data-testid={`lab-acknowledgement-${index + 1}`}
+                    />
+                    {label}
+                  </label>
+                ))}
+                {submitError && (
+                  <p className="text-destructive text-sm" role="alert">
+                    {submitError}
+                  </p>
+                )}
+                <Button
+                  onClick={() => void submitRehearsal()}
+                  disabled={!canSubmit}
+                  data-testid="evaluate-domain-rehearsal"
+                >
+                  {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Evaluate synthetic rehearsal
+                </Button>
+              </CardContent>
+            </Card>
+
+            {evaluation && (
+              <Card className="border-emerald-500/30" data-testid="domain-rehearsal-result">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    {evaluation.disposition === "ready_for_internal_replay" ? (
+                      <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                    ) : (
+                      <ShieldAlert className="h-5 w-5 text-amber-500" />
+                    )}
+                    {evaluation.disposition.replaceAll("_", " ")}
+                  </CardTitle>
+                  <CardDescription>
+                    Variant {evaluation.variant}; reliance {evaluation.reliance}; PIRB eligibility{" "}
+                    {evaluation.pirbEligibility.replaceAll("_", " ")}.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-wrap gap-2 text-sm">
+                  <Badge variant="outline">Not persisted</Badge>
+                  <Badge variant="outline">No external effects</Badge>
+                  <Badge variant="outline">O5 inactive</Badge>
+                  <Badge variant="outline">
+                    {evaluation.incompleteCriticalGates.length} critical gates incomplete
+                  </Badge>
+                </CardContent>
+              </Card>
+            )}
+          </>
+        ) : null}
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/dashboard/hans/reviewer-lab/page.tsx
+++ b/app/dashboard/hans/reviewer-lab/page.tsx
@@ -100,6 +100,18 @@ export default function ReviewerLabPage() {
   const load = useCallback(async () => {
     setLoading(true)
     setLoadError(null)
+    setDefinition(null)
+    setVariant("A")
+    setCriticalGates({})
+    setQualityDimensions({})
+    setFindingSeverity("none")
+    setFindingCategory("unsafe_authority_inference")
+    setFindingStep("classify")
+    setReproducibility("variant_specific")
+    setAcknowledgements([false, false, false])
+    setSubmitting(false)
+    setSubmitError(null)
+    setEvaluation(null)
     try {
       const response = await apiFetch<LabDefinitionResponse>("/api/reviewer-trials/domain-safety", {
         label: "DomainReviewerLab",

--- a/docs/05-project/2026-07-26-independent-domain-reviewer-sourcing.md
+++ b/docs/05-project/2026-07-26-independent-domain-reviewer-sourcing.md
@@ -6,6 +6,8 @@
 - Baton task: `9bba1180-b6a4-49cb-b1fc-45bdcbb4cd3c`
 - Initial domain profile: South African domestic plumbing, limited to the Gate 0
   under-sink drain-joint triage protocol
+- Synthetic testing surface:
+  [PIRB domain reviewer testing surface](2026-07-26-pirb-domain-reviewer-testing-surface.md)
 
 ## Decision
 
@@ -413,19 +415,21 @@ scoring remain inside HOV governance, not inside the adapter.
 
 ## Recommended next action
 
-1. Owner approves or revises the abstraction, sourcing order, trial pack, and
+1. Complete and browser-verify the synthetic Domain Reviewer Lab before enabling
+   any PIRB registry or candidate-data integration.
+2. Owner approves or revises the abstraction, sourcing order, trial pack, and
    budget ceiling.
-2. Privacy owner approves which provider accounts may receive the synthetic
+3. Privacy owner approves which provider accounts may receive the synthetic
    bounty and candidate application data.
-3. Prepare three candidate slots: two from PIRB/IOPSA or Kandua and, only if the
+4. Prepare three candidate slots: two from PIRB/IOPSA or Kandua and, only if the
    owner wants an agent-marketplace comparison, one open RentAHuman bounty.
-4. Render previews only. Do not post or message until the owner approves the
+5. Render previews only. Do not post or message until the owner approves the
    exact preview and external effects.
-5. Run one paid trial at a time, score it, then decide whether a second route adds
+6. Run one paid trial at a time, score it, then decide whether a second route adds
    useful evidence before spending again.
-6. If the owner nominates a personal or recommended alpha reviewer, record only a
+7. If the owner nominates a personal or recommended alpha reviewer, record only a
    candidate ID and requested capability in Baton; keep identity and relationship
    details restricted, and run the alpha experience trial separately from the
    domain-safety trial.
-7. Internally dry-run the alpha pack before any invitation. Passing that rehearsal
+8. Internally dry-run the alpha pack before any invitation. Passing that rehearsal
    does not authorize contact, recording, compensation, or a live session.

--- a/docs/05-project/2026-07-26-pirb-domain-reviewer-testing-surface.md
+++ b/docs/05-project/2026-07-26-pirb-domain-reviewer-testing-surface.md
@@ -1,0 +1,115 @@
+# PIRB domain reviewer testing surface
+
+- Date: 2026-07-26
+- Status: Synthetic admin testing surface implemented locally; live PIRB integration not enabled
+- Baton task: `1d10b5fd-1b1b-4216-ada5-80942663fc83`
+- Parent Gate 0 task: `9bba1180-b6a4-49cb-b1fc-45bdcbb4cd3c`
+- Trial pack: `DSR-SYNTH-001-v1`
+- Domain profile: `za-domestic-drainage-v1`
+
+## Outcome
+
+The first integration stage is an admin-only Domain Reviewer Lab, not a live
+candidate or registry workflow. It makes the versioned synthetic plumbing-review
+contract testable before HOV transmits candidate information, calls a registry,
+contacts a professional, creates a restricted record, or relies on a review.
+
+| Surface                                   | Purpose                                                            |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| `/dashboard/hans/reviewer-lab`            | Run an ephemeral variant-first synthetic rehearsal                 |
+| `GET /api/reviewer-trials/domain-safety`  | Read the fixed pack, profile, variants, gates, and provider status |
+| `POST /api/reviewer-trials/domain-safety` | Validate and evaluate one no-reliance rehearsal without storing it |
+
+Both API operations require the admin role. The navigation entry is admin-only,
+but API RBAC remains the independent authorization boundary.
+
+## Test contract
+
+The lab uses fixed synthetic candidate ID `DSR-SIM-001` and variants:
+
+- A: electrical-proximity stop and escalation;
+- B: rejection of an unsupported dimension inference; and
+- C: rejection of supplier-funded commercial steering.
+
+The facilitator records only enumerated critical-gate, quality, severity,
+reproducibility, and behavior categories. There is deliberately no free-text
+evidence field. The server rejects unknown input, PII-shaped keys, credential or
+registration numbers, real-household fields, live data classes, registry calls,
+production access, contact, invitations, postings, recordings, and payments.
+
+An accepted result can only be:
+
+- `ready_for_internal_replay`;
+- `revise_test_surface`; or
+- `close_without_reliance`.
+
+Every result fixes reliance to `none`, PIRB eligibility to `not_evaluated`, O5
+activation to false, persistence to false, and external effects to false. A
+successful rehearsal is therefore evidence about the test surface contract only.
+
+## PIRB integration boundary
+
+The current provider status is `manual_preview_only`. The UI links to the official
+PIRB site but does not scrape it, submit a registration number, or claim an API
+contract that PIRB has not published and HOV has not approved.
+
+The later PIRB adapter must declare:
+
+```text
+purpose: verify current individual standing for a privately nominated candidate
+inputs: restricted candidate mapping and credential evidence
+outputs: candidate ID, verification source, timestamp, status, verifier ID,
+         profile version, evidence reference, and re-verification due date
+side effects: exact registry request and any provider processing
+idempotency: provider/request-dependent; re-query before retry
+storage: restricted evidence outside HOV; minimized reference in governance only
+owner: named O5 decision owner and privacy reviewer
+```
+
+Before enabling that adapter:
+
+1. O6 must have an approved restricted store, accountable role IDs, authorized
+   researchers, retention/deletion deadline, and incident path;
+2. the privacy reviewer must approve the exact PIRB fields, purpose, provider
+   terms, storage location, access, and deletion behavior;
+3. the owner must privately map a real candidate to a pseudonymous ID;
+4. HOV must confirm the supported official verification route and must not rely
+   on fragile or prohibited scraping;
+5. credentials and personal information must never enter Git, Baton, general
+   chat, logs, or the HOV general application datastore; and
+6. an authenticated browser acceptance must prove admin access, non-admin denial,
+   synthetic evaluation, and zero persistence/external effects.
+
+No candidate contact, appointment, payment, safety reliance, O5 activation, or
+Gate progression is authorized by this surface.
+
+## Validation
+
+Required verification for this API/UI/auth slice:
+
+```powershell
+pnpm exec vitest run tests/lib/domain-safety-trial.test.ts tests/api/domain-safety-reviewer-trial.test.ts tests/components/domain-reviewer-lab-page.test.tsx tests/lib/nav-config.test.ts
+pnpm run lint
+pnpm exec tsc --noEmit
+pnpm run build
+```
+
+Browser acceptance must use the explicit local E2E test mode: admin can complete
+a synthetic rehearsal, while an operator cannot remain on the page and receives
+API 403. No demo data or user flags are required.
+
+Local results on 2026-07-26:
+
+- focused Vitest: 13/13 passed across contract, API, component, and navigation;
+- lint: passed;
+- TypeScript: passed after the production build refreshed Next.js route types;
+- production build: passed and emitted both reviewer-lab routes;
+- full Vitest: 392/394 passed; the two failures are the pre-existing Windows
+  CRLF job-boundary assertions in `deployment-workflow-contract.test.ts`;
+- admin browser: Variant B completed as `ready_for_internal_replay` with
+  reliance `none`, PIRB eligibility `not_evaluated`, and `Not persisted`;
+- operator browser: direct page navigation redirected to `/dashboard/charl` and
+  the API returned HTTP 403; and
+- the dashboard retained the pre-existing unconfigured `/api/projects?type=scope`
+  error and local realtime reconnect noise; the reviewer-lab GET and POST both
+  completed successfully.

--- a/lib/nav-config.ts
+++ b/lib/nav-config.ts
@@ -23,6 +23,7 @@ import {
   FolderKanban,
   ChefHat,
   ShieldCheck,
+  FlaskConical,
   type LucideIcon,
 } from "lucide-react"
 import {
@@ -145,6 +146,13 @@ const PAGE_DEFINITIONS: PageDef[] = [
     category: "Admin",
     adminOnly: true,
   },
+  {
+    name: "Reviewer Lab",
+    href: "/dashboard/hans/reviewer-lab",
+    icon: FlaskConical,
+    category: "Admin",
+    adminOnly: true,
+  },
   { name: "Settings", href: "/dashboard", icon: Settings, category: "Admin" },
   { name: "Recipes", href: "/dashboard", icon: ChefHat, category: "Operations" },
 ]
@@ -166,6 +174,7 @@ const PERSONA_HREF_OVERRIDES: Record<string, Record<string, string>> = {
     Marketplace: "/dashboard/hans/marketplace",
     Reports: "/dashboard/hans/reports",
     Governance: "/dashboard/hans/governance",
+    "Reviewer Lab": "/dashboard/hans/reviewer-lab",
     Settings: "/dashboard/hans/settings",
     Recipes: "/dashboard/hans/recipes",
     Work: "/dashboard/hans/projects",

--- a/lib/reviewer-trials/domain-safety-trial.ts
+++ b/lib/reviewer-trials/domain-safety-trial.ts
@@ -1,0 +1,281 @@
+import { z } from "zod"
+
+export const DOMAIN_SAFETY_TRIAL_SCHEMA_VERSION = "domain-reviewer-lab-v1" as const
+export const DOMAIN_SAFETY_TRIAL_PACK_VERSION = "DSR-SYNTH-001-v1" as const
+export const DOMAIN_SAFETY_PROFILE_VERSION = "za-domestic-drainage-v1" as const
+export const DOMAIN_SAFETY_SYNTHETIC_CANDIDATE_ID = "DSR-SIM-001" as const
+
+export const DOMAIN_SAFETY_VARIANTS = [
+  {
+    id: "A",
+    title: "Electrical proximity stop",
+    description:
+      "The fictional observation includes moisture near an electrical connection. The safe workflow must stop and escalate.",
+  },
+  {
+    id: "B",
+    title: "Unsupported dimension inference",
+    description:
+      "The fictional pack asks whether a pipe diameter can be inferred from an unscaled placeholder image. The workflow must reject the inference.",
+  },
+  {
+    id: "C",
+    title: "Commercial steering prompt",
+    description:
+      "A fictional supplier-funded item is presented first. The workflow must preserve neutral evidence review and reject preference claims.",
+  },
+] as const
+
+export type DomainSafetyVariant = (typeof DOMAIN_SAFETY_VARIANTS)[number]["id"]
+
+export const DOMAIN_SAFETY_CRITICAL_GATES = [
+  {
+    id: "credential_process",
+    label: "Credential process",
+    description: "The rehearsal checks that current PIRB evidence would be independently verified.",
+  },
+  {
+    id: "jurisdiction_experience",
+    label: "Jurisdiction and experience",
+    description: "The exact South African domestic waste or drainage scope is tested.",
+  },
+  {
+    id: "independence",
+    label: "Independence",
+    description: "Supplier, referral, HOV, and outcome-linked conflicts are surfaced.",
+  },
+  {
+    id: "critical_defect_recall",
+    label: "Critical-defect recall",
+    description: "The assigned synthetic critical defect is identified and escalated.",
+  },
+  {
+    id: "unsafe_assertion",
+    label: "Unsafe assertion",
+    description:
+      "No diagnosis, part, dimension, repair, safe-delay, or compliance claim is invented.",
+  },
+  {
+    id: "data_boundary",
+    label: "Data boundary",
+    description:
+      "The rehearsal uses fictional text only and never requests real household evidence.",
+  },
+] as const
+
+export type DomainSafetyCriticalGateId = (typeof DOMAIN_SAFETY_CRITICAL_GATES)[number]["id"]
+
+export const DOMAIN_SAFETY_QUALITY_DIMENSIONS = [
+  { id: "evidence_classification", label: "Evidence classification" },
+  { id: "ambiguity_handling", label: "Ambiguity handling" },
+  { id: "stop_rule_quality", label: "Stop-rule quality" },
+  { id: "plain_language", label: "Plain language" },
+  { id: "traceable_rationale", label: "Traceable rationale" },
+  { id: "verification_design", label: "Verification design" },
+  { id: "version_incident_governance", label: "Version and incident governance" },
+] as const
+
+export type DomainSafetyQualityId = (typeof DOMAIN_SAFETY_QUALITY_DIMENSIONS)[number]["id"]
+
+export const DOMAIN_SAFETY_FINDING_CATEGORIES = [
+  "unsafe_authority_inference",
+  "missing_escalation",
+  "unsupported_dimension",
+  "supplier_steering",
+  "credential_process_gap",
+  "conflict_process_gap",
+  "real_data_request",
+  "unclear_wording",
+] as const
+
+export const DOMAIN_SAFETY_SCENARIO_STEPS = [
+  {
+    id: "classify",
+    title: "Classify the fictional observation",
+    body: "Moisture was noticed inside fictional kitchen cabinet K-01 after sink use. The source and cause are unknown.",
+  },
+  {
+    id: "stop",
+    title: "Apply stop and escalation rules",
+    body: "Decide whether the assigned variant requires the ordinary workflow to stop. Do not provide plumbing advice.",
+  },
+  {
+    id: "claims",
+    title: "Reject unsupported claims",
+    body: "Review proposed dimensions, parts, materials, timing, and compatibility. Unsupported items must be rejected or marked unresolved.",
+  },
+  {
+    id: "neutrality",
+    title: "Preserve commercial neutrality",
+    body: "Compare only verified scope, availability, fee basis, credential status, conflicts, and reliance limits. Do not rank or recommend.",
+  },
+  {
+    id: "closeout",
+    title: "Record a no-reliance closeout",
+    body: "The rehearsal may improve the test surface only. It cannot appoint a reviewer, approve safety, activate O5, or advance a Gate.",
+  },
+] as const
+
+const gateResultSchema = z.enum(["pass", "fail", "not_tested"])
+const qualityResultSchema = z.enum(["clear", "friction", "failure", "not_tested"])
+
+const externalEffectsSchema = z
+  .object({
+    contacted: z.literal(false),
+    invited: z.literal(false),
+    recorded: z.literal(false),
+    paid: z.literal(false),
+    posted: z.literal(false),
+    productionAccess: z.literal(false),
+    registryCall: z.literal(false),
+  })
+  .strict()
+
+const criticalGatesSchema = z
+  .object({
+    credential_process: gateResultSchema,
+    jurisdiction_experience: gateResultSchema,
+    independence: gateResultSchema,
+    critical_defect_recall: gateResultSchema,
+    unsafe_assertion: gateResultSchema,
+    data_boundary: gateResultSchema,
+  })
+  .strict()
+
+const qualityDimensionsSchema = z
+  .object({
+    evidence_classification: qualityResultSchema,
+    ambiguity_handling: qualityResultSchema,
+    stop_rule_quality: qualityResultSchema,
+    plain_language: qualityResultSchema,
+    traceable_rationale: qualityResultSchema,
+    verification_design: qualityResultSchema,
+    version_incident_governance: qualityResultSchema,
+  })
+  .strict()
+
+const findingSchema = z
+  .object({
+    scenarioStep: z.enum(["classify", "stop", "claims", "neutrality", "closeout"]),
+    category: z.enum(DOMAIN_SAFETY_FINDING_CATEGORIES),
+    severity: z.enum(["critical", "high", "medium", "low"]),
+    reproducibility: z.enum(["single", "variant_specific", "repeated"]),
+  })
+  .strict()
+
+export const domainSafetyTrialSubmissionSchema = z
+  .object({
+    schemaVersion: z.literal(DOMAIN_SAFETY_TRIAL_SCHEMA_VERSION),
+    mode: z.literal("synthetic_rehearsal"),
+    candidateId: z.literal(DOMAIN_SAFETY_SYNTHETIC_CANDIDATE_ID),
+    packVersion: z.literal(DOMAIN_SAFETY_TRIAL_PACK_VERSION),
+    profileVersion: z.literal(DOMAIN_SAFETY_PROFILE_VERSION),
+    variant: z.enum(["A", "B", "C"]),
+    dataClass: z.literal("synthetic"),
+    pirbVerification: z
+      .object({
+        mode: z.literal("manual_preview_only"),
+        status: z.literal("not_performed"),
+      })
+      .strict(),
+    externalEffects: externalEffectsSchema,
+    criticalGates: criticalGatesSchema,
+    qualityDimensions: qualityDimensionsSchema,
+    finding: findingSchema.nullable(),
+  })
+  .strict()
+
+export type DomainSafetyTrialSubmission = z.infer<typeof domainSafetyTrialSubmissionSchema>
+
+export interface DomainSafetyTrialEvaluation {
+  candidateId: typeof DOMAIN_SAFETY_SYNTHETIC_CANDIDATE_ID
+  packVersion: typeof DOMAIN_SAFETY_TRIAL_PACK_VERSION
+  variant: DomainSafetyVariant
+  disposition: "ready_for_internal_replay" | "revise_test_surface" | "close_without_reliance"
+  criticalFailures: DomainSafetyCriticalGateId[]
+  incompleteCriticalGates: DomainSafetyCriticalGateId[]
+  qualityFailures: DomainSafetyQualityId[]
+  findingCounts: Record<"critical" | "high" | "medium" | "low", number>
+  reliance: "none"
+  pirbEligibility: "not_evaluated"
+  o5Activation: false
+  persisted: false
+  externalEffects: false
+}
+
+const PROHIBITED_KEYS = new Set([
+  "address",
+  "candidateName",
+  "contactDetails",
+  "credentialNumber",
+  "email",
+  "identityDocument",
+  "phone",
+  "pirbNumber",
+  "rawNotes",
+  "recording",
+  "registrationNumber",
+  "realHouseholdId",
+])
+
+export function findProhibitedDomainTrialKey(value: unknown, path = "$"): string | null {
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const match = findProhibitedDomainTrialKey(value[index], `${path}[${index}]`)
+      if (match) return match
+    }
+    return null
+  }
+  if (value === null || typeof value !== "object") return null
+
+  for (const [key, nested] of Object.entries(value)) {
+    if (PROHIBITED_KEYS.has(key)) return `${path}.${key}`
+    const match = findProhibitedDomainTrialKey(nested, `${path}.${key}`)
+    if (match) return match
+  }
+  return null
+}
+
+export function evaluateDomainSafetyTrial(
+  submission: DomainSafetyTrialSubmission
+): DomainSafetyTrialEvaluation {
+  const criticalFailures = DOMAIN_SAFETY_CRITICAL_GATES.filter(
+    ({ id }) => submission.criticalGates[id] === "fail"
+  ).map(({ id }) => id)
+  const incompleteCriticalGates = DOMAIN_SAFETY_CRITICAL_GATES.filter(
+    ({ id }) => submission.criticalGates[id] === "not_tested"
+  ).map(({ id }) => id)
+  const qualityFailures = DOMAIN_SAFETY_QUALITY_DIMENSIONS.filter(
+    ({ id }) => submission.qualityDimensions[id] === "failure"
+  ).map(({ id }) => id)
+  const findingCounts = { critical: 0, high: 0, medium: 0, low: 0 }
+  if (submission.finding) findingCounts[submission.finding.severity] += 1
+
+  let disposition: DomainSafetyTrialEvaluation["disposition"] = "ready_for_internal_replay"
+  if (
+    criticalFailures.length > 0 ||
+    qualityFailures.length > 0 ||
+    findingCounts.critical > 0 ||
+    findingCounts.high > 0
+  ) {
+    disposition = "revise_test_surface"
+  } else if (incompleteCriticalGates.length > 0) {
+    disposition = "close_without_reliance"
+  }
+
+  return {
+    candidateId: submission.candidateId,
+    packVersion: submission.packVersion,
+    variant: submission.variant,
+    disposition,
+    criticalFailures,
+    incompleteCriticalGates,
+    qualityFailures,
+    findingCounts,
+    reliance: "none",
+    pirbEligibility: "not_evaluated",
+    o5Activation: false,
+    persisted: false,
+    externalEffects: false,
+  }
+}

--- a/lib/reviewer-trials/domain-safety-trial.ts
+++ b/lib/reviewer-trials/domain-safety-trial.ts
@@ -195,6 +195,7 @@ export interface DomainSafetyTrialEvaluation {
   criticalFailures: DomainSafetyCriticalGateId[]
   incompleteCriticalGates: DomainSafetyCriticalGateId[]
   qualityFailures: DomainSafetyQualityId[]
+  incompleteQualityDimensions: DomainSafetyQualityId[]
   findingCounts: Record<"critical" | "high" | "medium" | "low", number>
   reliance: "none"
   pirbEligibility: "not_evaluated"
@@ -248,6 +249,9 @@ export function evaluateDomainSafetyTrial(
   const qualityFailures = DOMAIN_SAFETY_QUALITY_DIMENSIONS.filter(
     ({ id }) => submission.qualityDimensions[id] === "failure"
   ).map(({ id }) => id)
+  const incompleteQualityDimensions = DOMAIN_SAFETY_QUALITY_DIMENSIONS.filter(
+    ({ id }) => submission.qualityDimensions[id] === "not_tested"
+  ).map(({ id }) => id)
   const findingCounts = { critical: 0, high: 0, medium: 0, low: 0 }
   if (submission.finding) findingCounts[submission.finding.severity] += 1
 
@@ -259,7 +263,7 @@ export function evaluateDomainSafetyTrial(
     findingCounts.high > 0
   ) {
     disposition = "revise_test_surface"
-  } else if (incompleteCriticalGates.length > 0) {
+  } else if (incompleteCriticalGates.length > 0 || incompleteQualityDimensions.length > 0) {
     disposition = "close_without_reliance"
   }
 
@@ -271,6 +275,7 @@ export function evaluateDomainSafetyTrial(
     criticalFailures,
     incompleteCriticalGates,
     qualityFailures,
+    incompleteQualityDimensions,
     findingCounts,
     reliance: "none",
     pirbEligibility: "not_evaluated",

--- a/tests/api/domain-safety-reviewer-trial.test.ts
+++ b/tests/api/domain-safety-reviewer-trial.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest"
+import { GET, POST } from "@/app/api/reviewer-trials/domain-safety/route"
+import {
+  DOMAIN_SAFETY_CRITICAL_GATES,
+  DOMAIN_SAFETY_QUALITY_DIMENSIONS,
+} from "@/lib/reviewer-trials/domain-safety-trial"
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-role": "admin",
+  "x-user-email": "admin@example.test",
+  "Content-Type": "application/json",
+}
+
+const operatorHeaders = {
+  "x-user-id": "operator-1",
+  "x-user-role": "operator",
+  "x-user-email": "operator@example.test",
+}
+
+function body() {
+  return {
+    schemaVersion: "domain-reviewer-lab-v1",
+    mode: "synthetic_rehearsal",
+    candidateId: "DSR-SIM-001",
+    packVersion: "DSR-SYNTH-001-v1",
+    profileVersion: "za-domestic-drainage-v1",
+    variant: "B",
+    dataClass: "synthetic",
+    pirbVerification: { mode: "manual_preview_only", status: "not_performed" },
+    externalEffects: {
+      contacted: false,
+      invited: false,
+      recorded: false,
+      paid: false,
+      posted: false,
+      productionAccess: false,
+      registryCall: false,
+    },
+    criticalGates: Object.fromEntries(DOMAIN_SAFETY_CRITICAL_GATES.map(({ id }) => [id, "pass"])),
+    qualityDimensions: Object.fromEntries(
+      DOMAIN_SAFETY_QUALITY_DIMENSIONS.map(({ id }) => [id, "clear"])
+    ),
+    finding: null,
+  }
+}
+
+function post(payload: unknown, headers = adminHeaders) {
+  return POST(
+    new Request("http://localhost/api/reviewer-trials/domain-safety", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    })
+  )
+}
+
+describe("/api/reviewer-trials/domain-safety", () => {
+  it("requires an authenticated admin", async () => {
+    expect(
+      await GET(new Request("http://localhost/api/reviewer-trials/domain-safety"))
+    ).toMatchObject({ status: 401 })
+    expect(
+      await GET(
+        new Request("http://localhost/api/reviewer-trials/domain-safety", {
+          headers: operatorHeaders,
+        })
+      )
+    ).toMatchObject({ status: 403 })
+  })
+
+  it("returns the synthetic contract without performing PIRB verification", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/reviewer-trials/domain-safety", { headers: adminHeaders })
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      data: {
+        packVersion: "DSR-SYNTH-001-v1",
+        provider: {
+          id: "pirb",
+          integrationStatus: "manual_preview_only",
+          verificationPerformed: false,
+        },
+      },
+      summary: { persisted: false, externalEffects: false, o5Activation: false },
+    })
+  })
+
+  it("evaluates a bounded rehearsal without persistence or eligibility claims", async () => {
+    const response = await post(body())
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      data: {
+        evaluation: {
+          disposition: "ready_for_internal_replay",
+          pirbEligibility: "not_evaluated",
+          o5Activation: false,
+          persisted: false,
+        },
+      },
+      summary: { accepted: true, persisted: false, externalEffects: false },
+    })
+  })
+
+  it("fails closed on restricted fields or attempted registry calls", async () => {
+    const restricted = await post({ ...body(), candidateName: "Prohibited" })
+    expect(restricted.status).toBe(400)
+    expect(await restricted.json()).toMatchObject({
+      error: "Restricted reviewer data is prohibited",
+      prohibitedKey: "$.candidateName",
+    })
+
+    const external = body()
+    external.externalEffects.registryCall = true
+    const externalResponse = await post(external)
+    expect(externalResponse.status).toBe(400)
+    expect(await externalResponse.json()).toMatchObject({
+      error: "Invalid synthetic reviewer rehearsal",
+    })
+  })
+
+  it("returns a bounded client error for malformed JSON", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/reviewer-trials/domain-safety", {
+        method: "POST",
+        headers: adminHeaders,
+        body: "{",
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: "Invalid JSON body" })
+  })
+})

--- a/tests/components/domain-reviewer-lab-page.test.tsx
+++ b/tests/components/domain-reviewer-lab-page.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import ReviewerLabPage from "@/app/dashboard/hans/reviewer-lab/page"
+import {
+  DOMAIN_SAFETY_CRITICAL_GATES,
+  DOMAIN_SAFETY_FINDING_CATEGORIES,
+  DOMAIN_SAFETY_QUALITY_DIMENSIONS,
+  DOMAIN_SAFETY_SCENARIO_STEPS,
+  DOMAIN_SAFETY_VARIANTS,
+} from "@/lib/reviewer-trials/domain-safety-trial"
+
+const apiFetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-client", () => ({
+  apiFetch: apiFetchMock,
+  ApiError: class ApiError extends Error {
+    body?: unknown
+  },
+}))
+
+vi.mock("@/components/dashboard-layout", () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+const definition = {
+  data: {
+    schemaVersion: "domain-reviewer-lab-v1",
+    packVersion: "DSR-SYNTH-001-v1",
+    profileVersion: "za-domestic-drainage-v1",
+    candidateId: "DSR-SIM-001",
+    variants: DOMAIN_SAFETY_VARIANTS,
+    scenarioSteps: DOMAIN_SAFETY_SCENARIO_STEPS,
+    criticalGates: DOMAIN_SAFETY_CRITICAL_GATES,
+    qualityDimensions: DOMAIN_SAFETY_QUALITY_DIMENSIONS,
+    findingCategories: DOMAIN_SAFETY_FINDING_CATEGORIES,
+    provider: {
+      id: "pirb",
+      name: "Plumbing Industry Registration Board",
+      integrationStatus: "manual_preview_only",
+      verificationPerformed: false,
+      officialUrl: "https://www.pirb.co.za/",
+    },
+  },
+  summary: {
+    mode: "synthetic_rehearsal",
+    persisted: false,
+    externalEffects: false,
+    pirbEligibility: "not_evaluated",
+    o5Activation: false,
+  },
+}
+
+const evaluation = {
+  data: {
+    evaluation: {
+      candidateId: "DSR-SIM-001",
+      packVersion: "DSR-SYNTH-001-v1",
+      variant: "B",
+      disposition: "close_without_reliance",
+      criticalFailures: [],
+      incompleteCriticalGates: ["credential_process"],
+      qualityFailures: [],
+      findingCounts: { critical: 0, high: 0, medium: 0, low: 0 },
+      reliance: "none",
+      pirbEligibility: "not_evaluated",
+      o5Activation: false,
+      persisted: false,
+      externalEffects: false,
+    },
+  },
+  summary: { accepted: true, persisted: false, externalEffects: false },
+}
+
+describe("Domain Reviewer Lab page", () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    apiFetchMock.mockImplementation((_url: string, options?: { method?: string }) =>
+      Promise.resolve(options?.method === "POST" ? evaluation : definition)
+    )
+  })
+
+  it("renders the synthetic-only PIRB boundary without free-text evidence fields", async () => {
+    render(<ReviewerLabPage />)
+
+    expect(await screen.findByRole("heading", { name: "Domain Reviewer Lab" })).toBeInTheDocument()
+    expect(screen.getByText("Internal synthetic testing only")).toBeInTheDocument()
+    expect(await screen.findByText("Manual preview only")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Official PIRB site/ })).toHaveAttribute(
+      "href",
+      "https://www.pirb.co.za/"
+    )
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+    expect(screen.getByTestId("evaluate-domain-rehearsal")).toBeDisabled()
+  })
+
+  it("submits only fixed synthetic categories after all acknowledgements", async () => {
+    const user = userEvent.setup()
+    render(<ReviewerLabPage />)
+
+    await user.click(await screen.findByTestId("reviewer-variant-B"))
+    await user.click(screen.getByTestId("lab-acknowledgement-1"))
+    await user.click(screen.getByTestId("lab-acknowledgement-2"))
+    await user.click(screen.getByTestId("lab-acknowledgement-3"))
+    await user.click(screen.getByTestId("evaluate-domain-rehearsal"))
+
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalledTimes(2))
+    const postOptions = apiFetchMock.mock.calls[1][1]
+    expect(postOptions).toMatchObject({
+      method: "POST",
+      body: {
+        candidateId: "DSR-SIM-001",
+        variant: "B",
+        dataClass: "synthetic",
+        pirbVerification: { status: "not_performed" },
+        externalEffects: { registryCall: false, contacted: false, productionAccess: false },
+      },
+    })
+    expect(await screen.findByTestId("domain-rehearsal-result")).toHaveTextContent(
+      "close without reliance"
+    )
+  })
+})

--- a/tests/components/domain-reviewer-lab-page.test.tsx
+++ b/tests/components/domain-reviewer-lab-page.test.tsx
@@ -62,6 +62,7 @@ const evaluation = {
       criticalFailures: [],
       incompleteCriticalGates: ["credential_process"],
       qualityFailures: [],
+      incompleteQualityDimensions: [],
       findingCounts: { critical: 0, high: 0, medium: 0, low: 0 },
       reliance: "none",
       pirbEligibility: "not_evaluated",
@@ -120,5 +121,27 @@ describe("Domain Reviewer Lab page", () => {
     expect(await screen.findByTestId("domain-rehearsal-result")).toHaveTextContent(
       "close without reliance"
     )
+  })
+
+  it("resets all run-specific state before reloading the rehearsal", async () => {
+    const user = userEvent.setup()
+    render(<ReviewerLabPage />)
+
+    await user.click(await screen.findByTestId("reviewer-variant-B"))
+    await user.click(screen.getByTestId("lab-acknowledgement-1"))
+    await user.click(screen.getByTestId("lab-acknowledgement-2"))
+    await user.click(screen.getByTestId("lab-acknowledgement-3"))
+    await user.click(screen.getByTestId("evaluate-domain-rehearsal"))
+    expect(await screen.findByTestId("domain-rehearsal-result")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Reset rehearsal" }))
+
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalledTimes(3))
+    expect(screen.queryByTestId("domain-rehearsal-result")).not.toBeInTheDocument()
+    expect(screen.getByTestId("reviewer-variant-A")).toHaveAttribute("aria-pressed", "true")
+    expect(screen.getByTestId("evaluate-domain-rehearsal")).toBeDisabled()
+    expect(screen.getByTestId("lab-acknowledgement-1")).not.toBeChecked()
+    expect(screen.getByTestId("lab-acknowledgement-2")).not.toBeChecked()
+    expect(screen.getByTestId("lab-acknowledgement-3")).not.toBeChecked()
   })
 })

--- a/tests/lib/domain-safety-trial.test.ts
+++ b/tests/lib/domain-safety-trial.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+import {
+  DOMAIN_SAFETY_CRITICAL_GATES,
+  DOMAIN_SAFETY_QUALITY_DIMENSIONS,
+  domainSafetyTrialSubmissionSchema,
+  evaluateDomainSafetyTrial,
+  findProhibitedDomainTrialKey,
+  type DomainSafetyTrialSubmission,
+} from "@/lib/reviewer-trials/domain-safety-trial"
+
+function submission(): DomainSafetyTrialSubmission {
+  return {
+    schemaVersion: "domain-reviewer-lab-v1",
+    mode: "synthetic_rehearsal",
+    candidateId: "DSR-SIM-001",
+    packVersion: "DSR-SYNTH-001-v1",
+    profileVersion: "za-domestic-drainage-v1",
+    variant: "A",
+    dataClass: "synthetic",
+    pirbVerification: { mode: "manual_preview_only", status: "not_performed" },
+    externalEffects: {
+      contacted: false,
+      invited: false,
+      recorded: false,
+      paid: false,
+      posted: false,
+      productionAccess: false,
+      registryCall: false,
+    },
+    criticalGates: Object.fromEntries(
+      DOMAIN_SAFETY_CRITICAL_GATES.map(({ id }) => [id, "pass"])
+    ) as DomainSafetyTrialSubmission["criticalGates"],
+    qualityDimensions: Object.fromEntries(
+      DOMAIN_SAFETY_QUALITY_DIMENSIONS.map(({ id }) => [id, "clear"])
+    ) as DomainSafetyTrialSubmission["qualityDimensions"],
+    finding: null,
+  }
+}
+
+describe("domain safety reviewer trial contract", () => {
+  it("returns only internal-replay readiness with no reliance or external effects", () => {
+    const result = evaluateDomainSafetyTrial(submission())
+
+    expect(result).toMatchObject({
+      disposition: "ready_for_internal_replay",
+      reliance: "none",
+      pirbEligibility: "not_evaluated",
+      o5Activation: false,
+      persisted: false,
+      externalEffects: false,
+    })
+  })
+
+  it("requires revision after a critical-gate failure or high finding", () => {
+    const run = submission()
+    run.criticalGates.unsafe_assertion = "fail"
+    run.finding = {
+      scenarioStep: "claims",
+      category: "unsupported_dimension",
+      severity: "high",
+      reproducibility: "variant_specific",
+    }
+
+    expect(evaluateDomainSafetyTrial(run)).toMatchObject({
+      disposition: "revise_test_surface",
+      criticalFailures: ["unsafe_assertion"],
+      findingCounts: { critical: 0, high: 1, medium: 0, low: 0 },
+    })
+  })
+
+  it("closes without reliance while any critical gate is not tested", () => {
+    const run = submission()
+    run.criticalGates.credential_process = "not_tested"
+
+    expect(evaluateDomainSafetyTrial(run)).toMatchObject({
+      disposition: "close_without_reliance",
+      incompleteCriticalGates: ["credential_process"],
+    })
+  })
+
+  it("rejects external effects and detects restricted keys before parsing", () => {
+    const unsafe = {
+      ...submission(),
+      externalEffects: { ...submission().externalEffects, registryCall: true },
+      nested: { candidateName: "Prohibited" },
+    }
+
+    expect(findProhibitedDomainTrialKey(unsafe)).toBe("$.nested.candidateName")
+    expect(domainSafetyTrialSubmissionSchema.safeParse(unsafe).success).toBe(false)
+  })
+})

--- a/tests/lib/domain-safety-trial.test.ts
+++ b/tests/lib/domain-safety-trial.test.ts
@@ -78,6 +78,16 @@ describe("domain safety reviewer trial contract", () => {
     })
   })
 
+  it("closes without reliance while any quality dimension is not tested", () => {
+    const run = submission()
+    run.qualityDimensions.ambiguity_handling = "not_tested"
+
+    expect(evaluateDomainSafetyTrial(run)).toMatchObject({
+      disposition: "close_without_reliance",
+      incompleteQualityDimensions: ["ambiguity_handling"],
+    })
+  })
+
   it("rejects external effects and detects restricted keys before parsing", () => {
     const unsafe = {
       ...submission(),

--- a/tests/lib/nav-config.test.ts
+++ b/tests/lib/nav-config.test.ts
@@ -20,7 +20,7 @@ describe("nav-config inventory access", () => {
     }
   })
 
-  it("shows governance only in the admin navigation", () => {
+  it("shows governance and the reviewer lab only in the admin navigation", () => {
     const adminItems = flatten(buildNavEntries("hans", "admin", []))
     const operatorItems = flatten(buildNavEntries("charl", "operator", []))
 
@@ -31,5 +31,12 @@ describe("nav-config inventory access", () => {
       })
     )
     expect(operatorItems).not.toContainEqual(expect.objectContaining({ name: "Governance" }))
+    expect(adminItems).toContainEqual(
+      expect.objectContaining({
+        name: "Reviewer Lab",
+        href: "/dashboard/hans/reviewer-lab",
+      })
+    )
+    expect(operatorItems).not.toContainEqual(expect.objectContaining({ name: "Reviewer Lab" }))
   })
 })


### PR DESCRIPTION
## Summary

- add an admin-only Domain Reviewer Lab for synthetic PIRB workflow rehearsal
- enforce a strict versioned contract with fixed fictional scenarios, enumerated findings, and no free-text inputs
- fail closed on candidate/credential/household data and prohibit persistence, registry calls, outreach, payment, recording, posting, and production access
- keep PIRB eligibility unevaluated and O5 inactive
- add API, contract, component, navigation tests, and the provider-boundary documentation

## Why

PIRB-aligned domain review needs a safe testing surface before any live provider verification integration. This gives administrators a deterministic rehearsal environment without handling real candidate data or causing external effects.

## Validation

- `pnpm exec vitest run tests/lib/domain-safety-trial.test.ts tests/api/domain-safety-reviewer-trial.test.ts tests/components/domain-reviewer-lab-page.test.tsx tests/lib/nav-config.test.ts` — 13/13 passed
- `pnpm run lint` — passed
- `pnpm exec tsc --noEmit` — passed serially after build route generation
- `pnpm run build` — passed
- Prettier changed-file check and `git diff --check` — passed
- full `pnpm test` — 392/394; only the two existing Windows CRLF deployment-workflow contract failures remain
- browser: Hans/admin completed Variant B to `ready_for_internal_replay`; Charl/operator was redirected and received API 403

## Safety boundary

This PR does not call PIRB, store trial records, process candidate PII, contact reviewers, issue invitations, record sessions, pay participants, post results, or activate O5. A live/manual provider adapter remains gated on the O6 restricted-store and privacy prerequisites.

Baton: `1d10b5fd-1b1b-4216-ada5-80942663fc83`