### PR TITLE
Prepare restricted O6 evidence storage

### DIFF
--- a/.azure/plan.md
+++ b/.azure/plan.md
@@ -1,6 +1,6 @@
 # Azure Deployment Plan
 
-> **Status:** Ready for Validation
+> **Status:** Validated
 
 Generated: 2026-07-17
 
@@ -16,27 +16,27 @@ Generated: 2026-07-17
 
 ## 2. Requirements
 
-| Attribute | Value |
-|-----------|-------|
-| Classification | Production MVP, private/single-user validation |
-| Scale | Small |
-| Budget | Cost-Optimized |
-| Subscription | Existing HOV Azure subscription already used by Terraform |
-| Location | southafricanorth |
-| Compliance | MVP sign-off only for Jurie/private use; broader public usage requires renewed legal/compliance sign-off |
+| Attribute        | Value                                                                                                                                                                                                                                                                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Classification   | Production MVP, private/single-user validation                                                                                                                                                                                                                                                                               |
+| Scale            | Small                                                                                                                                                                                                                                                                                                                        |
+| Budget           | Cost-Optimized                                                                                                                                                                                                                                                                                                               |
+| Subscription     | Existing HOV Azure subscription already used by Terraform                                                                                                                                                                                                                                                                    |
+| Location         | southafricanorth                                                                                                                                                                                                                                                                                                             |
+| Compliance       | MVP sign-off only for Jurie/private use; broader public usage requires renewed legal/compliance sign-off                                                                                                                                                                                                                     |
 | Docket Alignment | `https://docket.phoenixvc.tech` is the canonical Docket host for operational evidence. Live discovery on 2026-07-18 found OpenAPI at `/openapi.json`, Swagger UI at `/docs`, and health at `/health`. There is no assumed separate `DOCKET_BASE_URL` or ticket API in HOV until an authenticated write contract is selected. |
 
 ---
 
 ## 3. Components Detected
 
-| Component | Type | Technology | Path |
-|-----------|------|------------|------|
-| web | SSR Web App/API | Next.js 16 / TypeScript | `app/`, `lib/` |
-| functions | Scheduled worker | Python Azure Functions | `config/azure-functions/` |
-| infrastructure | IaC | Terraform | `terraform/` |
-| monitoring | Existing module | Azure Monitor / Log Analytics | `terraform/modules/monitoring/` |
-| docket | External evidence/ops system | FastAPI / Uvicorn | `https://docket.phoenixvc.tech` |
+| Component      | Type                         | Technology                    | Path                            |
+| -------------- | ---------------------------- | ----------------------------- | ------------------------------- |
+| web            | SSR Web App/API              | Next.js 16 / TypeScript       | `app/`, `lib/`                  |
+| functions      | Scheduled worker             | Python Azure Functions        | `config/azure-functions/`       |
+| infrastructure | IaC                          | Terraform                     | `terraform/`                    |
+| monitoring     | Existing module              | Azure Monitor / Log Analytics | `terraform/modules/monitoring/` |
+| docket         | External evidence/ops system | FastAPI / Uvicorn             | `https://docket.phoenixvc.tech` |
 
 ---
 
@@ -54,36 +54,36 @@ Generated: 2026-07-17
 
 ### Service Mapping
 
-| Component | Azure Service | SKU |
-|-----------|---------------|-----|
-| DealRadarRefresh telemetry | Azure Functions logs / traces | Existing Function App |
-| Radar API telemetry | App Service logs / traces | Existing Web App |
-| Radar alert rules | Azure Monitor scheduled query rules | Existing Log Analytics workspace |
-| Alert delivery | Azure Monitor action group | Existing monitoring action group |
-| MVP evidence record | Docket action/operations surface | Existing Docket host |
+| Component                  | Azure Service                       | SKU                              |
+| -------------------------- | ----------------------------------- | -------------------------------- |
+| DealRadarRefresh telemetry | Azure Functions logs / traces       | Existing Function App            |
+| Radar API telemetry        | App Service logs / traces           | Existing Web App                 |
+| Radar alert rules          | Azure Monitor scheduled query rules | Existing Log Analytics workspace |
+| Alert delivery             | Azure Monitor action group          | Existing monitoring action group |
+| MVP evidence record        | Docket action/operations surface    | Existing Docket host             |
 
 ### Supporting Services
 
-| Service | Purpose |
-|---------|---------|
-| Log Analytics | Centralized function/web logs queried by scheduled rules |
-| Application Insights | Runtime telemetry source for traces and exceptions |
-| Key Vault | Existing secret governance for runtime config |
-| Managed Identity | Existing service-to-service auth posture |
+| Service              | Purpose                                                  |
+| -------------------- | -------------------------------------------------------- |
+| Log Analytics        | Centralized function/web logs queried by scheduled rules |
+| Application Insights | Runtime telemetry source for traces and exceptions       |
+| Key Vault            | Existing secret governance for runtime config            |
+| Managed Identity     | Existing service-to-service auth posture                 |
 
 ### Docket Contract
 
 Live Docket API discovery:
 
-| Endpoint | Purpose | Notes |
-|----------|---------|-------|
-| `GET /health` | Runtime health | Public JSON: `{"status":"ok","backend":"table"}` |
-| `GET /openapi.json` | API contract | Public OpenAPI document titled `Cost Centre Adoption API` |
-| `GET /docs` | Swagger UI | Public API explorer |
-| `GET /action-log` | Unified action log | Authenticated; candidate read path for Radar monitoring/enable evidence |
-| `GET /resource-actions/pending` | Pending resource actions | Authenticated; candidate governance queue |
-| `POST /resource-actions/approve` and `/reject` | Decision recording | Authenticated; only suitable if Radar enablement is represented as a resource action |
-| `POST /api/azure-ops/workflows/run` | Run predefined workflow | Authenticated, dry-run default; do not call for Radar until a named workflow exists |
+| Endpoint                                       | Purpose                  | Notes                                                                                |
+| ---------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
+| `GET /health`                                  | Runtime health           | Public JSON: `{"status":"ok","backend":"table"}`                                     |
+| `GET /openapi.json`                            | API contract             | Public OpenAPI document titled `Cost Centre Adoption API`                            |
+| `GET /docs`                                    | Swagger UI               | Public API explorer                                                                  |
+| `GET /action-log`                              | Unified action log       | Authenticated; candidate read path for Radar monitoring/enable evidence              |
+| `GET /resource-actions/pending`                | Pending resource actions | Authenticated; candidate governance queue                                            |
+| `POST /resource-actions/approve` and `/reject` | Decision recording       | Authenticated; only suitable if Radar enablement is represented as a resource action |
+| `POST /api/azure-ops/workflows/run`            | Run predefined workflow  | Authenticated, dry-run default; do not call for Radar until a named workflow exists  |
 
 Radar 6 will align with Docket by documenting Radar enable/monitoring evidence in Docket-compatible terms and leaving a small adapter seam for the verified host. It will not invent or populate stale `DOCKET_BASE_URL` values, and it will not call destructive Docket resource-action endpoints in this PR.
 
@@ -93,11 +93,11 @@ Radar 6 will align with Docket by documenting Radar enable/monitoring evidence i
 
 This slice adds lightweight Azure Monitor alert-rule definitions only. It does not add compute, networking, storage, databases, public IPs, or container capacity.
 
