### PR TITLE
Prepare Gate 0 production auth acceptance probes

### DIFF
--- a/app/dashboard/hans/reviewer-lab/page.tsx
+++ b/app/dashboard/hans/reviewer-lab/page.tsx
@@ -411,6 +411,7 @@ export default function ReviewerLabPage() {
                           }))
                         }
                         className="border-input bg-background h-10 w-full rounded-md border px-3"
+                        data-testid={`quality-dimension-${dimension.id}`}
                       >
                         <option value="not_tested">Not tested</option>
                         <option value="clear">Clear</option>

--- a/docs/handoffs/2026-07-27-gate0-production-auth-probes-prepared.md
+++ b/docs/handoffs/2026-07-27-gate0-production-auth-probes-prepared.md
@@ -62,6 +62,10 @@ The probe accepts only the configured Auth.js session-cookie base name and its
 numeric chunk suffixes. Supply the JSON through the process environment without
 printing it or placing it on the command line.
 
+Production-probe mode also forces Playwright retries to zero and tracing off.
+This prevents a retry trace from retaining raw Cookie request headers in
+`test-results/**/trace.zip`. Do not override tracing for a production-auth run.
+
 Do not place values on a command line, in shell history, logs, screenshots,
 GitHub output, Baton, Git, or this document. Once the environment is prepared,
 run:

--- a/docs/handoffs/2026-07-27-gate0-production-auth-probes-prepared.md
+++ b/docs/handoffs/2026-07-27-gate0-production-auth-probes-prepared.md
@@ -1,0 +1,90 @@
+# Gate 0 production-auth probes prepared
+
+- Date: 2026-07-27
+- Repository: `C:\Users\smitj\repos\house-of-veritas`
+- Branch: `agent/gate0-reviewer-testing-handoff`
+- Baton project: `house-of-veritas` (`da62c803-1a03-45a4-9ce1-b6e86dd8d23d`)
+- Reviewer acceptance task: `374f9f21-c76e-4547-a16e-b8238c26ddb1`
+- Governance persistence task: `5445ec3b-386f-4624-b005-fd3d74ae3a13`
+
+## Outcome
+
+The production-auth Gate 0 Playwright coverage is prepared but was not executed
+against production because legitimate short-lived admin and operator sessions
+were unavailable. The checks remain `skipped`; no session was fabricated,
+printed, stored, or added to Git or Baton.
+
+The new manually invoked spec verifies:
+
+1. admin access to the synthetic Domain Reviewer Lab;
+2. fictional Variant B with all critical gates passing, all quality dimensions
+   clear, and all fail-closed acknowledgements accepted;
+3. the no-reliance result labels and reload-clears-result behavior;
+4. admin read-only access to the Gate governance projection; and
+5. operator page denial and HTTP 403 responses for both reviewer and governance
+   surfaces.
+
+The spec is intentionally absent from automatic deployment workflows. It needs
+both legitimate roles at the same time and must not encourage long-lived
+production session secrets.
+
+The same scenarios can be replayed locally with synthetic Auth.js sessions by
+running `pnpm run test:e2e:gate0`. Local sessions are generated in memory with
+fictional `example.invalid` addresses and are never accepted in production
+probe mode.
+
+## Secure invocation boundary
+
+Supply these values only through the approved short-lived process environment:
+
+- `BASE_URL`;
+- `POST_DEPLOY_PROBE=true`;
+- `POST_DEPLOY_ADMIN_SESSION`;
+- `POST_DEPLOY_OPERATOR_SESSION`; and
+- optional role-specific cookie-name variables when the deployment does not use
+  `__Secure-authjs.session-token`.
+
+Do not place values on a command line, in shell history, logs, screenshots,
+GitHub output, Baton, Git, or this document. Once the environment is prepared,
+run:
+
+```powershell
+pnpm run test:e2e:post-deploy-gate0
+```
+
+Remove the process environment values immediately after the run.
+
+## Explicitly still outstanding
+
+This coverage performs no governance mutation. It therefore does not prove the
+append-only governance write, reload, application restart, or post-restart
+persistence required by task `5445ec3b-386f-4624-b005-fd3d74ae3a13`.
+
+A production governance write changes durable owner-decision state, and an
+application restart changes production runtime state. Both require an exact
+approved test decision and explicit operational approval before execution. No
+O5/O6 activation decision should be used merely as a persistence probe.
+
+The following also remain prohibited without their private prerequisites and
+separate approval: PIRB activity, candidate contact, real household evidence,
+restricted records, payment, Terraform apply, Azure RBAC changes, O5/O6
+activation, and Gate progression.
+
+## Validation
+
+Completed on 2026-07-27:
+
+- `pnpm exec vitest run tests/lib/domain-safety-trial.test.ts tests/api/domain-safety-reviewer-trial.test.ts tests/components/domain-reviewer-lab-page.test.tsx tests/lib/nav-config.test.ts`
+  passed 15/15;
+- `pnpm run lint` passed;
+- `pnpm exec tsc --noEmit` passed;
+- `pnpm run build` passed and emitted both Gate 0 pages and APIs;
+- the production-mode command with no session variables reported all six tests
+  as skipped and made no authenticated request; and
+- `pnpm run test:e2e:gate0` passed 6/6 against a local runtime with synthetic
+  admin and operator sessions.
+
+The first local browser replay passed five scenarios but hit the default
+30-second timeout while creating the fifth test page. The spec now uses the
+same 60-second authenticated-UI timeout established in `00-auth.spec.ts`; the
+complete replay then passed 6/6. No source failure remained.