-| Resource Type | Number to Deploy | Total After Deployment | Limit/Quota | Notes |
-|---------------|------------------|------------------------|-------------|-------|
-| Microsoft.Insights/scheduledQueryRules | 4 | Existing + 4 | Azure Monitor rule limit, no regional compute quota impact | Uses existing Log Analytics workspace and action group |
-| Microsoft.Insights/actionGroups | 0 | Existing | No change | Reuse existing module action group |
-| Microsoft.OperationalInsights/workspaces | 0 | Existing | No change | Reuse existing workspace |
+| Resource Type                            | Number to Deploy | Total After Deployment | Limit/Quota                                                | Notes                                                  |
+| ---------------------------------------- | ---------------- | ---------------------- | ---------------------------------------------------------- | ------------------------------------------------------ |
+| Microsoft.Insights/scheduledQueryRules   | 4                | Existing + 4           | Azure Monitor rule limit, no regional compute quota impact | Uses existing Log Analytics workspace and action group |
+| Microsoft.Insights/actionGroups          | 0                | Existing               | No change                                                  | Reuse existing module action group                     |
+| Microsoft.OperationalInsights/workspaces | 0                | Existing               | No change                                                  | Reuse existing workspace                               |
 
 **Status:** All planned changes have no compute/network/storage quota impact.
 
@@ -106,6 +106,7 @@ This slice adds lightweight Azure Monitor alert-rule definitions only. It does n
 ## 7. Execution Checklist
 
 ### Phase 1: Planning
+
 - [x] Analyze workspace
 - [x] Gather requirements from current Radar MVP decision
 - [x] Confirm subscription and location from existing production Terraform context
@@ -117,6 +118,7 @@ This slice adds lightweight Azure Monitor alert-rule definitions only. It does n
 - [x] User approved this plan with "lets go for 6"
 
 ### Phase 2: Execution
+
 - [x] Add Radar ingestion telemetry contract
 - [x] Add Radar monitoring Terraform variables/resources
 - [x] Add enable-governance documentation/config checks aligned with Docket evidence/decision terminology
@@ -125,33 +127,35 @@ This slice adds lightweight Azure Monitor alert-rule definitions only. It does n
 - [x] Update plan status to "Ready for Validation"
 
 ### Phase 3: Validation
+
 - [ ] Validate Terraform formatting/config
 - [ ] Run relevant Python and TypeScript tests
 - [ ] Run lint/build where affected
 
 ### Phase 4: Deployment
+
 - [ ] Not in scope for this PR
 
 ---
 
 ## 8. Validation Proof
 
-| Check | Command Run | Result | Timestamp |
-|-------|-------------|--------|-----------|
-| Pending | Pending | Pending | Pending |
+| Check   | Command Run | Result  | Timestamp |
+| ------- | ----------- | ------- | --------- |
+| Pending | Pending     | Pending | Pending   |
 
 ---
 
 ## 9. Files to Generate
 
-| File | Purpose | Status |
-|------|---------|--------|
-| `.azure/plan.md` | Radar 6 Azure preparation plan | Complete |
-| `config/azure-functions/shared/radar_ingestion.py` | Radar telemetry emission | Planned |
-| `terraform/modules/monitoring/*` | Radar alert rules | Planned |
-| `terraform/environments/production/*` | Monitoring module wiring | Planned |
-| `docs/03-deployment/08-property-deal-radar-monitoring.md` | Enablement/monitoring runbook updates | Added |
-| Docket alignment note/runbook section | Evidence and decision handoff via verified Docket host/API contract | Added |
+| File                                                      | Purpose                                                             | Status   |
+| --------------------------------------------------------- | ------------------------------------------------------------------- | -------- |
+| `.azure/plan.md`                                          | Radar 6 Azure preparation plan                                      | Complete |
+| `config/azure-functions/shared/radar_ingestion.py`        | Radar telemetry emission                                            | Planned  |
+| `terraform/modules/monitoring/*`                          | Radar alert rules                                                   | Planned  |
+| `terraform/environments/production/*`                     | Monitoring module wiring                                            | Planned  |
+| `docs/03-deployment/08-property-deal-radar-monitoring.md` | Enablement/monitoring runbook updates                               | Added    |
+| Docket alignment note/runbook section                     | Evidence and decision handoff via verified Docket host/API contract | Added    |
 
 ---
 
@@ -182,13 +186,13 @@ Fix three production gaps verified after the OIDC Terraform apply:
 
 ### Scope
 
-| Area | Decision |
-|------|----------|
-| Web telemetry | Add Terraform-managed Application Insights for `nl-prod-hov-app` and wire `APPLICATIONINSIGHTS_CONNECTION_STRING` / role name into App Service settings. |
-| Node instrumentation | Initialize Azure Monitor from `instrumentation.ts` when the connection string exists. |
-| Project persistence | Use the existing production `AZURE_STORAGE_CONNECTION_STRING` to store project JSON in Blob Storage, with local file fallback for dev/tests. |
-| Dummy data | Remove visible project/task seed defaults from production paths; keep explicit demo data behind `ALLOW_DEMO_DATA=true`. |
-| Deployment | Prepare and validate in PR first; production apply/deploy remains a separate controlled action after merge. |
+| Area                 | Decision                                                                                                                                                 |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Web telemetry        | Add Terraform-managed Application Insights for `nl-prod-hov-app` and wire `APPLICATIONINSIGHTS_CONNECTION_STRING` / role name into App Service settings. |
+| Node instrumentation | Initialize Azure Monitor from `instrumentation.ts` when the connection string exists.                                                                    |
+| Project persistence  | Use the existing production `AZURE_STORAGE_CONNECTION_STRING` to store project JSON in Blob Storage, with local file fallback for dev/tests.             |
+| Dummy data           | Remove visible project/task seed defaults from production paths; keep explicit demo data behind `ALLOW_DEMO_DATA=true`.                                  |
+| Deployment           | Prepare and validate in PR first; production apply/deploy remains a separate controlled action after merge.                                              |
 
 ### Validation
 
@@ -196,3 +200,202 @@ Fix three production gaps verified after the OIDC Terraform apply:
 - Run focused API tests for projects/tasks.
 - Run `pnpm run build`.
 - Run `terraform fmt -recursive` and `terraform -chdir=terraform/environments/production validate`.
+
+---
+
+## 12. O6 restricted evidence store before live PIRB integration
+
+> **Status:** Ready for Validation - deployment remains prohibited
+
+Added: 2026-07-26
+
+### 12.1 Project overview
+
+**Goal:** Prepare, but do not deploy, a dedicated Azure Blob restricted store
+for later O6-approved reviewer identity, credential, consent, contract, and
+verification evidence. The store must remain disconnected from the HOV general
+application datastore and unavailable until named human owners and authorized
+researcher Microsoft Entra object IDs are supplied.
+
+**Path:** Add components to the existing production Terraform stack (MODIFY).
+
+**Non-goals:** Terraform apply, Azure resource creation, candidate collection,
+PIRB registry calls, public access, shared-key access, application runtime
+access, O5/O6 activation, or Gate progression.
+
+### 12.2 Requirements
+
+| Attribute           | Value                                                                                                                                                                                               |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Classification      | Production security/privacy prerequisite; no live data during preparation                                                                                                                           |
+| Scale               | Small: one restricted container and a small named research group                                                                                                                                    |
+| Budget              | Cost-optimized without weakening encryption, audit, deletion, or private networking                                                                                                                 |
+| Subscription        | Confirmed: `Azure subscription 1` (`bb4e3882-2079-4bab-8974-611bc0b8bb58`)                                                                                                                          |
+| Location            | Confirmed: `southafricanorth`, matching the canonical HOV stack                                                                                                                                     |
+| Data residency      | South Africa North unless the privacy reviewer approves a different location                                                                                                                        |
+| Compliance boundary | POPIA-oriented operating controls, not a claim of legal compliance                                                                                                                                  |
+| Activation inputs   | Responsible-party ID, privacy-reviewer ID, research-owner ID, authorized-researcher Entra object IDs, deletion/correction-owner ID, incident-owner ID, retention deadline, and approved access path |
+
+### 12.3 Components detected
+
+| Component                  | Type                                 | Technology                                          | Path                                    |
+| -------------------------- | ------------------------------------ | --------------------------------------------------- | --------------------------------------- |
+| Web/API                    | SSR application                      | Next.js 16 / TypeScript                             | `app/`, `lib/`                          |
+| Production infrastructure  | IaC                                  | Terraform / AzureRM 4.x                             | `terraform/environments/production/`    |
+| Shared application storage | Existing Azure Blob module           | Terraform                                           | `terraform/modules/storage/`            |
+| Restricted store           | New opt-in module                    | Azure Blob, Private Link, Entra RBAC, Azure Monitor | `terraform/modules/restricted-storage/` |
+| Privacy operations         | Activation/deletion/incident runbook | Markdown                                            | `docs/03-deployment/`                   |
+
+Live inspection found only `nlprodhovst` in the HOV resource group. It has
+public networking enabled, firewall default `Allow`, blob public access
+allowed, and shared-key access allowed, so it is not eligible for O6 restricted
+evidence and will not be repurposed by this plan.
+
+### 12.4 Recipe selection
+
+**Selected:** Existing pure Terraform workflow.
+
+**Rationale:** The repository already owns its production Azure topology through
+Terraform modules and a remote AzureRM backend. Introducing AZD or an imperative
+deployment path would create a second authority. This change adds one isolated,
+disabled-by-default module to the existing stack.
+
+### 12.5 Architecture
+
+| Component                     | Azure service / SKU                                           | Planned control                                                                                            |
+| ----------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Restricted evidence account   | StorageV2 Standard LRS                                        | HTTPS/TLS 1.2, infrastructure encryption, blob public access disabled, shared keys disabled, OAuth default |
+| Restricted evidence container | Private Blob container                                        | No anonymous or organization-wide access; no application connection string                                 |
+| Network boundary              | Private Endpoint in existing private-endpoint subnet          | Public network access disabled; Blob private DNS linked to the existing VNet                               |
+| Human access                  | Azure RBAC                                                    | `Storage Blob Data Contributor` only for explicitly supplied authorized-researcher Entra object IDs        |
+| Retention                     | Blob lifecycle plus versioning and short soft-delete recovery | Owner-approved bounded retention; deletion remains possible and auditable                                  |
+| Audit                         | Azure Monitor diagnostic setting                              | Blob read, write, delete, and all-metrics events sent to a dedicated low-volume Log Analytics workspace    |
+| Evidence reference            | HOV governance datastore                                      | Pseudonymous candidate ID and minimized evidence reference only; no restricted record content              |
+
+The module will be gated by `enable_restricted_evidence_store = false` by
+default. Enabling it without authorized researcher object IDs or a valid bounded
+retention period must fail Terraform validation/preconditions. No HOV App
+Service or Function managed identity receives data-plane access.
+
+### 12.6 Provisioning limit checklist
+
+Capacity was checked against the detected subscription and proposed region on
+2026-07-26. No cells are pending.
+
+| Resource type                                 | Number to deploy               | Total after deployment             | Limit/quota                                    | Evidence                                                                                                   |
+| --------------------------------------------- | ------------------------------ | ---------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `Microsoft.Storage/storageAccounts`           | 1                              | 16                                 | 250 per region                                 | `az quota list` and `az quota usage list` for Microsoft.Storage in South Africa North: usage 15, limit 250 |
+| `Microsoft.Network/privateEndpoints`          | 1                              | 2                                  | 65,536 regional quota                          | `az quota list` and `az quota usage list` for Microsoft.Network: usage 1, limit 65,536                     |
+| `Microsoft.Network/privateDnsZones`           | 1                              | 2 in HOV RG                        | Service limit, no regional capacity allocation | Live lookup found one HOV private DNS zone; the Blob zone is a lightweight control-plane resource          |
+| `Microsoft.OperationalInsights/workspaces`    | 1                              | 1 in HOV RG                        | Service limit, no compute quota allocation     | Live lookup found zero HOV Log Analytics workspaces                                                        |
+| Blob container, diagnostic setting, VNet link | 1 each                         | 1 each for this module             | Child/control-plane resources                  | No independent regional compute quota                                                                      |
+| Blob data-contributor role assignments        | One per supplied researcher ID | Determined by approved named users | Azure RBAC assignment service limit            | Empty until the owner supplies non-secret Entra object IDs                                                 |
+
+**Capacity status:** All quota-governed resources are comfortably within limits.
+The storage account name `nlprodhovrestricted` was available when checked on
+2026-07-26; availability must be rechecked immediately before any apply.
+
+### 12.7 Execution checklist
+
+#### Phase 1 - planning
+
+- [x] Analyze existing Azure/Terraform workspace in MODIFY mode.
+- [x] Gather requirements from the merged O6 and PIRB provider-boundary docs.
+- [x] Scan live Azure storage, networking, DNS, and Log Analytics state.
+- [x] Select the existing Terraform recipe.
+- [x] Plan the isolated restricted-store architecture.
+- [x] Validate proposed-region storage and private-endpoint capacity.
+- [x] User confirms subscription `bb4e3882-2079-4bab-8974-611bc0b8bb58`.
+- [x] User confirms location `southafricanorth`.
+- [x] User approves this plan with `proceed` on 2026-07-26.
+
+#### Phase 2 - execution after approval
+
+- [x] Load Azure Storage and monitoring implementation references.
+- [x] Add `terraform/modules/restricted-storage/{main,variables,outputs}.tf`.
+- [x] Wire disabled-by-default production variables, module, outputs, and example values.
+- [x] Add deterministic Terraform contract tests/policy checks where supported.
+- [x] Add the O6 restricted-store activation, access-review, correction/deletion, and incident runbook.
+- [x] Keep human role IDs and live values out of Git and Baton.
+- [x] Set this plan status to `Ready for Validation` before invoking `azure-validate`.
+
+#### Phase 3 - validation
+
+- [x] Invoke `azure-validate` after preparation status is `Ready for Validation`.
+- [x] Run `terraform fmt -recursive -check`.
+- [x] Run Terraform initialization/validation without applying changes.
+- [x] Prove disabled-default plan shape has no new resources.
+- [x] Prove enabled fixture fails without named researchers and bounded retention.
+- [x] Run repository lint/tests required by touched files.
+- [x] Record validation proof in this plan and the O6 runbook.
+
+#### Phase 4 - deployment
+
+- [ ] Out of scope for this plan and PR.
+- [ ] Requires a separate user-approved `azure-deploy` workflow after privacy,
+      owner, identity, access-path, cost, and Terraform plan review.
+
+### 12.8 Files to generate
+
+| File                                                    | Purpose                                                                         | Status   |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------- | -------- |
+| `.azure/plan.md`                                        | Current preparation authority and approval gate                                 | Complete |
+| `terraform/modules/restricted-storage/main.tf`          | Fail-closed storage, network, retention, RBAC, and diagnostics                  | Complete |
+| `terraform/modules/restricted-storage/variables.tf`     | Typed activation, identity, retention, network, and tag inputs                  | Complete |
+| `terraform/modules/restricted-storage/outputs.tf`       | Non-secret resource IDs/endpoints only                                          | Complete |
+| `terraform/modules/restricted-storage/versions.tf`      | Explicit AzureRM and AzAPI provider sources                                     | Complete |
+| `terraform/environments/production/main.tf`             | Opt-in module wiring                                                            | Complete |
+| `terraform/environments/production/variables.tf`        | Disabled-by-default production inputs                                           | Complete |
+| `terraform/environments/production/outputs.tf`          | Optional non-sensitive outputs                                                  | Complete |
+| `terraform/environments/production/*.tfvars.example`    | Safe placeholder examples only                                                  | Complete |
+| `docs/03-deployment/09-o6-restricted-evidence-store.md` | Human activation, access, retention, deletion, correction, and incident runbook | Complete |
+
+### 12.9 Approval boundary
+
+Approval of this preparation plan authorizes repository changes and validation
+only. It does not authorize Terraform apply, Azure RBAC changes, candidate data,
+PIRB calls, reviewer outreach, O5/O6 activation, or Gate progression.
+
+### 12.10 Research summary
+
+- AzureRM 4.x supports the required account controls: public networking and
+  nested public access disabled, shared keys disabled, OAuth as the default,
+  and infrastructure encryption enabled.
+- AzureRM normally uses Storage data-plane authorization to provision a Blob
+  container. The restricted container will instead use the AzAPI ARM
+  control-plane resource so deployment never needs a shared key and does not
+  require changing the existing provider's storage authentication behavior.
+- The container ARM contract supports explicit `publicAccess = "None"` and
+  encryption-scope override denial.
+- RBAC assignments will use the built-in `Storage Blob Data Contributor` role
+  at the restricted account scope only. Application identities are not inputs.
+- Blob diagnostics will use explicit `StorageRead`, `StorageWrite`, and
+  `StorageDelete` categories plus `AllMetrics`, sent to the module's dedicated
+  Log Analytics workspace.
+- Lifecycle deletion will use days since creation, including base blobs,
+  versions, and snapshots, so modification cannot silently extend retention.
+
+### 12.11 Validation evidence
+
+Validated on 2026-07-26 without applying or changing any Azure resource:
+
+- `terraform init -backend=false -upgrade`: passed; locked AzAPI `2.11.0`.
+- `terraform init -reconfigure -backend-config=backend.hcl`: passed for
+  read-only production-state plan inspection.
+- `terraform fmt -recursive -check`: passed.
+- `terraform validate`: passed without warnings.
+- Disabled-default plan: `0` restricted-store resource changes. The broader
+  production baseline was `0 to add, 9 to change, 0 to destroy`; those
+  unrelated in-place changes must be reconciled before any future apply.
+- Enabled synthetic targeted plan: `9 to add, 1 to change, 0 to destroy`; the
+  single VNet change is an existing provider/state normalization outside this
+  module, so the saved plan is evidence only and must not be applied.
+- Empty researcher set: plan rejected with the named-researcher precondition.
+- Retention and soft-delete both set to 30 days: plan rejected because soft
+  delete must be shorter than evidence retention.
+- Restricted-storage contract test: `4 passed`.
+- `pnpm run lint`: passed.
+- Focused Prettier check: passed.
+- Full `pnpm test`: `398 passed`, with two pre-existing Windows CRLF failures
+  in `tests/lib/deployment-workflow-contract.test.ts`; this change does not
+  touch deployment workflows or that test.