--- a/docs/handoffs/2026-07-27-gate0-production-auth-probes-prepared.md
+++ b/docs/handoffs/2026-07-27-gate0-production-auth-probes-prepared.md
@@ -44,6 +44,24 @@ Supply these values only through the approved short-lived process environment:
 - optional role-specific cookie-name variables when the deployment does not use
   `__Secure-authjs.session-token`.
 
+The single-session variables remain supported when Auth.js emits one cookie. If
+Auth.js splits a session into numbered chunks, leave the corresponding
+single-session variable unset and provide every chunk through
+`POST_DEPLOY_ADMIN_SESSION_COOKIES` or
+`POST_DEPLOY_OPERATOR_SESSION_COOKIES`. Each plural variable is a JSON array of
+name/value objects, for example:
+
+```json
+[
+  { "name": "__Secure-authjs.session-token.0", "value": "<chunk-0>" },
+  { "name": "__Secure-authjs.session-token.1", "value": "<chunk-1>" }
+]
+```
+
+The probe accepts only the configured Auth.js session-cookie base name and its
+numeric chunk suffixes. Supply the JSON through the process environment without
+printing it or placing it on the command line.
+
 Do not place values on a command line, in shell history, logs, screenshots,
 GitHub output, Baton, Git, or this document. Once the environment is prepared,
 run:

--- a/docs/handoffs/2026-07-27-gate0-reviewer-testing-followups-handoff.md
+++ b/docs/handoffs/2026-07-27-gate0-reviewer-testing-followups-handoff.md
@@ -1,0 +1,222 @@
+# Gate 0 reviewer testing and follow-ups handoff
+
+- Date: 2026-07-27
+- Repository: `C:\Users\smitj\repos\house-of-veritas`
+- Default branch: `main`
+- Remote `main` at handoff refresh: `1126fd2ed55aa7245daef812ed277edd8713bf10`
+- Production runtime at handoff refresh: `2a42ee54cd4b8d5b3e8ae94888daa9194cb1c684`
+- Baton project: `house-of-veritas` (`da62c803-1a03-45a4-9ce1-b6e86dd8d23d`)
+- Status: current Gate 0 discovery slice is closed for now; local synthetic reviewer
+  acceptance passed; human O5/O6 and production-auth acceptance remain separate
+  follow-ups
+
+## Current decision
+
+The original Gate 0 discovery task
+`9bba1180-b6a4-49cb-b1fc-45bdcbb4cd3c` is administratively complete. Its O5
+and O6 checklist entries were marked complete only because the owner asked to
+close the current slice and move the unresolved prerequisites into durable,
+separate tasks. That action is not evidence that O5 or O6 passed.
+
+The repository now has:
+
+1. an admin-only Gate governance control plane;
+2. an admin-only, ephemeral Domain Reviewer Lab using fictional scenarios;
+3. a disabled-by-default Terraform definition and runbook for a dedicated O6
+   restricted evidence store; and
+4. passing local synthetic admin/operator browser acceptance for the Domain
+   Reviewer Lab.
+
+No live PIRB verification, candidate contact, real household evidence,
+restricted record, Terraform apply, Azure RBAC change, payment, O5/O6
+activation, or Gate progression has occurred.
+
+## Delivered sequence
+
+| PR                                                                | Merge commit | Outcome                                                                                                     |
+| ----------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| [#149](https://github.com/neuralliquid/house-of-veritas/pull/149) | `032c7d6`    | Admin-only append-only Gate governance control plane with fail-closed activation prerequisites.             |
+| [#150](https://github.com/neuralliquid/house-of-veritas/pull/150) | `2a42ee5`    | Synthetic Domain Reviewer Lab, provider boundary, API/UI/auth tests, and review fixes.                      |
+| [#151](https://github.com/neuralliquid/house-of-veritas/pull/151) | `1126fd2`    | Disabled-by-default O6 restricted-store Terraform, retention/RBAC/diagnostics controls, tests, and runbook. |
+
+PRs #149, #150, and #151 are closed and merged. PR #151's Terraform Plan and
+Deployment Checklist passed, and it had no actionable review findings or
+unresolved threads before merge. PR #151 did not apply Terraform or redeploy the
+application.
+
+## Canonical artifacts
+
+Read these in order:
+
+1. [Previous alpha/Gate 0 handoff](2026-07-26-alpha-review-e2e-gate0-handoff.md)
+2. [Gate governance admin control plane](../05-project/2026-07-26-gate-governance-admin-control-plane.md)
+3. [PIRB Domain Reviewer testing surface](../05-project/2026-07-26-pirb-domain-reviewer-testing-surface.md)
+4. [Independent Domain Reviewer sourcing](../05-project/2026-07-26-independent-domain-reviewer-sourcing.md)
+5. [O6 restricted evidence store runbook](../03-deployment/09-o6-restricted-evidence-store.md)
+6. [Current Azure preparation plan](../../.azure/plan.md)
+
+Key implementation paths:
+
+- `app/dashboard/hans/governance/page.tsx`
+- `app/api/governance/gates/route.ts`
+- `lib/repositories/gate-governance-repository.ts`
+- `app/dashboard/hans/reviewer-lab/page.tsx`
+- `app/api/reviewer-trials/domain-safety/route.ts`
+- `lib/reviewer-trials/domain-safety-trial.ts`
+- `terraform/modules/restricted-storage/`
+- `tests/lib/restricted-storage-terraform-contract.test.ts`
+
+## Local synthetic reviewer acceptance
+
+Baton task `7d0f57f3-a827-4911-a9eb-63c3b8884c38` is complete.
+
+Repository gates run on 2026-07-26:
+
+```powershell
+pnpm exec vitest run tests/lib/domain-safety-trial.test.ts tests/api/domain-safety-reviewer-trial.test.ts tests/components/domain-reviewer-lab-page.test.tsx tests/lib/nav-config.test.ts
+pnpm run lint
+pnpm exec tsc --noEmit
+pnpm run build
+```
+
+Results:
+
+- focused Vitest: 15/15 passed;
+- lint: passed;
+- TypeScript: passed;
+- production build: passed and emitted the reviewer-lab page and API route;
+- local health: HTTP 200 on the built E2E runtime;
+- synthetic admin `hans` reached `/dashboard/hans/reviewer-lab`;
+- fictional Variant B completed with six critical gates `Pass`, seven quality
+  dimensions `Clear`, and all three fail-closed acknowledgements checked;
+- disposition: `ready_for_internal_replay`;
+- reliance: `none`;
+- PIRB eligibility: `not_evaluated`;
+- result labels: `Not persisted`, `No external effects`, `O5 inactive`, and
+  `0 critical gates incomplete`;
+- reload removed the evaluation and reset Variant B, proving the browser result
+  was ephemeral;
+- synthetic operator `charl` was redirected from the reviewer-lab route to
+  `/dashboard/charl`; and
+- operator `GET /api/reviewer-trials/domain-safety` returned HTTP 403 with
+  `Insufficient permissions`.
+
+Known unrelated local console noise remained:
+
+- `/api/projects?type=scope` returned HTTP 500 in the unconfigured local data
+  mode; and
+- the intentional operator API denial appeared as HTTP 403 in the console.
+
+The local server, browser sessions, session data, generated Playwright artifacts,
+and temporary logs were removed after testing. No source files changed during
+the acceptance run.
+
+## Live state refreshed for this handoff
+
+On 2026-07-27, a fresh public health request returned:
+
+```json
+{
+  "status": "healthy",
+  "build": {
+    "commit": "2a42ee54cd4b8d5b3e8ae94888daa9194cb1c684"
+  },
+  "dataMode": "empty"
+}
+```
+
+`baserow` and `docuseal` were `unconfigured`, consistent with the low-usage
+canonical stack. Remote `main` was `1126fd2`, so the production runtime contains
+the reviewer lab from PR #150 but not the later Terraform-only PR #151 commit.
+Recheck this state live before relying on it in a future session.
+
+## Separate open follow-ups
+
+| Baton task                             | Status       | Owner/action                                                                                                                                                 |
+| -------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `1b3f29a9-0391-4ac5-95a6-8d8f0bf8d2fe` | `todo`       | Privately nominate the qualified independent plumbing reviewer and approve the bounded eligibility/protocol, conflicts, compensation, and consent decisions. |
+| `7fede6f2-50e9-4d30-93c6-3ad2d17e50af` | `todo`       | Complete the O6 privacy/accountability record, named owners, approved Entra researcher IDs, exact Terraform plan review, and separate apply approval.        |
+| `374f9f21-c76e-4547-a16e-b8238c26ddb1` | `todo`       | Run production-auth synthetic reviewer acceptance with legitimate short-lived admin and operator sessions.                                                   |
+| `5445ec3b-386f-4624-b005-fd3d74ae3a13` | `inprogress` | Prove authentic production governance write/reload/restart persistence plus operator page/API denial.                                                        |
+
+Production-auth reviewer and governance acceptance were not run because neither
+an approved production admin session nor an operator session was available in
+the current environment. Report these checks as skipped until legitimate
+short-lived sessions are supplied. Never expose or persist session material.
+
+## O5 and O6 remain hard gates
+
+The follow-up split changes task organization only. It does not authorize:
+
+- accepting or contacting a reviewer;
+- PIRB lookup, scraping, registry requests, or credential transmission;
+- invitation, booking, contracting, escrow, compensation, or payment;
+- real household or participant evidence;
+- a restricted record or recording;
+- Terraform apply, Azure resource creation, or RBAC mutation;
+- activating O5 or O6; or
+- advancing Gate 0 or beginning Gate 1 implementation.
+
+Identity, contact details, registration or credential evidence, relationship and
+conflict narratives, compensation terms, consent evidence, raw notes, household
+information, restricted-store details, and session tokens must remain outside
+Git, Baton, prompts, and general chat.
+
+## Restricted-store state
+
+The restricted-store module is present but absent by default:
+
+```hcl
+enable_restricted_evidence_store = false
+restricted_evidence_researcher_object_ids = []
+```
+
+Validation completed before PR #151 merged:
+
+- Terraform initialization, formatting, and validation passed;
+- the disabled-default plan contained zero restricted-store resource changes;
+- the enabled synthetic targeted plan proposed nine module creates, no deletes,
+  and one unrelated pre-existing VNet state/provider normalization;
+- an empty researcher set failed closed;
+- equal 30-day retention and soft-delete values failed closed; and
+- focused restricted-storage contract tests passed 4/4.
+
+Do not apply the saved or reconstructed synthetic plan. A future apply requires
+the exact production plan to be regenerated and reviewed after private O6 inputs
+exist. The unrelated production baseline changes must also be reconciled first.
+
+## Recommended continuation
+
+Safe next actions without new external authority:
+
+1. refresh `main`, Baton, open PRs, workflow state, and public health;
+2. replay the focused synthetic reviewer tests or local browser acceptance;
+3. review synthetic-only wording and fail-closed boundaries; and
+4. prepare production-auth probes without inserting or storing session material.
+
+The next human-owned actions are the O5 and O6 follow-up tasks. Once legitimate
+production sessions are available, complete the two production acceptance tasks
+before considering any live integration. After O5/O6 evidence exists, stop for
+explicit approval of the exact external action or Terraform apply; do not infer
+authority from this handoff.
+
+## Copy-pastable continuation
+
+```text
+Continue House of Veritas Gate 0 reviewer work from docs/handoffs/2026-07-27-gate0-reviewer-testing-followups-handoff.md.
+
+Repo: C:\Users\smitj\repos\house-of-veritas
+Baton project: house-of-veritas (da62c803-1a03-45a4-9ce1-b6e86dd8d23d)
+Remote main at handoff: 1126fd2ed55aa7245daef812ed277edd8713bf10
+Production runtime at handoff: 2a42ee54cd4b8d5b3e8ae94888daa9194cb1c684
+
+First refresh Git/main, PR and workflow state, public /api/health build identity, and these Baton tasks:
+- O5 reviewer/protocol: 1b3f29a9-0391-4ac5-95a6-8d8f0bf8d2fe
+- O6 privacy/store activation: 7fede6f2-50e9-4d30-93c6-3ad2d17e50af
+- production reviewer acceptance: 374f9f21-c76e-4547-a16e-b8238c26ddb1
+- governance production persistence: 5445ec3b-386f-4624-b005-fd3d74ae3a13
+
+The old Gate 0 checklist was administratively closed and superseded into these tasks; O5/O6 did not pass. Local synthetic Domain Reviewer Lab acceptance passed with admin Variant B, no persistence/external effects, reload reset, operator redirect, and API 403. Production-auth checks remain skipped until legitimate short-lived admin/operator sessions are supplied.
+
+Do not expose session material or private O5/O6 inputs. Do not call PIRB, contact or pay candidates, use real household evidence, create restricted records, apply Terraform, activate O5/O6, or advance a Gate without the exact private prerequisites and explicit approval.
+```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:gate0": "playwright test tests/e2e/06-post-deploy-gate0-acceptance.spec.ts",
+    "test:e2e:post-deploy-gate0": "playwright test tests/e2e/06-post-deploy-gate0-acceptance.spec.ts",
     "test:e2e:install": "npx playwright install chromium",
     "verify:alpha-review-e2e": "node scripts/verify-alpha-review-e2e.mjs tests/fixtures/alpha-review/synthetic-complete.json",
     "inngest:dev": "npx --ignore-scripts=false @inngest/cli@1.17.1 dev",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,8 @@
 import { defineConfig, devices } from "@playwright/test"
 import { loadEnvConfig } from "@next/env"
-import { productionProbePolicy } from "./tests/e2e/helpers/production-probe-policy"
+import { resolveProductionProbePolicy } from "./tests/e2e/helpers/production-probe-policy"
 
 process.env.E2E_TEST = "1"
-
-const isPostDeployProbe = process.env.POST_DEPLOY_PROBE === "true"
-const probePolicy = productionProbePolicy(isPostDeployProbe, !!process.env.CI)
 
 // Resolve AUTH_SECRET the same way the dev server (booted below) will — Next
 // loads .env.local via @next/env — so the session cookie the auth helper mints
@@ -14,7 +11,8 @@ const probePolicy = productionProbePolicy(isPostDeployProbe, !!process.env.CI)
 // both sides agree whether or not a .env.local is present (e.g. CI has none, so
 // the fallback below applies on both sides). Keep the fallback in sync with the
 // helper.
-loadEnvConfig(process.cwd())
+const probePolicy = resolveProductionProbePolicy(process.env, () => loadEnvConfig(process.cwd()))
+const { isPostDeployProbe } = probePolicy
 process.env.AUTH_SECRET =
   process.env.AUTH_SECRET ?? "e2e-insecure-test-secret-do-not-use-in-production"
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig, devices } from "@playwright/test"
 import { loadEnvConfig } from "@next/env"
+import { productionProbePolicy } from "./tests/e2e/helpers/production-probe-policy"
 
 process.env.E2E_TEST = "1"
+
+const isPostDeployProbe = process.env.POST_DEPLOY_PROBE === "true"
+const probePolicy = productionProbePolicy(isPostDeployProbe, !!process.env.CI)
 
 // Resolve AUTH_SECRET the same way the dev server (booted below) will — Next
 // loads .env.local via @next/env — so the session cookie the auth helper mints
@@ -18,12 +22,14 @@ export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: probePolicy.retries,
   workers: 1,
   reporter: process.env.CI ? "github" : "html",
   use: {
     baseURL: process.env.BASE_URL || "http://localhost:3000",
-    trace: "on-first-retry",
+    // Production traces retain raw Cookie request headers. Never write a trace
+    // when legitimate short-lived production sessions are injected.
+    trace: probePolicy.trace,
     screenshot: "only-on-failure",
   },
   projects: [
@@ -34,17 +40,19 @@ export default defineConfig({
   ],
   // Post-deploy probes target an already deployed application. Do not build or
   // start a local server when BASE_URL points at that deployment.
-  webServer: process.env.POST_DEPLOY_PROBE === "true" ? undefined : {
-    // Serve a production build so route compilation cannot consume an E2E
-    // assertion timeout. This also keeps the suite on the same runtime path
-    // used by deployment rather than relying on the dev server's bundler.
-    command: "pnpm run build && pnpm start",
-    url: "http://localhost:3000",
-    reuseExistingServer: true,
-    timeout: 300_000,
-    // Auth.js rejects localhost unless the host is explicitly trusted. Without
-    // this, the login page's session probe never resolves and every browser
-    // authentication flow remains on its loading spinner.
-    env: { ...process.env, E2E_TEST: "1", AUTH_TRUST_HOST: "true" },
-  },
+  webServer: isPostDeployProbe
+    ? undefined
+    : {
+        // Serve a production build so route compilation cannot consume an E2E
+        // assertion timeout. This also keeps the suite on the same runtime path
+        // used by deployment rather than relying on the dev server's bundler.
+        command: "pnpm run build && pnpm start",
+        url: "http://localhost:3000",
+        reuseExistingServer: true,
+        timeout: 300_000,
+        // Auth.js rejects localhost unless the host is explicitly trusted. Without
+        // this, the login page's session probe never resolves and every browser
+        // authentication flow remains on its loading spinner.
+        env: { ...process.env, E2E_TEST: "1", AUTH_TRUST_HOST: "true" },
+      },
 })

--- a/tests/e2e/06-post-deploy-gate0-acceptance.spec.ts
+++ b/tests/e2e/06-post-deploy-gate0-acceptance.spec.ts
@@ -1,11 +1,14 @@
 import { expect, test, type BrowserContext } from "@playwright/test"
 import { seedSession } from "./helpers/auth"
-
-type ProbeRole = "admin" | "operator"
+import {
+  productionSessionCookies,
+  type ProbeRole,
+  type SessionCookie,
+} from "./helpers/production-session"
 
 const baseUrl = process.env.BASE_URL
-const adminSession = process.env.POST_DEPLOY_ADMIN_SESSION
-const operatorSession = process.env.POST_DEPLOY_OPERATOR_SESSION
+const adminSessionCookies = productionSessionCookies("admin")
+const operatorSessionCookies = productionSessionCookies("operator")
 const isPostDeployProbe = process.env.POST_DEPLOY_PROBE === "true"
 
 test.describe.configure({ timeout: 60_000 })
@@ -29,37 +32,28 @@ const qualityDimensionIds = [
   "version_incident_governance",
 ] as const
 
-function cookieName(role: ProbeRole) {
-  const roleSpecificName =
-    role === "admin"
-      ? process.env.POST_DEPLOY_ADMIN_SESSION_COOKIE_NAME
-      : process.env.POST_DEPLOY_OPERATOR_SESSION_COOKIE_NAME
-
-  return roleSpecificName ?? "__Secure-authjs.session-token"
-}
-
-async function addSessionCookie(context: BrowserContext, role: ProbeRole, sessionToken: string) {
+async function addSessionCookies(context: BrowserContext, sessionCookies: SessionCookie[]) {
   const hostname = new URL(baseUrl!).hostname
-  await context.addCookies([
-    {
-      name: cookieName(role),
-      value: sessionToken,
+  await context.addCookies(
+    sessionCookies.map(({ name, value }) => ({
+      name,
+      value,
       domain: hostname,
       path: "/",
       httpOnly: true,
       secure: true,
       sameSite: "Lax",
-    },
-  ])
+    }))
+  )
 }
 
 async function prepareRoleSession(
   context: BrowserContext,
   role: ProbeRole,
-  sessionToken: string | undefined
+  sessionCookies: SessionCookie[]
 ) {
   if (isPostDeployProbe) {
-    await addSessionCookie(context, role, sessionToken!)
+    await addSessionCookies(context, sessionCookies)
     return
   }
 
@@ -72,12 +66,12 @@ async function prepareRoleSession(
 
 test.describe("Post-deployment Gate 0 admin acceptance", () => {
   test.skip(
-    isPostDeployProbe && (!baseUrl || !adminSession),
+    isPostDeployProbe && (!baseUrl || adminSessionCookies.length === 0),
     "Requires POST_DEPLOY_PROBE, BASE_URL, and a legitimate short-lived admin session."
   )
 
   test.beforeEach(async ({ context }) => {
-    await prepareRoleSession(context, "admin", adminSession)
+    await prepareRoleSession(context, "admin", adminSessionCookies)
   })
 
   test("completes a fictional reviewer rehearsal without persistence or external effects", async ({
@@ -137,12 +131,12 @@ test.describe("Post-deployment Gate 0 admin acceptance", () => {
 
 test.describe("Post-deployment Gate 0 operator denial", () => {
   test.skip(
-    isPostDeployProbe && (!baseUrl || !operatorSession),
+    isPostDeployProbe && (!baseUrl || operatorSessionCookies.length === 0),
     "Requires POST_DEPLOY_PROBE, BASE_URL, and a legitimate short-lived operator session."
   )
 
   test.beforeEach(async ({ context }) => {
-    await prepareRoleSession(context, "operator", operatorSession)
+    await prepareRoleSession(context, "operator", operatorSessionCookies)
   })
 
   for (const path of ["/api/reviewer-trials/domain-safety", "/api/governance/gates"] as const) {

--- a/tests/e2e/06-post-deploy-gate0-acceptance.spec.ts
+++ b/tests/e2e/06-post-deploy-gate0-acceptance.spec.ts
@@ -1,0 +1,166 @@
+import { expect, test, type BrowserContext } from "@playwright/test"
+import { seedSession } from "./helpers/auth"
+
+type ProbeRole = "admin" | "operator"
+
+const baseUrl = process.env.BASE_URL
+const adminSession = process.env.POST_DEPLOY_ADMIN_SESSION
+const operatorSession = process.env.POST_DEPLOY_OPERATOR_SESSION
+const isPostDeployProbe = process.env.POST_DEPLOY_PROBE === "true"
+
+test.describe.configure({ timeout: 60_000 })
+
+const criticalGateIds = [
+  "credential_process",
+  "jurisdiction_experience",
+  "independence",
+  "critical_defect_recall",
+  "unsafe_assertion",
+  "data_boundary",
+] as const
+
+const qualityDimensionIds = [
+  "evidence_classification",
+  "ambiguity_handling",
+  "stop_rule_quality",
+  "plain_language",
+  "traceable_rationale",
+  "verification_design",
+  "version_incident_governance",
+] as const
+
+function cookieName(role: ProbeRole) {
+  const roleSpecificName =
+    role === "admin"
+      ? process.env.POST_DEPLOY_ADMIN_SESSION_COOKIE_NAME
+      : process.env.POST_DEPLOY_OPERATOR_SESSION_COOKIE_NAME
+
+  return roleSpecificName ?? "__Secure-authjs.session-token"
+}
+
+async function addSessionCookie(context: BrowserContext, role: ProbeRole, sessionToken: string) {
+  const hostname = new URL(baseUrl!).hostname
+  await context.addCookies([
+    {
+      name: cookieName(role),
+      value: sessionToken,
+      domain: hostname,
+      path: "/",
+      httpOnly: true,
+      secure: true,
+      sameSite: "Lax",
+    },
+  ])
+}
+
+async function prepareRoleSession(
+  context: BrowserContext,
+  role: ProbeRole,
+  sessionToken: string | undefined
+) {
+  if (isPostDeployProbe) {
+    await addSessionCookie(context, role, sessionToken!)
+    return
+  }
+
+  await seedSession(context, {
+    id: role === "admin" ? "hans" : "charl",
+    role,
+    email: `${role}@example.invalid`,
+  })
+}
+
+test.describe("Post-deployment Gate 0 admin acceptance", () => {
+  test.skip(
+    isPostDeployProbe && (!baseUrl || !adminSession),
+    "Requires POST_DEPLOY_PROBE, BASE_URL, and a legitimate short-lived admin session."
+  )
+
+  test.beforeEach(async ({ context }) => {
+    await prepareRoleSession(context, "admin", adminSession)
+  })
+
+  test("completes a fictional reviewer rehearsal without persistence or external effects", async ({
+    page,
+  }) => {
+    const response = await page.goto("/dashboard/hans/reviewer-lab")
+
+    expect(response?.status()).toBe(200)
+    await expect(page.getByTestId("domain-reviewer-lab-page")).toBeVisible()
+
+    const variant = page.getByTestId("reviewer-variant-B")
+    await variant.click()
+    await expect(variant).toHaveAttribute("aria-pressed", "true")
+
+    for (const gateId of criticalGateIds) {
+      await page.getByTestId(`critical-gate-${gateId}`).selectOption("pass")
+    }
+    for (const dimensionId of qualityDimensionIds) {
+      await page.getByTestId(`quality-dimension-${dimensionId}`).selectOption("clear")
+    }
+    for (let index = 1; index <= 3; index += 1) {
+      await page.getByTestId(`lab-acknowledgement-${index}`).check()
+    }
+
+    await page.getByTestId("evaluate-domain-rehearsal").click()
+
+    const result = page.getByTestId("domain-rehearsal-result")
+    await expect(result).toBeVisible()
+    await expect(result).toContainText("ready for internal replay")
+    await expect(result).toContainText("Variant B; reliance none; PIRB eligibility not evaluated")
+    await expect(result).toContainText("Not persisted")
+    await expect(result).toContainText("No external effects")
+    await expect(result).toContainText("O5 inactive")
+    await expect(result).toContainText("0 critical gates incomplete")
+
+    await page.reload()
+
+    await expect(page.getByTestId("domain-reviewer-lab-page")).toBeVisible()
+    await expect(page.getByTestId("domain-rehearsal-result")).toHaveCount(0)
+    await expect(page.getByTestId("reviewer-variant-B")).toHaveAttribute("aria-pressed", "false")
+  })
+
+  test("can read the governance projection without mutating it", async ({ page }) => {
+    const apiResponse = await page.request.get("/api/governance/gates")
+
+    expect(apiResponse.status()).toBe(200)
+    const body = await apiResponse.json()
+    expect(Array.isArray(body.data?.decisions)).toBe(true)
+
+    const pageResponse = await page.goto("/dashboard/hans/governance")
+    expect(pageResponse?.status()).toBe(200)
+    await expect(page.getByTestId("gate-governance-page")).toBeVisible()
+    await expect(page.getByTestId("gate-decision-O5")).toBeVisible()
+    await expect(page.getByTestId("gate-decision-O6")).toBeVisible()
+  })
+})
+
+test.describe("Post-deployment Gate 0 operator denial", () => {
+  test.skip(
+    isPostDeployProbe && (!baseUrl || !operatorSession),
+    "Requires POST_DEPLOY_PROBE, BASE_URL, and a legitimate short-lived operator session."
+  )
+
+  test.beforeEach(async ({ context }) => {
+    await prepareRoleSession(context, "operator", operatorSession)
+  })
+
+  for (const path of ["/api/reviewer-trials/domain-safety", "/api/governance/gates"] as const) {
+    test(`denies operator API access to ${path}`, async ({ page }) => {
+      const response = await page.request.get(path)
+
+      expect(response.status()).toBe(403)
+      await expect(response.json()).resolves.toMatchObject({ error: "Insufficient permissions" })
+    })
+  }
+
+  for (const path of ["/dashboard/hans/reviewer-lab", "/dashboard/hans/governance"] as const) {
+    test(`redirects an operator away from ${path}`, async ({ page }) => {
+      await page.goto(path)
+
+      await expect(page).not.toHaveURL(new RegExp(`${path.replaceAll("/", "\\/")}(?:\\?.*)?$`))
+      await expect(page.getByTestId("domain-reviewer-lab-page")).toHaveCount(0)
+      await expect(page.getByTestId("gate-governance-page")).toHaveCount(0)
+    })
+  }
+})

--- a/tests/e2e/helpers/production-probe-policy.ts
+++ b/tests/e2e/helpers/production-probe-policy.ts
@@ -1,0 +1,6 @@
+export function productionProbePolicy(isPostDeployProbe: boolean, isCI: boolean) {
+  return {
+    retries: isPostDeployProbe ? 0 : isCI ? 2 : 0,
+    trace: isPostDeployProbe ? ("off" as const) : ("on-first-retry" as const),
+  }
+}

--- a/tests/e2e/helpers/production-probe-policy.ts
+++ b/tests/e2e/helpers/production-probe-policy.ts
@@ -1,6 +1,21 @@
+type ProbeEnvironment = Readonly<Record<string, string | undefined>>
+
 export function productionProbePolicy(isPostDeployProbe: boolean, isCI: boolean) {
   return {
     retries: isPostDeployProbe ? 0 : isCI ? 2 : 0,
     trace: isPostDeployProbe ? ("off" as const) : ("on-first-retry" as const),
+  }
+}
+
+export function resolveProductionProbePolicy(
+  environment: ProbeEnvironment,
+  loadEnvironment: () => unknown
+) {
+  loadEnvironment()
+
+  const isPostDeployProbe = environment.POST_DEPLOY_PROBE === "true"
+  return {
+    isPostDeployProbe,
+    ...productionProbePolicy(isPostDeployProbe, !!environment.CI),
   }
 }

--- a/tests/e2e/helpers/production-session.test.ts
+++ b/tests/e2e/helpers/production-session.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+import { productionSessionCookies } from "./production-session"
+
+describe("productionSessionCookies", () => {
+  it("preserves the single-cookie environment contract", () => {
+    expect(
+      productionSessionCookies("admin", {
+        POST_DEPLOY_ADMIN_SESSION: "single-token",
+      })
+    ).toEqual([{ name: "__Secure-authjs.session-token", value: "single-token" }])
+  })
+
+  it("uses a configured single-cookie name", () => {
+    expect(
+      productionSessionCookies("operator", {
+        POST_DEPLOY_OPERATOR_SESSION: "single-token",
+        POST_DEPLOY_OPERATOR_SESSION_COOKIE_NAME: "authjs.session-token",
+      })
+    ).toEqual([{ name: "authjs.session-token", value: "single-token" }])
+  })
+
+  it("returns every supplied Auth.js session chunk", () => {
+    expect(
+      productionSessionCookies("admin", {
+        POST_DEPLOY_ADMIN_SESSION_COOKIES: JSON.stringify([
+          { name: "__Secure-authjs.session-token.0", value: "chunk-zero" },
+          { name: "__Secure-authjs.session-token.1", value: "chunk-one" },
+        ]),
+      })
+    ).toEqual([
+      { name: "__Secure-authjs.session-token.0", value: "chunk-zero" },
+      { name: "__Secure-authjs.session-token.1", value: "chunk-one" },
+    ])
+  })
+
+  it("prefers the chunked contract when both forms are present", () => {
+    expect(
+      productionSessionCookies("operator", {
+        POST_DEPLOY_OPERATOR_SESSION: "unused-single-token",
+        POST_DEPLOY_OPERATOR_SESSION_COOKIES: JSON.stringify([
+          { name: "__Secure-authjs.session-token.0", value: "chunk-zero" },
+        ]),
+      })
+    ).toEqual([{ name: "__Secure-authjs.session-token.0", value: "chunk-zero" }])
+  })
+
+  it("rejects malformed or empty chunked input without exposing values", () => {
+    expect(() =>
+      productionSessionCookies("admin", {
+        POST_DEPLOY_ADMIN_SESSION_COOKIES: "not-json",
+      })
+    ).toThrow("POST_DEPLOY_ADMIN_SESSION_COOKIES must be a valid JSON array.")
+
+    expect(() =>
+      productionSessionCookies("admin", {
+        POST_DEPLOY_ADMIN_SESSION_COOKIES: "[]",
+      })
+    ).toThrow("POST_DEPLOY_ADMIN_SESSION_COOKIES must contain at least one cookie.")
+  })
+
+  it("rejects unrelated and duplicate cookie names", () => {
+    expect(() =>
+      productionSessionCookies("admin", {
+        POST_DEPLOY_ADMIN_SESSION_COOKIES: JSON.stringify([
+          { name: "unrelated-cookie", value: "not-logged" },
+        ]),
+      })
+    ).toThrow("must use __Secure-authjs.session-token or a numeric chunk suffix")
+
+    expect(() =>
+      productionSessionCookies("admin", {
+        POST_DEPLOY_ADMIN_SESSION_COOKIES: JSON.stringify([
+          { name: "__Secure-authjs.session-token.0", value: "chunk-zero" },
+          { name: "__Secure-authjs.session-token.0", value: "chunk-zero-again" },
+        ]),
+      })
+    ).toThrow("must not contain duplicate cookie names")
+  })
+})

--- a/tests/e2e/helpers/production-session.ts
+++ b/tests/e2e/helpers/production-session.ts
@@ -1,0 +1,94 @@
+const DEFAULT_SESSION_COOKIE_NAME = "__Secure-authjs.session-token"
+
+export type ProbeRole = "admin" | "operator"
+
+export type SessionCookie = {
+  name: string
+  value: string
+}
+
+type SessionEnvironment = Readonly<Record<string, string | undefined>>
+
+function environmentPrefix(role: ProbeRole) {
+  return role === "admin" ? "POST_DEPLOY_ADMIN_SESSION" : "POST_DEPLOY_OPERATOR_SESSION"
+}
+
+function cookieBaseName(role: ProbeRole, environment: SessionEnvironment) {
+  return environment[`${environmentPrefix(role)}_COOKIE_NAME`] ?? DEFAULT_SESSION_COOKIE_NAME
+}
+
+function isExpectedCookieName(name: string, baseName: string) {
+  if (name === baseName) {
+    return true
+  }
+
+  const chunkSuffix = name.slice(baseName.length + 1)
+  return name.startsWith(`${baseName}.`) && /^\d+$/.test(chunkSuffix)
+}
+
+function parseChunkedCookies(
+  role: ProbeRole,
+  serializedCookies: string,
+  environment: SessionEnvironment
+): SessionCookie[] {
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(serializedCookies)
+  } catch {
+    throw new Error(`${environmentPrefix(role)}_COOKIES must be a valid JSON array.`)
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error(`${environmentPrefix(role)}_COOKIES must contain at least one cookie.`)
+  }
+
+  const baseName = cookieBaseName(role, environment)
+  const cookies = parsed.map((candidate, index) => {
+    if (
+      typeof candidate !== "object" ||
+      candidate === null ||
+      typeof candidate.name !== "string" ||
+      candidate.name.length === 0 ||
+      typeof candidate.value !== "string" ||
+      candidate.value.length === 0
+    ) {
+      throw new Error(
+        `${environmentPrefix(role)}_COOKIES entry ${index} must have non-empty name and value strings.`
+      )
+    }
+
+    if (!isExpectedCookieName(candidate.name, baseName)) {
+      throw new Error(
+        `${environmentPrefix(role)}_COOKIES entry ${index} must use ${baseName} or a numeric chunk suffix.`
+      )
+    }
+
+    return { name: candidate.name, value: candidate.value }
+  })
+
+  if (new Set(cookies.map(({ name }) => name)).size !== cookies.length) {
+    throw new Error(`${environmentPrefix(role)}_COOKIES must not contain duplicate cookie names.`)
+  }
+
+  return cookies
+}
+
+export function productionSessionCookies(
+  role: ProbeRole,
+  environment: SessionEnvironment = process.env
+): SessionCookie[] {
+  const prefix = environmentPrefix(role)
+  const serializedCookies = environment[`${prefix}_COOKIES`]
+
+  if (serializedCookies !== undefined) {
+    return parseChunkedCookies(role, serializedCookies, environment)
+  }
+
+  const sessionToken = environment[prefix]
+  if (!sessionToken) {
+    return []
+  }
+
+  return [{ name: cookieBaseName(role, environment), value: sessionToken }]
+}

--- a/tests/lib/production-probe-policy.test.ts
+++ b/tests/lib/production-probe-policy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { productionProbePolicy } from "../e2e/helpers/production-probe-policy"
+
+describe("productionProbePolicy", () => {
+  it("disables retries and tracing for legitimate production sessions", () => {
+    expect(productionProbePolicy(true, true)).toEqual({
+      retries: 0,
+      trace: "off",
+    })
+  })
+
+  it("preserves retry tracing for ordinary CI E2E tests", () => {
+    expect(productionProbePolicy(false, true)).toEqual({
+      retries: 2,
+      trace: "on-first-retry",
+    })
+  })
+
+  it("does not retry ordinary local E2E tests", () => {
+    expect(productionProbePolicy(false, false)).toEqual({
+      retries: 0,
+      trace: "on-first-retry",
+    })
+  })
+})

--- a/tests/lib/production-probe-policy.test.ts
+++ b/tests/lib/production-probe-policy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest"
-import { productionProbePolicy } from "../e2e/helpers/production-probe-policy"
+import {
+  productionProbePolicy,
+  resolveProductionProbePolicy,
+} from "../e2e/helpers/production-probe-policy"
 
 describe("productionProbePolicy", () => {
   it("disables retries and tracing for legitimate production sessions", () => {
@@ -20,6 +23,20 @@ describe("productionProbePolicy", () => {
     expect(productionProbePolicy(false, false)).toEqual({
       retries: 0,
       trace: "on-first-retry",
+    })
+  })
+
+  it("loads environment files before deciding whether production tracing is safe", () => {
+    const environment: Record<string, string | undefined> = { CI: "true" }
+
+    expect(
+      resolveProductionProbePolicy(environment, () => {
+        environment.POST_DEPLOY_PROBE = "true"
+      })
+    ).toEqual({
+      isPostDeployProbe: true,
+      retries: 0,
+      trace: "off",
     })
   })
 })

--- a/tests/lib/production-session.test.ts
+++ b/tests/lib/production-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { productionSessionCookies } from "./production-session"
+import { productionSessionCookies } from "../e2e/helpers/production-session"
 
 describe("productionSessionCookies", () => {
   it("preserves the single-cookie environment contract", () => {


### PR DESCRIPTION
## What changed

- add a manually invoked Gate 0 Playwright acceptance suite for admin synthetic reviewer rehearsal, reload-clears-result behavior, governance read visibility, and operator page/API denial
- add stable quality-dimension selectors and local/production probe scripts
- preserve and extend the Gate 0 continuation handoff with secure session and explicit non-goal boundaries

## Why

Local synthetic acceptance had passed, but production-auth reviewer and governance boundaries lacked a deterministic replay path. This prepares that path without storing sessions, automating production use, mutating governance decisions, restarting production, activating O5/O6, or performing any external reviewer or infrastructure action.

## Validation

- focused Vitest: 15/15 passed
- local Gate 0 Playwright: 6/6 passed with synthetic admin/operator sessions
- production-mode Playwright without sessions: 6 skipped as designed
- `pnpm run lint`: passed
- `pnpm exec tsc --noEmit`: passed
- `pnpm run build`: passed
- Prettier and `git diff --check`: passed

Production-auth acceptance remains skipped until legitimate short-lived admin and operator sessions are supplied. Governance write/reload/restart persistence remains separately approval-gated.