--- a/docs/03-deployment/09-o6-restricted-evidence-store.md
+++ b/docs/03-deployment/09-o6-restricted-evidence-store.md
@@ -1,0 +1,214 @@
+# O6 restricted evidence store
+
+## Status and authority
+
+- Status: Terraform preparation only; disabled by default and not deployed
+- Baton task: `6f42f193-9372-41d8-ae27-0ba2e32fbf7f`
+- Azure context: subscription `bb4e3882-2079-4bab-8974-611bc0b8bb58`,
+  South Africa North
+- Application access: prohibited
+- O5/O6 activation: prohibited until every human and operational gate below is
+  satisfied
+
+This runbook defines the technical O6 evidence boundary. It is not legal advice,
+does not claim POPIA compliance, and does not authorize collection, PIRB
+verification, outreach, payment, appointment, or Gate progression.
+
+The existing shared account `nlprodhovst` is not the restricted store. Live
+inspection on 2026-07-26 found public networking enabled, firewall default
+`Allow`, blob public access allowed, and shared-key access allowed. It remains
+untouched because it also serves general application and Terraform workloads.
+
+## Prepared architecture
+
+The opt-in `restricted-storage` Terraform module creates:
+
+- a dedicated StorageV2 account with TLS 1.2, secure transfer, infrastructure
+  encryption, public Blob access disabled, shared keys disabled, OAuth default,
+  public networking disabled, and firewall default `Deny`;
+- a private Blob container created through the ARM control plane, with public
+  access set to `None` and encryption-scope overrides denied;
+- a Blob private endpoint and `privatelink.blob.core.windows.net` DNS zone linked
+  to the existing production VNet;
+- account-scoped `Storage Blob Data Contributor` assignments only for approved
+  Microsoft Entra object IDs supplied through private Terraform inputs;
+- versioning, seven-day soft deletion, and creation-age lifecycle deletion for
+  base blobs, versions, and snapshots; and
+- a dedicated Log Analytics workspace receiving Blob read, write, delete, and
+  metric diagnostics.
+
+The module exports resource identifiers only. It exports no key, SAS token, or
+connection string and grants no HOV web app or Function identity access.
+
+## Activation record required outside Git and Baton
+
+Before setting `enable_restricted_evidence_store = true`, the owner and privacy
+reviewer must approve a private record containing:
+
+1. responsible-party and Information Officer/delegated privacy-owner IDs;
+2. independent privacy/legal reviewer ID;
+3. research-owner ID;
+4. named authorized-researcher IDs and Microsoft Entra object IDs;
+5. correction/deletion-owner ID;
+6. security-incident-owner ID and tested contact path;
+7. exact purpose and permitted PIRB/candidate evidence fields;
+8. approved retention and final-deletion deadline;
+9. approved private access path, such as a managed device connected to the HOV
+   VNet through an owner-approved VPN or controlled jump host;
+10. provider/operator, location, MFA, access-review, breach, correction,
+    deletion, and contract decisions; and
+11. the reviewed Terraform plan, cost estimate, deployment owner, and rollback
+    owner.
+
+Do not put names, contact details, candidate mappings, credentials, consent,
+contracts, payment information, raw notes, private endpoints, or access
+instructions in Git, Baton, general chat, HOV production, logs, prompts, or model
+training data. Non-secret Microsoft Entra object IDs still belong in untracked
+Terraform inputs or approved secure automation because they identify authorized
+people.
+
+## Private Terraform inputs
+
+The following is a shape example only. Populate it in an untracked tfvars file
+or approved secure pipeline input after the activation record is approved:
+
+```hcl
+enable_restricted_evidence_store = true
+
+restricted_evidence_researcher_object_ids = [
+  "00000000-0000-4000-8000-000000000000",
+]
+
+restricted_evidence_retention_days       = 90
+restricted_evidence_soft_delete_days     = 7
+restricted_evidence_audit_retention_days = 180
+```
+
+The placeholder UUID is not an identity and must never be used for an apply.
+Terraform fails enabled provisioning when no authorized researcher ID exists or
+when soft deletion is not shorter than evidence retention.
+
+## Access and MFA boundary
+
+Azure Storage data access uses Microsoft Entra authorization only. MFA and
+Conditional Access are tenant policies and therefore require live owner/privacy
+proof; Terraform in this repository cannot truthfully assert that they are
+enabled for a person.
+
+An authorized researcher must access Blob data from the approved private-network
+path and use `--auth-mode login` or an equivalent Entra-authenticated client.
+Storage keys, account SAS, connection strings, local users, SFTP, anonymous
+links, organization-wide links, and application proxying are prohibited.
+
+After deployment but before collection, capture private evidence that:
+
+- public network access is disabled and the private endpoint is approved;
+- the Blob hostname resolves to the private endpoint from the approved device;
+- an approved researcher can list the empty container with Entra authentication;
+- a non-authorized user is denied;
+- shared-key authorization is rejected;
+- the diagnostic setting reports Blob read/write/delete categories as enabled;
+- the Log Analytics workspace receives a synthetic access event; and
+- HOV production cannot read or write the container.
+
+## Data minimization and layout
+
+Use pseudonymous candidate IDs in filenames and working records. Keep the
+candidate-to-identity mapping separate from evaluation material. Store only the
+minimum approved evidence needed for the declared purpose.
+
+Suggested logical prefixes are `identity-map/`, `credentials/`, `consent/`,
+`contracts/`, `trial-evidence/`, and `deletion-receipts/`. Prefixes do not create
+authorization boundaries; every authorized researcher can access the account.
+If duties require different access, create separate containers/accounts and
+roles in a reviewed follow-up rather than relying on naming conventions.
+
+## Retention, correction, and deletion
+
+The default lifecycle deletes base blobs, versions, and snapshots 90 days after
+creation. Creation age is intentional: editing an item must not silently extend
+its retention. The privacy reviewer must approve any different period before
+activation.
+
+Soft deletion provides a seven-day accidental-deletion recovery window. A
+correction/deletion request therefore has two dates:
+
+1. logical deletion initiated by the deletion owner; and
+2. final non-recoverability after the soft-delete period expires.
+
+The approved participant notice and deadline must reflect that recovery window.
+Do not disable soft deletion or purge evidence ad hoc. For an urgent legal or
+security requirement, stop processing and obtain the named privacy/incident
+owner's documented decision.
+
+For every correction or deletion, privately record the candidate ID, affected
+evidence references, request/decision timestamps, action owner, versions and
+snapshots addressed, expected final-deletion date, verification result, and
+incident escalation if the action fails. Baton and Git may receive only a
+minimized non-sensitive completion reference.
+
+## Access review and offboarding
+
+- Review the Entra object-ID set before deployment, before each trial, monthly
+  while evidence exists, and immediately when a role changes.
+- Remove access before announcing offboarding completion.
+- Confirm the removed identity is denied from the approved private path.
+- Review Azure Activity Log and Blob diagnostic events for unexpected access,
+  role assignment, network, retention, or diagnostic changes.
+- Keep Terraform state, plan output, and CI logs free of restricted content.
+
+## Incident path
+
+On suspected unauthorized access, disclosure, loss, unsafe processing, or
+diagnostic failure:
+
+1. stop collection, PIRB verification, sharing, and all non-essential access;
+2. preserve audit logs and relevant resource-change evidence without copying
+   restricted content into general systems;
+3. notify the named incident owner and privacy reviewer through the tested
+   private contact route;
+4. remove or narrow access only under the incident owner's authority;
+5. assess operator, data-subject, insurer, contractual, and Information
+   Regulator notification duties; and
+6. record a minimized incident reference and explicit restart decision.
+
+O5, O6, and Gate progression remain inactive until the incident is contained
+and the named human owner records restart authority.
+
+## Deployment gate
+
+Repository merge is not deployment approval. A later deployment must use the
+`azure-deploy` workflow and stop before `terraform apply` until the user has
+approved:
+
+- the exact plan showing one restricted account, container, private endpoint,
+  DNS zone/link, audit workspace/diagnostics, lifecycle policy, and intended
+  role assignments;
+- the global storage-account name recheck and cost estimate;
+- the private access path and MFA/Conditional Access evidence plan;
+- the human accountability record and retention/deletion wording; and
+- the post-deploy empty-store, deny-path, logging, and deletion tests.
+
+No real candidate or household evidence may be used for deployment verification.
+
+## Repository validation
+
+Preparation must pass:
+
+```text
+terraform fmt -recursive -check
+terraform -chdir=terraform/environments/production init -backend=false
+terraform -chdir=terraform/environments/production validate
+pnpm exec vitest run tests/lib/restricted-storage-terraform-contract.test.ts
+pnpm run lint
+```
+
+Validation is configuration proof only. It does not prove Azure deployment,
+private DNS resolution, MFA, access denial, diagnostics delivery, or deletion.
+
+The 2026-07-26 preparation validation passed Terraform formatting and
+validation, the four focused contract tests, lint, and the disabled/enabled
+plan-shape checks. The enabled synthetic plan proposed nine module resources,
+no deletes, and one unrelated pre-existing VNet normalization. The full test
+suite passed 398 tests and retained two pre-existing Windows CRLF failures in
+`tests/lib/deployment-workflow-contract.test.ts`. No plan was applied.

--- a/docs/05-project/2026-07-26-gate-governance-admin-control-plane.md
+++ b/docs/05-project/2026-07-26-gate-governance-admin-control-plane.md
@@ -74,6 +74,11 @@ O6 cannot become active without non-sensitive IDs or approvals for:
 - correction/deletion owner; and
 - incident owner.
 
+The technical restricted-store preparation and its remaining human/deployment
+gates are documented in the
+[O6 restricted evidence store runbook](../03-deployment/09-o6-restricted-evidence-store.md).
+Terraform preparation alone does not satisfy these activation inputs.
+
 Names, contact details, credentials, registration artifacts, consent evidence,
 raw notes, and restricted-store details remain prohibited from the general
 application datastore. The interface stores references, not the restricted

--- a/docs/05-project/2026-07-26-pirb-domain-reviewer-testing-surface.md
+++ b/docs/05-project/2026-07-26-pirb-domain-reviewer-testing-surface.md
@@ -80,6 +80,10 @@ Before enabling that adapter:
 6. an authenticated browser acceptance must prove admin access, non-admin denial,
    synthetic evaluation, and zero persistence/external effects.
 
+The repository preparation for prerequisite 1 is defined in the
+[O6 restricted evidence store runbook](../03-deployment/09-o6-restricted-evidence-store.md).
+It is disabled by default and is not deployment or O6 approval.
+
 No candidate contact, appointment, payment, safety reliance, O5 activation, or
 Gate progression is authorized by this surface.
 

--- a/terraform/environments/production/.terraform.lock.hcl
+++ b/terraform/environments/production/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/azure/azapi" {
+  version     = "2.11.0"
+  constraints = ">= 2.11.0, ~> 2.11"
+  hashes = [
+    "h1:SfbC7Fp2gMGXOzZlPHcirTKDNhKjXYjymMtD/PGpD68=",
+    "zh:05ae9abf23abf003229e9e04734fce2b881974b0df4313083a890d9f67b1fc35",
+    "zh:1dc85011f0dc8480d34d4fab9fe90de56e171d99b8b19d7b65b0f3ed2af20376",
+    "zh:21f84feed46eba054575e5866dfef2e1073b7fc129d789ff16a1fc53802bdcd9",
+    "zh:27f2f26c1e42a648d250d5911722f7aeeb5f15ed2982bea5c55075c39b8e0848",
+    "zh:2e1a2cbef57ae39a4e8f70d900ae07cf9b751f70cbcc92172cf627e984d2d32c",
+    "zh:53130ebb58fd9a9a8e916e234253ee38916303f69c26100574f4f0d66d19327e",
+    "zh:6dca6143c9eb3184574eaf67a6294bf4378416efa4de1dd3734af53043e499f2",
+    "zh:8377df97253638c6fea0b2f6e02835f06bd58e8c6864371050111d37e2352182",
+    "zh:87f891986bac05ddc5c75938eeae5bc53b45adef22dd9d8b202e5fa4f978cda3",
+    "zh:8cf0b1b1e064ea0bc4c785e68f2b239a57ffece529b21a60b415b9d310a610a9",
+    "zh:97e827f791c2f33c23f37a98d150a5d8c244cfa8967d5c6f742dc5757b1377d3",
+    "zh:9cb08cdb6e54bc380bd22add9522767c45457b322a26cdad7d7bb33d07ba3aa7",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.81.0"
   constraints = "~> 4.58"

--- a/terraform/environments/production/canonical.tfvars.example
+++ b/terraform/environments/production/canonical.tfvars.example
@@ -18,6 +18,19 @@ vnet_name           = "nl-prod-hov-vnet"
 storage_account_name             = "nlprodhovst"
 storage_account_replication_type = "LRS"
 storage_network_default_action   = "Allow"
+
+# O6 restricted reviewer evidence is a separate, opt-in store. Keep disabled
+# until private owner/reviewer approvals and Entra object IDs are supplied via
+# an untracked tfvars file or approved secure automation.
+enable_restricted_evidence_store             = false
+restricted_evidence_storage_account_name     = "nlprodhovrestricted"
+restricted_evidence_replication_type         = "LRS"
+restricted_evidence_container_name           = "reviewer-evidence"
+restricted_evidence_researcher_object_ids    = []
+restricted_evidence_retention_days           = 90
+restricted_evidence_soft_delete_days         = 7
+restricted_evidence_audit_workspace_name     = "nl-prod-hov-restricted-law"
+restricted_evidence_audit_retention_days     = 180
 key_vault_name                   = "nl-prod-hov-kv"
 key_vault_network_default_action = "Allow"
 terraform_key_vault_access_policy_object_id = "593a093c-d4fd-4390-977b-a64abfc97606"

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.5"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.11"
+    }
   }
 
   backend "azurerm" {
@@ -72,6 +76,34 @@ module "storage" {
   deployer_ip_addresses    = local.ci_ip_rules_storage
 
   tags = local.common_tags
+}
+
+# O6 restricted evidence storage is isolated from the application's general
+# storage account and remains absent unless human privacy prerequisites are
+# supplied through private Terraform inputs.
+module "restricted_evidence_storage" {
+  source = "../../modules/restricted-storage"
+  count  = var.enable_restricted_evidence_store ? 1 : 0
+
+  resource_group_name              = azurerm_resource_group.main.name
+  location                         = azurerm_resource_group.main.location
+  storage_account_name             = var.restricted_evidence_storage_account_name
+  account_replication_type         = var.restricted_evidence_replication_type
+  container_name                   = var.restricted_evidence_container_name
+  private_endpoint_subnet_id       = module.network.private_endpoint_subnet_id
+  vnet_id                          = module.network.vnet_id
+  authorized_researcher_object_ids = var.restricted_evidence_researcher_object_ids
+  retention_days                   = var.restricted_evidence_retention_days
+  soft_delete_days                 = var.restricted_evidence_soft_delete_days
+  audit_workspace_name             = var.restricted_evidence_audit_workspace_name
+  audit_log_retention_days         = var.restricted_evidence_audit_retention_days
+
+  tags = merge(local.common_tags, {
+    DataClass = "Restricted"
+    Purpose   = "O6ReviewerEvidence"
+  })
+
+  depends_on = [module.network]
 }
 
 # Security Module (Key Vault)

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -18,6 +18,26 @@ output "storage_blob_endpoint" {
   value       = module.storage.primary_blob_endpoint
 }
 
+output "restricted_evidence_storage_account_id" {
+  description = "Restricted evidence storage account ID when O6 storage is provisioned"
+  value       = try(module.restricted_evidence_storage[0].storage_account_id, null)
+}
+
+output "restricted_evidence_container_resource_id" {
+  description = "Restricted evidence container resource ID when O6 storage is provisioned"
+  value       = try(module.restricted_evidence_storage[0].container_resource_id, null)
+}
+
+output "restricted_evidence_private_endpoint_id" {
+  description = "Restricted evidence Blob private endpoint ID when provisioned"
+  value       = try(module.restricted_evidence_storage[0].private_endpoint_id, null)
+}
+
+output "restricted_evidence_audit_workspace_id" {
+  description = "Restricted evidence audit workspace ID when provisioned"
+  value       = try(module.restricted_evidence_storage[0].audit_workspace_id, null)
+}
+
 output "key_vault_uri" {
   description = "URI of the Key Vault"
   value       = module.security.key_vault_uri

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -19,6 +19,15 @@
 # storage_account_replication_type = "LRS"
 # storage_network_default_action = "Allow"
 
+# O6 restricted evidence store. Activation values belong in untracked tfvars or
+# approved secure automation; never commit real researcher object IDs here.
+# enable_restricted_evidence_store          = false
+# restricted_evidence_storage_account_name  = "nlprodhovrestricted"
+# restricted_evidence_researcher_object_ids = []
+# restricted_evidence_retention_days        = 90
+# restricted_evidence_soft_delete_days      = 7
+# restricted_evidence_audit_retention_days  = 180
+
 # Key Vault - globally unique within Azure DNS.
 # key_vault_name = "nl-prod-hov-kv"
 # key_vault_network_default_action = "Allow"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -106,6 +106,67 @@ variable "storage_network_default_action" {
   }
 }
 
+# O6 restricted evidence storage remains disabled until private role IDs and
+# the full privacy-accountability record are approved outside Git and Baton.
+variable "enable_restricted_evidence_store" {
+  description = "Whether to provision the dedicated O6 restricted evidence store"
+  type        = bool
+  default     = false
+}
+
+variable "restricted_evidence_storage_account_name" {
+  description = "Globally unique name for the dedicated O6 restricted evidence storage account"
+  type        = string
+  default     = "nlprodhovrestricted"
+}
+
+variable "restricted_evidence_replication_type" {
+  description = "Replication type for restricted evidence storage"
+  type        = string
+  default     = "LRS"
+
+  validation {
+    condition     = contains(["LRS", "ZRS", "GRS", "GZRS"], var.restricted_evidence_replication_type)
+    error_message = "restricted_evidence_replication_type must be LRS, ZRS, GRS, or GZRS."
+  }
+}
+
+variable "restricted_evidence_container_name" {
+  description = "Private container for O6 reviewer evidence"
+  type        = string
+  default     = "reviewer-evidence"
+}
+
+variable "restricted_evidence_researcher_object_ids" {
+  description = "Approved Microsoft Entra object IDs for named restricted-evidence researchers"
+  type        = set(string)
+  default     = []
+}
+
+variable "restricted_evidence_retention_days" {
+  description = "Maximum age before restricted evidence blobs, versions, and snapshots are deleted"
+  type        = number
+  default     = 90
+}
+
+variable "restricted_evidence_soft_delete_days" {
+  description = "Short recovery period for accidental restricted evidence deletion"
+  type        = number
+  default     = 7
+}
+
+variable "restricted_evidence_audit_workspace_name" {
+  description = "Dedicated Log Analytics workspace for restricted Blob access events"
+  type        = string
+  default     = "nl-prod-hov-restricted-law"
+}
+
+variable "restricted_evidence_audit_retention_days" {
+  description = "Retention period for restricted Blob access audit events"
+  type        = number
+  default     = 180
+}
+
 # Security variables
 variable "key_vault_name" {
   description = "Key Vault name (must be globally unique)"

--- a/terraform/modules/restricted-storage/main.tf
+++ b/terraform/modules/restricted-storage/main.tf
@@ -1,0 +1,190 @@
+locals {
+  blob_service_resource_id = "${azurerm_storage_account.restricted.id}/blobServices/default"
+}
+
+resource "azurerm_storage_account" "restricted" {
+  name                     = var.storage_account_name
+  resource_group_name      = var.resource_group_name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = var.account_replication_type
+  account_kind             = "StorageV2"
+  access_tier              = "Hot"
+
+  https_traffic_only_enabled        = true
+  min_tls_version                   = "TLS1_2"
+  allow_nested_items_to_be_public   = false
+  shared_access_key_enabled         = false
+  public_network_access_enabled     = false
+  default_to_oauth_authentication   = true
+  infrastructure_encryption_enabled = true
+  cross_tenant_replication_enabled  = false
+  local_user_enabled                = false
+  allowed_copy_scope                = "PrivateLink"
+
+  blob_properties {
+    versioning_enabled = true
+
+    delete_retention_policy {
+      days = var.soft_delete_days
+    }
+
+    container_delete_retention_policy {
+      days = var.soft_delete_days
+    }
+  }
+
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["Logging", "Metrics"]
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.authorized_researcher_object_ids) > 0
+      error_message = "At least one approved authorized researcher Microsoft Entra object ID is required."
+    }
+
+    precondition {
+      condition     = var.soft_delete_days < var.retention_days
+      error_message = "soft_delete_days must be shorter than retention_days."
+    }
+  }
+
+  tags = var.tags
+}
+
+# Use the ARM control plane so the container can be provisioned while Shared Key
+# authorization remains disabled. No connection string or storage key is needed.
+resource "azapi_resource" "evidence_container" {
+  type      = "Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01"
+  name      = var.container_name
+  parent_id = local.blob_service_resource_id
+
+  body = {
+    properties = {
+      defaultEncryptionScope      = "$account-encryption-key"
+      denyEncryptionScopeOverride = true
+      publicAccess                = "None"
+      metadata = {
+        data_class       = "restricted"
+        purpose          = "o6-reviewer-evidence"
+        application_read = "prohibited"
+      }
+    }
+  }
+
+  response_export_values = []
+}
+
+resource "azurerm_storage_management_policy" "retention" {
+  storage_account_id = azurerm_storage_account.restricted.id
+
+  rule {
+    name    = "delete-restricted-evidence"
+    enabled = true
+
+    filters {
+      prefix_match = ["${var.container_name}/"]
+      blob_types   = ["blockBlob"]
+    }
+
+    actions {
+      base_blob {
+        delete_after_days_since_creation_greater_than = var.retention_days
+      }
+
+      snapshot {
+        delete_after_days_since_creation_greater_than = var.retention_days
+      }
+
+      version {
+        delete_after_days_since_creation = var.retention_days
+      }
+    }
+  }
+
+  depends_on = [azapi_resource.evidence_container]
+}
+
+resource "azurerm_private_dns_zone" "blob" {
+  name                = var.private_dns_zone_name
+  resource_group_name = var.resource_group_name
+
+  tags = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "blob" {
+  name                  = "${var.storage_account_name}-blob-dns-link"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.blob.name
+  virtual_network_id    = var.vnet_id
+  registration_enabled  = false
+
+  tags = var.tags
+}
+
+resource "azurerm_private_endpoint" "blob" {
+  name                = "${var.storage_account_name}-blob-pe"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  subnet_id           = var.private_endpoint_subnet_id
+
+  private_service_connection {
+    name                           = "${var.storage_account_name}-blob-psc"
+    private_connection_resource_id = azurerm_storage_account.restricted.id
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  private_dns_zone_group {
+    name                 = "blob"
+    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_role_assignment" "authorized_researchers" {
+  for_each = var.authorized_researcher_object_ids
+
+  scope                = azurerm_storage_account.restricted.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = each.value
+}
+
+resource "azurerm_log_analytics_workspace" "audit" {
+  name                = var.audit_workspace_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  sku                 = "PerGB2018"
+  retention_in_days   = var.audit_log_retention_days
+
+  local_authentication_enabled = false
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_diagnostic_setting" "blob_access" {
+  name                       = "restricted-blob-access"
+  target_resource_id         = local.blob_service_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.audit.id
+
+  enabled_log {
+    category = "StorageRead"
+  }
+
+  enabled_log {
+    category = "StorageWrite"
+  }
+
+  enabled_log {
+    category = "StorageDelete"
+  }
+
+  enabled_metric {
+    category = "AllMetrics"
+  }
+
+  depends_on = [azapi_resource.evidence_container]
+}

--- a/terraform/modules/restricted-storage/outputs.tf
+++ b/terraform/modules/restricted-storage/outputs.tf
@@ -1,0 +1,29 @@
+output "storage_account_id" {
+  description = "Resource ID of the restricted evidence storage account"
+  value       = azurerm_storage_account.restricted.id
+}
+
+output "storage_account_name" {
+  description = "Name of the restricted evidence storage account"
+  value       = azurerm_storage_account.restricted.name
+}
+
+output "blob_endpoint" {
+  description = "Private-network Blob endpoint for the restricted evidence account"
+  value       = azurerm_storage_account.restricted.primary_blob_endpoint
+}
+
+output "container_resource_id" {
+  description = "ARM resource ID of the restricted evidence container"
+  value       = azapi_resource.evidence_container.id
+}
+
+output "private_endpoint_id" {
+  description = "Resource ID of the restricted Blob private endpoint"
+  value       = azurerm_private_endpoint.blob.id
+}
+
+output "audit_workspace_id" {
+  description = "Resource ID of the restricted evidence audit workspace"
+  value       = azurerm_log_analytics_workspace.audit.id
+}

--- a/terraform/modules/restricted-storage/variables.tf
+++ b/terraform/modules/restricted-storage/variables.tf
@@ -1,0 +1,115 @@
+variable "resource_group_name" {
+  description = "Name of the resource group that owns the restricted evidence store"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region for the restricted evidence store"
+  type        = string
+}
+
+variable "storage_account_name" {
+  description = "Globally unique lowercase name for the restricted evidence storage account"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{3,24}$", var.storage_account_name))
+    error_message = "storage_account_name must contain 3-24 lowercase alphanumeric characters."
+  }
+}
+
+variable "container_name" {
+  description = "Private Blob container used for restricted O6 evidence"
+  type        = string
+  default     = "reviewer-evidence"
+
+  validation {
+    condition     = can(regex("^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$", var.container_name))
+    error_message = "container_name must be a valid 3-63 character lowercase Blob container name."
+  }
+}
+
+variable "account_replication_type" {
+  description = "Replication type for the restricted evidence storage account"
+  type        = string
+  default     = "LRS"
+
+  validation {
+    condition     = contains(["LRS", "ZRS", "GRS", "GZRS"], var.account_replication_type)
+    error_message = "account_replication_type must be LRS, ZRS, GRS, or GZRS."
+  }
+}
+
+variable "private_endpoint_subnet_id" {
+  description = "ID of the subnet dedicated to Azure Private Endpoints"
+  type        = string
+}
+
+variable "vnet_id" {
+  description = "ID of the virtual network linked to the Blob private DNS zone"
+  type        = string
+}
+
+variable "private_dns_zone_name" {
+  description = "Private DNS zone for Azure Blob Private Link"
+  type        = string
+  default     = "privatelink.blob.core.windows.net"
+}
+
+variable "authorized_researcher_object_ids" {
+  description = "Approved Microsoft Entra object IDs granted Blob data contributor access"
+  type        = set(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for object_id in var.authorized_researcher_object_ids :
+      can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", object_id))
+    ])
+    error_message = "Every authorized researcher object ID must be a valid Microsoft Entra UUID."
+  }
+}
+
+variable "retention_days" {
+  description = "Maximum age in days before restricted base blobs, versions, and snapshots are deleted"
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.retention_days >= 30 && var.retention_days <= 365
+    error_message = "retention_days must be between 30 and 365 days."
+  }
+}
+
+variable "soft_delete_days" {
+  description = "Short recovery period for accidental Blob or container deletion"
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = var.soft_delete_days >= 1 && var.soft_delete_days <= 30
+    error_message = "soft_delete_days must be between 1 and 30 days."
+  }
+}
+
+variable "audit_workspace_name" {
+  description = "Name of the dedicated Log Analytics workspace for restricted Blob access events"
+  type        = string
+}
+
+variable "audit_log_retention_days" {
+  description = "Retention in days for restricted Blob access audit events"
+  type        = number
+  default     = 180
+
+  validation {
+    condition     = var.audit_log_retention_days >= 30 && var.audit_log_retention_days <= 730
+    error_message = "audit_log_retention_days must be between 30 and 730 days."
+  }
+}
+
+variable "tags" {
+  description = "Tags applied to restricted evidence resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/restricted-storage/versions.tf
+++ b/terraform/modules/restricted-storage/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.58"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 2.11"
+    }
+  }
+}

--- a/tests/lib/restricted-storage-terraform-contract.test.ts
+++ b/tests/lib/restricted-storage-terraform-contract.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+function read(path: string) {
+  return readFileSync(resolve(process.cwd(), path), "utf8").replace(/\r\n/g, "\n")
+}
+
+const moduleMain = read("terraform/modules/restricted-storage/main.tf")
+const moduleOutputs = read("terraform/modules/restricted-storage/outputs.tf")
+const productionMain = read("terraform/environments/production/main.tf")
+const productionVariables = read("terraform/environments/production/variables.tf")
+
+describe("O6 restricted storage Terraform contract", () => {
+  it("is absent by default and requires private activation inputs", () => {
+    expect(productionVariables).toMatch(
+      /variable "enable_restricted_evidence_store"[\s\S]*?default\s+= false/
+    )
+    expect(productionVariables).toMatch(
+      /variable "restricted_evidence_researcher_object_ids"[\s\S]*?default\s+= \[\]/
+    )
+    expect(productionMain).toContain("count  = var.enable_restricted_evidence_store ? 1 : 0")
+  })
+
+  it("enforces private Entra-only storage without application credentials", () => {
+    expect(moduleMain).toMatch(/allow_nested_items_to_be_public\s+= false/)
+    expect(moduleMain).toMatch(/shared_access_key_enabled\s+= false/)
+    expect(moduleMain).toMatch(/public_network_access_enabled\s+= false/)
+    expect(moduleMain).toMatch(/default_to_oauth_authentication\s+= true/)
+    expect(moduleMain).toMatch(/default_action\s+= "Deny"/)
+    expect(moduleMain).toMatch(/subresource_names\s+= \["blob"\]/)
+    expect(moduleMain).toMatch(/role_definition_name\s+= "Storage Blob Data Contributor"/)
+    expect(moduleMain).toMatch(/local_authentication_enabled\s+= false/)
+    expect(moduleOutputs).not.toMatch(/access_key|connection_string/i)
+  })
+
+  it("uses the ARM control plane for a private container", () => {
+    expect(moduleMain).toContain(
+      "Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01"
+    )
+    expect(moduleMain).toContain('publicAccess                = "None"')
+    expect(moduleMain).toContain("denyEncryptionScopeOverride = true")
+    expect(moduleMain).not.toContain('resource "azurerm_storage_container"')
+  })
+
+  it("bounds evidence lifetime and records blob access operations", () => {
+    expect(moduleMain).toContain(
+      "delete_after_days_since_creation_greater_than = var.retention_days"
+    )
+    expect(moduleMain).toContain("delete_after_days_since_creation = var.retention_days")
+    expect(moduleMain).toContain('category = "StorageRead"')
+    expect(moduleMain).toContain('category = "StorageWrite"')
+    expect(moduleMain).toContain('category = "StorageDelete"')
+    expect(moduleMain).toContain('category = "AllMetrics"')
+  })
+})


### PR DESCRIPTION
## Summary

- add a dedicated, disabled-by-default Terraform module for O6 restricted reviewer evidence
- require private Blob access, Entra-only RBAC for explicitly named researchers, bounded lifecycle deletion, and access diagnostics
- provision the container through the AzAPI ARM control plane so shared-key access stays disabled
- add production opt-in wiring, non-secret outputs, deterministic contract tests, and the privacy/activation runbook
- link the PIRB testing surface and admin governance docs to the new deployment prerequisite

## Safety boundary

This PR prepares infrastructure only. It does not apply Terraform, create Azure resources, change RBAC, process candidate data, call PIRB, activate O5/O6, or advance a gate.

## Validation

- `terraform fmt -recursive -check` — passed
- `terraform validate` — passed without warnings
- disabled-default plan — zero restricted-store resource changes
- enabled synthetic targeted plan — 9 adds, 1 unrelated existing VNet normalization, 0 destroys
- empty researcher set — rejected by precondition
- invalid 30/30 retention/soft-delete pair — rejected by precondition
- `pnpm exec vitest run tests/lib/restricted-storage-terraform-contract.test.ts` — 4 passed
- `pnpm run lint` — passed
- focused Prettier check — passed
- `pnpm test` — 398 passed; 2 pre-existing Windows CRLF failures remain in `tests/lib/deployment-workflow-contract.test.ts`

No saved Terraform plan is included or authorized for apply.