### PR TITLE
Add user-selectable workspace themes

### DIFF
--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { withAuth } from "@/lib/auth/rbac"
 import { getUserWithManagement } from "@/lib/user-management"
 import { updateUserProfileAsync } from "@/lib/users"
+import { isUserThemeId, type UserThemeId } from "@/lib/user-themes"
 
 export const GET = withAuth(async (_request, context) => {
   const user = await getUserWithManagement(context.userId)
@@ -12,12 +13,17 @@ export const GET = withAuth(async (_request, context) => {
 export const PATCH = withAuth(async (request, context) => {
   try {
     const body = await request.json()
-    const { name, phone, photoUrl } = body
+    const { name, phone, photoUrl, themeId } = body
 
-    const updates: { name?: string; phone?: string; photoUrl?: string } = {}
+    if (themeId !== undefined && !isUserThemeId(themeId)) {
+      return NextResponse.json({ error: "Invalid theme" }, { status: 400 })
+    }
+
+    const updates: { name?: string; phone?: string; photoUrl?: string; themeId?: UserThemeId } = {}
     if (typeof name === "string" && name.trim()) updates.name = name.trim()
     if (typeof phone === "string") updates.phone = phone.trim()
     if (typeof photoUrl === "string") updates.photoUrl = photoUrl.trim() || undefined
+    if (isUserThemeId(themeId)) updates.themeId = themeId
 
     if (Object.keys(updates).length === 0) {
       return NextResponse.json({ error: "No valid updates" }, { status: 400 })

--- a/app/dashboard/charl/page.tsx
+++ b/app/dashboard/charl/page.tsx
@@ -29,13 +29,13 @@ function WorkshopPattern() {
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* Gear/Tool patterns */}
-      <svg className="absolute top-10 right-10 h-64 w-64 text-amber-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
         <path
           d="M50 20 L55 35 L70 35 L58 45 L63 60 L50 50 L37 60 L42 45 L30 35 L45 35 Z"
           fill="currentColor"
         />
       </svg>
-      <svg className="absolute bottom-20 left-10 h-48 w-48 text-amber-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
         <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" strokeWidth="8" />
         <circle cx="50" cy="50" r="15" fill="currentColor" />
         {[0, 45, 90, 135, 180, 225, 270, 315].map((angle, i) => (
@@ -50,13 +50,13 @@ function WorkshopPattern() {
           />
         ))}
       </svg>
-      <svg className="absolute top-1/3 left-1/4 h-32 w-32 text-amber-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute top-1/3 left-1/4 h-32 w-32" viewBox="0 0 100 100">
         <path d="M20 80 L30 50 L50 50 L60 20 L70 50 L90 50 L80 80 Z" fill="currentColor" />
         <rect x="45" y="50" width="10" height="40" fill="currentColor" />
       </svg>
       {/* Wrench */}
       <svg
-        className="absolute right-1/3 bottom-1/4 h-40 w-40 rotate-45 text-amber-500/5"
+        className="text-primary/5 absolute right-1/3 bottom-1/4 h-40 w-40 rotate-45"
         viewBox="0 0 100 100"
       >
         <path
@@ -72,10 +72,10 @@ function WorkshopPattern() {
 
 function EmptyPanel({ title, action }: { title: string; action?: string }) {
   return (
-    <div className="flex h-full min-h-40 items-center justify-center rounded-xl border border-amber-500/10 bg-amber-950/30 p-6 text-center">
+    <div className="border-primary/10 bg-primary/10 flex h-full min-h-40 items-center justify-center rounded-xl border p-6 text-center">
       <div>
-        <p className="font-medium text-amber-100">{title}</p>
-        {action && <p className="mt-2 text-sm text-amber-200/50">{action}</p>}
+        <p className="text-foreground font-medium">{title}</p>
+        {action && <p className="text-muted-foreground mt-2 text-sm">{action}</p>}
       </div>
     </div>
   )
@@ -123,23 +123,23 @@ export default function CharlDashboard() {
   return (
     <DashboardLayout persona="charl">
       {/* Persona-specific background */}
-      <div className="fixed inset-0 -z-10 bg-linear-to-br from-amber-950/40 via-[#0a0a0f] to-orange-950/30" />
+      <div className="from-primary/10 to-secondary/10 fixed inset-0 -z-10 bg-linear-to-br via-[#0a0a0f]" />
       <WorkshopPattern />
 
       {/* Time Clock Banner */}
       <div
-        className="relative mb-8 overflow-hidden rounded-2xl border border-amber-500/30 bg-linear-to-r from-amber-600/30 to-orange-700/20 p-6 backdrop-blur-sm"
+        className="border-primary/30 from-primary/30 to-secondary/20 relative mb-8 overflow-hidden rounded-2xl border bg-linear-to-r p-6 backdrop-blur-sm"
         data-testid="time-clock-banner"
       >
         <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjAgMTBMMjIgMTVIMjhMMjMgMTlMMjUgMjVMMjAgMjFMMTUgMjVMMTcgMTlMMTIgMTVIMThMMjAgMTBaIiBmaWxsPSJyZ2JhKDI0NSwxNTgsMTEsMC4wNSkiLz48L3N2Zz4=')] opacity-50" />
         <div className="relative flex flex-col items-center justify-between gap-4 md:flex-row">
           <div className="flex items-center gap-4">
-            <div className="flex h-16 w-16 items-center justify-center rounded-xl border border-amber-500/30 bg-linear-to-br from-amber-500/30 to-orange-600/30">
-              <Clock className="h-8 w-8 text-amber-400" />
+            <div className="border-primary/30 from-primary/30 to-secondary/30 flex h-16 w-16 items-center justify-center rounded-xl border bg-linear-to-br">
+              <Clock className="text-primary h-8 w-8" />
             </div>
             <div>
               <p className="text-sm text-amber-200/60">Today&apos;s Work Time</p>
-              <p className="font-mono text-4xl font-bold text-amber-100" data-testid="clock-time">
+              <p className="text-foreground font-mono text-4xl font-bold" data-testid="clock-time">
                 {clockTime}
               </p>
             </div>
@@ -147,7 +147,7 @@ export default function CharlDashboard() {
           <div className="flex items-center gap-3">
             <div className="mr-4 hidden text-right md:block">
               <p className="text-sm text-amber-200/60">Clocked in at</p>
-              <p className="font-medium text-amber-100">
+              <p className="text-foreground font-medium">
                 {isClockRunning ? "Manual session" : "Not clocked in"}
               </p>
             </div>
@@ -178,7 +178,7 @@ export default function CharlDashboard() {
 
       {/* Specialty Tags */}
       <div className="mb-6 flex flex-wrap gap-2">
-        <span className="flex items-center gap-2 rounded-full border border-amber-500/30 bg-amber-500/20 px-3 py-1.5 text-sm font-medium text-amber-400">
+        <span className="border-primary/30 bg-primary/20 text-primary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
           <Zap className="h-4 w-4" /> Electrician
         </span>
         <span className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/20 px-3 py-1.5 text-sm font-medium text-blue-400">
@@ -197,36 +197,36 @@ export default function CharlDashboard() {
       {/* Stats Row */}
       <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
         <div
-          className="rounded-xl border border-amber-500/20 bg-amber-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-tasks"
         >
           <p className="text-sm text-amber-200/60">Active Tasks</p>
-          <p className="text-2xl font-bold text-amber-100">{tasks.total}</p>
-          <p className="text-sm text-amber-400">{tasks.completed} completed</p>
+          <p className="text-foreground text-2xl font-bold">{tasks.total}</p>
+          <p className="text-primary text-sm">{tasks.completed} completed</p>
         </div>
         <div
-          className="rounded-xl border border-amber-500/20 bg-amber-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-hours"
         >
           <p className="text-sm text-amber-200/60">Hours This Week</p>
-          <p className="text-2xl font-bold text-amber-100">0</p>
-          <p className="text-sm text-amber-200/50">No time records</p>
+          <p className="text-foreground text-2xl font-bold">0</p>
+          <p className="text-muted-foreground text-sm">No time records</p>
         </div>
         <div
-          className="rounded-xl border border-amber-500/20 bg-amber-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-assets"
         >
           <p className="text-sm text-amber-200/60">Assets Checked</p>
-          <p className="text-2xl font-bold text-amber-100">0</p>
-          <p className="text-sm text-amber-200/50">No live checkout data</p>
+          <p className="text-foreground text-2xl font-bold">0</p>
+          <p className="text-muted-foreground text-sm">No live checkout data</p>
         </div>
         <div
-          className="rounded-xl border border-amber-500/20 bg-amber-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-leave"
         >
           <p className="text-sm text-amber-200/60">Leave Balance</p>
-          <p className="text-2xl font-bold text-amber-100">—</p>
-          <p className="text-sm text-amber-200/50">No leave sync</p>
+          <p className="text-foreground text-2xl font-bold">—</p>
+          <p className="text-muted-foreground text-sm">No leave sync</p>
         </div>
       </div>
 
@@ -234,21 +234,21 @@ export default function CharlDashboard() {
       <div className="mb-8 grid gap-6 lg:grid-cols-3">
         {/* Weekly Task Completion */}
         <div
-          className="rounded-2xl border border-amber-500/20 bg-amber-950/40 p-6 backdrop-blur-sm lg:col-span-2"
+          className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm lg:col-span-2"
           data-testid="weekly-tasks-chart"
         >
           <div className="mb-6 flex items-center justify-between">
             <div>
-              <h3 className="font-semibold text-amber-100">Weekly Task Progress</h3>
-              <p className="text-sm text-amber-200/50">Completed vs Assigned</p>
+              <h3 className="text-foreground font-semibold">Weekly Task Progress</h3>
+              <p className="text-muted-foreground text-sm">Completed vs Assigned</p>
             </div>
             <div className="flex items-center gap-4 text-sm">
               <div className="flex items-center gap-2">
-                <div className="h-3 w-3 rounded-full bg-amber-500" />
+                <div className="bg-primary h-3 w-3 rounded-full" />
                 <span className="text-amber-200/60">Completed</span>
               </div>
               <div className="flex items-center gap-2">
-                <div className="h-3 w-3 rounded-full bg-amber-500/30" />
+                <div className="bg-primary/30 h-3 w-3 rounded-full" />
                 <span className="text-amber-200/60">Assigned</span>
               </div>
             </div>
@@ -263,11 +263,11 @@ export default function CharlDashboard() {
 
         {/* Skills Distribution */}
         <div
-          className="rounded-2xl border border-amber-500/20 bg-amber-950/40 p-6 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm"
           data-testid="skills-chart"
         >
-          <h3 className="mb-2 font-semibold text-amber-100">Skills Distribution</h3>
-          <p className="mb-4 text-sm text-amber-200/50">Task types this month</p>
+          <h3 className="text-foreground mb-2 font-semibold">Skills Distribution</h3>
+          <p className="text-muted-foreground mb-4 text-sm">Task types this month</p>
           <div className="h-48">
             <EmptyPanel
               title="No task-type data"
@@ -281,18 +281,18 @@ export default function CharlDashboard() {
       <div className="grid gap-6 lg:grid-cols-2">
         {/* My Tasks */}
         <div
-          className="overflow-hidden rounded-2xl border border-amber-500/20 bg-amber-950/40 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
           data-testid="my-tasks"
         >
-          <div className="flex items-center justify-between border-b border-amber-500/20 p-6">
+          <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <ClipboardList className="h-5 w-5 text-amber-400" />
+              <ClipboardList className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-amber-100">My Tasks</h3>
-                <p className="text-sm text-amber-200/50">Today&apos;s assignments</p>
+                <h3 className="text-foreground font-semibold">My Tasks</h3>
+                <p className="text-muted-foreground text-sm">Today&apos;s assignments</p>
               </div>
             </div>
-            <span className="rounded-full border border-amber-500/30 bg-amber-500/20 px-3 py-1 text-sm text-amber-400">
+            <span className="border-primary/30 bg-primary/20 text-primary rounded-full border px-3 py-1 text-sm">
               {tasks.total} tasks
             </span>
           </div>
@@ -306,15 +306,15 @@ export default function CharlDashboard() {
 
         {/* Assets */}
         <div
-          className="overflow-hidden rounded-2xl border border-amber-500/20 bg-amber-950/40 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
           data-testid="workshop-assets"
         >
-          <div className="flex items-center justify-between border-b border-amber-500/20 p-6">
+          <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <Package className="h-5 w-5 text-amber-400" />
+              <Package className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-amber-100">Workshop Assets</h3>
-                <p className="text-sm text-amber-200/50">Equipment status</p>
+                <h3 className="text-foreground font-semibold">Workshop Assets</h3>
+                <p className="text-muted-foreground text-sm">Equipment status</p>
               </div>
             </div>
           </div>
@@ -328,18 +328,18 @@ export default function CharlDashboard() {
 
         {/* Vehicles */}
         <div
-          className="overflow-hidden rounded-2xl border border-amber-500/20 bg-amber-950/40 backdrop-blur-sm lg:col-span-2"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm lg:col-span-2"
           data-testid="vehicle-log"
         >
-          <div className="flex items-center justify-between border-b border-amber-500/20 p-6">
+          <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <Car className="h-5 w-5 text-amber-400" />
+              <Car className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-amber-100">Vehicles</h3>
-                <p className="text-sm text-amber-200/50">Coming soon</p>
+                <h3 className="text-foreground font-semibold">Vehicles</h3>
+                <p className="text-muted-foreground text-sm">Coming soon</p>
               </div>
             </div>
-            <span className="rounded-full border border-amber-500/30 bg-amber-500/20 px-3 py-1 text-sm font-medium text-amber-400">
+            <span className="border-primary/30 bg-primary/20 text-primary rounded-full border px-3 py-1 text-sm font-medium">
               Coming soon
             </span>
           </div>

--- a/app/dashboard/charl/page.tsx
+++ b/app/dashboard/charl/page.tsx
@@ -29,13 +29,13 @@ function WorkshopPattern() {
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* Gear/Tool patterns */}
-      <svg className="text-primary/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
         <path
           d="M50 20 L55 35 L70 35 L58 45 L63 60 L50 50 L37 60 L42 45 L30 35 L45 35 Z"
           fill="currentColor"
         />
       </svg>
-      <svg className="text-primary/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
         <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" strokeWidth="8" />
         <circle cx="50" cy="50" r="15" fill="currentColor" />
         {[0, 45, 90, 135, 180, 225, 270, 315].map((angle, i) => (
@@ -50,13 +50,13 @@ function WorkshopPattern() {
           />
         ))}
       </svg>
-      <svg className="text-primary/5 absolute top-1/3 left-1/4 h-32 w-32" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute top-1/3 left-1/4 h-32 w-32" viewBox="0 0 100 100">
         <path d="M20 80 L30 50 L50 50 L60 20 L70 50 L90 50 L80 80 Z" fill="currentColor" />
         <rect x="45" y="50" width="10" height="40" fill="currentColor" />
       </svg>
       {/* Wrench */}
       <svg
-        className="text-primary/5 absolute right-1/3 bottom-1/4 h-40 w-40 rotate-45"
+        className="text-primary-text/5 absolute right-1/3 bottom-1/4 h-40 w-40 rotate-45"
         viewBox="0 0 100 100"
       >
         <path
@@ -135,7 +135,7 @@ export default function CharlDashboard() {
         <div className="relative flex flex-col items-center justify-between gap-4 md:flex-row">
           <div className="flex items-center gap-4">
             <div className="border-primary/30 from-primary/30 to-secondary/30 flex h-16 w-16 items-center justify-center rounded-xl border bg-linear-to-br">
-              <Clock className="text-primary h-8 w-8" />
+              <Clock className="text-primary-text h-8 w-8" />
             </div>
             <div>
               <p className="text-sm text-amber-200/60">Today&apos;s Work Time</p>
@@ -178,7 +178,7 @@ export default function CharlDashboard() {
 
       {/* Specialty Tags */}
       <div className="mb-6 flex flex-wrap gap-2">
-        <span className="border-primary/30 bg-primary/20 text-primary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
+        <span className="border-primary/30 bg-primary/20 text-primary-text flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
           <Zap className="h-4 w-4" /> Electrician
         </span>
         <span className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/20 px-3 py-1.5 text-sm font-medium text-blue-400">
@@ -202,7 +202,7 @@ export default function CharlDashboard() {
         >
           <p className="text-sm text-amber-200/60">Active Tasks</p>
           <p className="text-foreground text-2xl font-bold">{tasks.total}</p>
-          <p className="text-primary text-sm">{tasks.completed} completed</p>
+          <p className="text-primary-text text-sm">{tasks.completed} completed</p>
         </div>
         <div
           className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
@@ -286,13 +286,13 @@ export default function CharlDashboard() {
         >
           <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <ClipboardList className="text-primary h-5 w-5" />
+              <ClipboardList className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">My Tasks</h3>
                 <p className="text-muted-foreground text-sm">Today&apos;s assignments</p>
               </div>
             </div>
-            <span className="border-primary/30 bg-primary/20 text-primary rounded-full border px-3 py-1 text-sm">
+            <span className="border-primary/30 bg-primary/20 text-primary-text rounded-full border px-3 py-1 text-sm">
               {tasks.total} tasks
             </span>
           </div>
@@ -311,7 +311,7 @@ export default function CharlDashboard() {
         >
           <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <Package className="text-primary h-5 w-5" />
+              <Package className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">Workshop Assets</h3>
                 <p className="text-muted-foreground text-sm">Equipment status</p>
@@ -333,13 +333,13 @@ export default function CharlDashboard() {
         >
           <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <Car className="text-primary h-5 w-5" />
+              <Car className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">Vehicles</h3>
                 <p className="text-muted-foreground text-sm">Coming soon</p>
               </div>
             </div>
-            <span className="border-primary/30 bg-primary/20 text-primary rounded-full border px-3 py-1 text-sm font-medium">
+            <span className="border-primary/30 bg-primary/20 text-primary-text rounded-full border px-3 py-1 text-sm font-medium">
               Coming soon
             </span>
           </div>

--- a/app/dashboard/hans/page.tsx
+++ b/app/dashboard/hans/page.tsx
@@ -63,7 +63,7 @@ function TechPattern() {
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* Circuit board pattern */}
-      <svg className="absolute top-10 right-10 h-64 w-64 text-blue-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
         <circle cx="20" cy="20" r="5" fill="currentColor" />
         <circle cx="80" cy="20" r="5" fill="currentColor" />
         <circle cx="50" cy="50" r="8" fill="currentColor" />
@@ -77,7 +77,7 @@ function TechPattern() {
         />
       </svg>
       {/* Network nodes */}
-      <svg className="absolute bottom-20 left-10 h-48 w-48 text-blue-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
         <circle cx="50" cy="50" r="15" fill="currentColor" />
         <circle cx="20" cy="30" r="8" fill="currentColor" />
         <circle cx="80" cy="30" r="8" fill="currentColor" />
@@ -89,16 +89,13 @@ function TechPattern() {
         <line x1="50" y1="50" x2="80" y2="70" stroke="currentColor" strokeWidth="2" />
       </svg>
       {/* Monitor/Screen */}
-      <svg className="absolute top-1/3 left-1/5 h-40 w-40 text-blue-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute top-1/3 left-1/5 h-40 w-40" viewBox="0 0 100 100">
         <rect x="10" y="15" width="80" height="55" rx="3" fill="currentColor" />
         <rect x="40" y="70" width="20" height="10" fill="currentColor" />
         <rect x="30" y="80" width="40" height="5" rx="2" fill="currentColor" />
       </svg>
       {/* Chip/CPU */}
-      <svg
-        className="absolute right-1/5 bottom-1/3 h-36 w-36 text-blue-500/5"
-        viewBox="0 0 100 100"
-      >
+      <svg className="text-primary/5 absolute right-1/5 bottom-1/3 h-36 w-36" viewBox="0 0 100 100">
         <rect x="25" y="25" width="50" height="50" rx="5" fill="currentColor" />
         {[30, 40, 50, 60, 70].map((pos) => (
           <g key={pos}>
@@ -119,8 +116,8 @@ function TechPattern() {
 const CustomTooltip = ({ active, payload, label }: ChartTooltipProps) => {
   if (active && payload && payload.length) {
     return (
-      <div className="rounded-lg border border-blue-500/20 bg-blue-950 p-3 shadow-xl">
-        <p className="mb-1 font-medium text-blue-100">{label}</p>
+      <div className="border-primary/20 bg-primary/15 rounded-lg border p-3 shadow-xl">
+        <p className="text-foreground mb-1 font-medium">{label}</p>
         {payload.map((entry, index) => (
           <p key={index} className="text-sm" style={{ color: entry.color }}>
             {entry.name}:{" "}
@@ -157,7 +154,7 @@ function StatCard({
   color: StatCardColor
 }) {
   const colorClasses: Record<StatCardColor, string> = {
-    blue: "from-blue-600/30 to-blue-600/10 border-blue-500/30",
+    blue: "from-primary/30 to-primary/10 border-primary/30",
     green: "from-green-600/30 to-green-600/10 border-green-500/30",
     amber: "from-amber-600/30 to-amber-600/10 border-amber-500/30",
     red: "from-red-600/30 to-red-600/10 border-red-500/30",
@@ -165,7 +162,7 @@ function StatCard({
   }
 
   const iconColors: Record<StatCardColor, string> = {
-    blue: "text-blue-400",
+    blue: "text-primary",
     green: "text-green-400",
     amber: "text-amber-400",
     red: "text-red-400",
@@ -180,7 +177,7 @@ function StatCard({
       <div className="flex items-start justify-between">
         <div>
           <p className="mb-1 text-sm text-blue-200/60">{title}</p>
-          <p className="text-3xl font-bold text-blue-100">{value}</p>
+          <p className="text-foreground text-3xl font-bold">{value}</p>
           {change && (
             <div className="mt-2 flex items-center gap-1">
               {changeType === "up" && <TrendingUp className="h-4 w-4 text-green-400" />}
@@ -194,7 +191,7 @@ function StatCard({
           )}
         </div>
         <div
-          className={`rounded-xl border border-blue-500/20 bg-blue-950/50 p-3 ${iconColors[color as keyof typeof iconColors]}`}
+          className={`border-primary/20 bg-primary/15 rounded-xl border p-3 ${iconColors[color as keyof typeof iconColors]}`}
         >
           <Icon className="h-6 w-6" />
         </div>
@@ -205,10 +202,10 @@ function StatCard({
 
 function EmptyPanel({ title, action }: { title: string; action?: string }) {
   return (
-    <div className="flex h-full min-h-40 items-center justify-center rounded-xl border border-blue-500/10 bg-blue-950/30 p-6 text-center">
+    <div className="border-primary/10 bg-primary/10 flex h-full min-h-40 items-center justify-center rounded-xl border p-6 text-center">
       <div>
-        <p className="font-medium text-blue-100">{title}</p>
-        {action && <p className="mt-2 text-sm text-blue-200/50">{action}</p>}
+        <p className="text-foreground font-medium">{title}</p>
+        {action && <p className="text-muted-foreground mt-2 text-sm">{action}</p>}
       </div>
     </div>
   )
@@ -233,7 +230,7 @@ export default function DashboardPage() {
     return (
       <DashboardLayout persona="hans">
         <div className="flex h-64 items-center justify-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-500/30 border-t-blue-500" />
+          <div className="border-primary/30 border-t-primary h-8 w-8 animate-spin rounded-full border-2" />
         </div>
       </DashboardLayout>
     )
@@ -266,15 +263,15 @@ export default function DashboardPage() {
   return (
     <DashboardLayout persona="hans">
       {/* Persona-specific background */}
-      <div className="fixed inset-0 -z-10 bg-linear-to-br from-blue-950/40 via-[#0a0a0f] to-cyan-950/30" />
+      <div className="from-primary/10 to-secondary/10 fixed inset-0 -z-10 bg-linear-to-br via-[#0a0a0f]" />
       <TechPattern />
 
       {/* Specialty Tags */}
       <div className="mb-6 flex flex-wrap gap-2">
-        <span className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/20 px-3 py-1.5 text-sm font-medium text-blue-400">
+        <span className="border-primary/30 bg-primary/20 text-primary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
           <Monitor className="h-4 w-4" /> Tech Lead
         </span>
-        <span className="flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-500/20 px-3 py-1.5 text-sm font-medium text-cyan-400">
+        <span className="border-secondary/30 bg-secondary/20 text-secondary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
           <Cpu className="h-4 w-4" /> Electronics
         </span>
         <span className="flex items-center gap-2 rounded-full border border-purple-500/30 bg-purple-500/20 px-3 py-1.5 text-sm font-medium text-purple-400">
@@ -334,17 +331,17 @@ export default function DashboardPage() {
         {/* Budget Overview */}
         <WidgetErrorBoundary className="lg:col-span-2">
           <div
-            className="rounded-2xl border border-blue-500/20 bg-blue-950/40 p-6 backdrop-blur-sm"
+            className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm"
             data-testid="budget-chart"
           >
             <div className="mb-6 flex items-center justify-between">
               <div>
-                <h3 className="font-semibold text-blue-100">Budget Overview</h3>
-                <p className="text-sm text-blue-200/50">6-month spending trend</p>
+                <h3 className="text-foreground font-semibold">Budget Overview</h3>
+                <p className="text-muted-foreground text-sm">6-month spending trend</p>
               </div>
               <div className="flex items-center gap-4 text-sm">
                 <div className="flex items-center gap-2">
-                  <div className="h-3 w-3 rounded-full bg-blue-500" />
+                  <div className="bg-primary h-3 w-3 rounded-full" />
                   <span className="text-blue-200/60">Allocated</span>
                 </div>
                 <div className="flex items-center gap-2">
@@ -387,11 +384,11 @@ export default function DashboardPage() {
         {/* Task Status */}
         <WidgetErrorBoundary>
           <div
-            className="rounded-2xl border border-blue-500/20 bg-blue-950/40 p-6 backdrop-blur-sm"
+            className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm"
             data-testid="task-status-chart"
           >
-            <h3 className="mb-2 font-semibold text-blue-100">Task Status</h3>
-            <p className="mb-4 text-sm text-blue-200/50">Current overview</p>
+            <h3 className="text-foreground mb-2 font-semibold">Task Status</h3>
+            <p className="text-muted-foreground mb-4 text-sm">Current overview</p>
             <div className="h-48">
               {hasTaskStatus ? (
                 <ResponsiveContainer width="100%" height="100%">
@@ -430,7 +427,7 @@ export default function DashboardPage() {
                       />
                       <span className="text-blue-200/60">{status.name}</span>
                     </div>
-                    <span className="font-medium text-blue-100">{status.value}</span>
+                    <span className="text-foreground font-medium">{status.value}</span>
                   </div>
                 ))}
               </div>
@@ -444,13 +441,13 @@ export default function DashboardPage() {
         {/* Employee Task Performance */}
         <WidgetErrorBoundary>
           <div
-            className="rounded-2xl border border-blue-500/20 bg-blue-950/40 p-6 backdrop-blur-sm"
+            className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm"
             data-testid="employee-performance-chart"
           >
             <div className="mb-6 flex items-center justify-between">
               <div>
-                <h3 className="font-semibold text-blue-100">Employee Performance</h3>
-                <p className="text-sm text-blue-200/50">Tasks completed this month</p>
+                <h3 className="text-foreground font-semibold">Employee Performance</h3>
+                <p className="text-muted-foreground text-sm">Tasks completed this month</p>
               </div>
             </div>
             <div className="h-64">
@@ -465,17 +462,17 @@ export default function DashboardPage() {
         {/* Compliance Trend */}
         <WidgetErrorBoundary>
           <div
-            className="rounded-2xl border border-blue-500/20 bg-blue-950/40 p-6 backdrop-blur-sm"
+            className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm"
             data-testid="compliance-chart"
           >
             <div className="mb-6 flex items-center justify-between">
               <div>
-                <h3 className="font-semibold text-blue-100">Document Compliance</h3>
-                <p className="text-sm text-blue-200/50">6-month trend</p>
+                <h3 className="text-foreground font-semibold">Document Compliance</h3>
+                <p className="text-muted-foreground text-sm">6-month trend</p>
               </div>
               <div className="text-right">
                 <p className="text-2xl font-bold text-blue-200/60">—</p>
-                <p className="text-sm text-blue-200/50">Current</p>
+                <p className="text-muted-foreground text-sm">Current</p>
               </div>
             </div>
             <div className="h-64">
@@ -493,13 +490,13 @@ export default function DashboardPage() {
         {/* Pending Approvals - 2 columns */}
         <WidgetErrorBoundary className="lg:col-span-2">
           <div
-            className="overflow-hidden rounded-2xl border border-blue-500/20 bg-blue-950/40 backdrop-blur-sm"
+            className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
             data-testid="pending-approvals"
           >
-            <div className="flex items-center justify-between border-b border-blue-500/20 p-6">
+            <div className="border-primary/20 flex items-center justify-between border-b p-6">
               <div>
-                <h3 className="text-lg font-semibold text-blue-100">Pending Approvals</h3>
-                <p className="text-sm text-blue-200/50">Items requiring your action</p>
+                <h3 className="text-foreground text-lg font-semibold">Pending Approvals</h3>
+                <p className="text-muted-foreground text-sm">Items requiring your action</p>
               </div>
               <span className="rounded-full border border-amber-500/30 bg-amber-500/20 px-3 py-1 text-sm font-medium text-amber-400">
                 {expenses.pending} pending
@@ -511,9 +508,9 @@ export default function DashboardPage() {
                 action="Submitted expenses or approval workflows will appear here."
               />
             </div>
-            <div className="border-t border-blue-500/20 p-4">
+            <div className="border-primary/20 border-t p-4">
               <button
-                className="flex w-full items-center justify-center gap-2 text-center text-sm font-medium text-blue-400 hover:text-blue-300"
+                className="text-primary flex w-full items-center justify-center gap-2 text-center text-sm font-medium hover:text-blue-300"
                 onClick={() => router.push("/dashboard/hans/approvals")}
                 aria-label="View all pending items"
               >
@@ -529,13 +526,13 @@ export default function DashboardPage() {
           {/* Document Expiry Alerts */}
           <WidgetErrorBoundary>
             <div
-              className="overflow-hidden rounded-2xl border border-blue-500/20 bg-blue-950/40 backdrop-blur-sm"
+              className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
               data-testid="document-expiry"
             >
-              <div className="flex items-center justify-between border-b border-blue-500/20 p-6">
+              <div className="border-primary/20 flex items-center justify-between border-b p-6">
                 <div>
-                  <h3 className="font-semibold text-blue-100">Expiring Documents</h3>
-                  <p className="text-sm text-blue-200/50">Requiring review</p>
+                  <h3 className="text-foreground font-semibold">Expiring Documents</h3>
+                  <p className="text-muted-foreground text-sm">Requiring review</p>
                 </div>
                 <AlertTriangle className="h-5 w-5 text-amber-400" />
               </div>
@@ -551,13 +548,13 @@ export default function DashboardPage() {
           {/* Recent Activity */}
           <WidgetErrorBoundary>
             <div
-              className="overflow-hidden rounded-2xl border border-blue-500/20 bg-blue-950/40 backdrop-blur-sm"
+              className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
               data-testid="recent-activity"
             >
-              <div className="border-b border-blue-500/20 p-6">
-                <h3 className="font-semibold text-blue-100">Recent Activity</h3>
+              <div className="border-primary/20 border-b p-6">
+                <h3 className="text-foreground font-semibold">Recent Activity</h3>
               </div>
-              <div className="divide-y divide-blue-500/10 p-4">
+              <div className="divide-primary/10 divide-y p-4">
                 <EmptyPanel
                   title="No recent activity"
                   action="Live events will appear here after work is recorded."
@@ -569,27 +566,27 @@ export default function DashboardPage() {
           {/* System Status */}
           <WidgetErrorBoundary>
             <div
-              className="rounded-2xl border border-blue-500/20 bg-blue-950/40 p-6 backdrop-blur-sm"
+              className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm"
               data-testid="system-status"
             >
               <div className="mb-4 flex items-center gap-3">
-                <Server className="h-5 w-5 text-blue-400" />
-                <h3 className="font-semibold text-blue-100">System Status</h3>
+                <Server className="text-primary h-5 w-5" />
+                <h3 className="text-foreground font-semibold">System Status</h3>
               </div>
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-blue-200/60">Data mode</span>
-                  <span className="text-sm font-medium text-blue-100">
+                  <span className="text-foreground text-sm font-medium">
                     {stats?.dataSource ?? "empty"}
                   </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-blue-200/60">Tasks tracked</span>
-                  <span className="text-sm font-medium text-blue-100">{tasks.total}</span>
+                  <span className="text-foreground text-sm font-medium">{tasks.total}</span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-blue-200/60">Employees tracked</span>
-                  <span className="text-sm font-medium text-blue-100">{users.active}</span>
+                  <span className="text-foreground text-sm font-medium">{users.active}</span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-blue-200/60">API Status</span>

--- a/app/dashboard/hans/page.tsx
+++ b/app/dashboard/hans/page.tsx
@@ -63,7 +63,7 @@ function TechPattern() {
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* Circuit board pattern */}
-      <svg className="text-primary/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
         <circle cx="20" cy="20" r="5" fill="currentColor" />
         <circle cx="80" cy="20" r="5" fill="currentColor" />
         <circle cx="50" cy="50" r="8" fill="currentColor" />
@@ -77,7 +77,7 @@ function TechPattern() {
         />
       </svg>
       {/* Network nodes */}
-      <svg className="text-primary/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
         <circle cx="50" cy="50" r="15" fill="currentColor" />
         <circle cx="20" cy="30" r="8" fill="currentColor" />
         <circle cx="80" cy="30" r="8" fill="currentColor" />
@@ -89,13 +89,13 @@ function TechPattern() {
         <line x1="50" y1="50" x2="80" y2="70" stroke="currentColor" strokeWidth="2" />
       </svg>
       {/* Monitor/Screen */}
-      <svg className="text-primary/5 absolute top-1/3 left-1/5 h-40 w-40" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute top-1/3 left-1/5 h-40 w-40" viewBox="0 0 100 100">
         <rect x="10" y="15" width="80" height="55" rx="3" fill="currentColor" />
         <rect x="40" y="70" width="20" height="10" fill="currentColor" />
         <rect x="30" y="80" width="40" height="5" rx="2" fill="currentColor" />
       </svg>
       {/* Chip/CPU */}
-      <svg className="text-primary/5 absolute right-1/5 bottom-1/3 h-36 w-36" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute right-1/5 bottom-1/3 h-36 w-36" viewBox="0 0 100 100">
         <rect x="25" y="25" width="50" height="50" rx="5" fill="currentColor" />
         {[30, 40, 50, 60, 70].map((pos) => (
           <g key={pos}>
@@ -162,7 +162,7 @@ function StatCard({
   }
 
   const iconColors: Record<StatCardColor, string> = {
-    blue: "text-primary",
+    blue: "text-primary-text",
     green: "text-green-400",
     amber: "text-amber-400",
     red: "text-red-400",
@@ -268,7 +268,7 @@ export default function DashboardPage() {
 
       {/* Specialty Tags */}
       <div className="mb-6 flex flex-wrap gap-2">
-        <span className="border-primary/30 bg-primary/20 text-primary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
+        <span className="border-primary/30 bg-primary/20 text-primary-text flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
           <Monitor className="h-4 w-4" /> Tech Lead
         </span>
         <span className="border-secondary/30 bg-secondary/20 text-secondary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
@@ -510,7 +510,7 @@ export default function DashboardPage() {
             </div>
             <div className="border-primary/20 border-t p-4">
               <button
-                className="text-primary flex w-full items-center justify-center gap-2 text-center text-sm font-medium hover:text-blue-300"
+                className="text-primary-text flex w-full items-center justify-center gap-2 text-center text-sm font-medium hover:text-blue-300"
                 onClick={() => router.push("/dashboard/hans/approvals")}
                 aria-label="View all pending items"
               >
@@ -570,7 +570,7 @@ export default function DashboardPage() {
               data-testid="system-status"
             >
               <div className="mb-4 flex items-center gap-3">
-                <Server className="text-primary h-5 w-5" />
+                <Server className="text-primary-text h-5 w-5" />
                 <h3 className="text-foreground font-semibold">System Status</h3>
               </div>
               <div className="space-y-4">

--- a/app/dashboard/hans/settings/settings-content.tsx
+++ b/app/dashboard/hans/settings/settings-content.tsx
@@ -98,17 +98,17 @@ export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "
 
   const handleSave = async () => {
     setSaveError(false)
+    localStorage.setItem("hov_settings", JSON.stringify(settings))
+    setSaved(true)
+    setTimeout(() => setSaved(false), 3000)
     try {
       await apiFetch("/api/users/me", {
         method: "PATCH",
         body: { themeId: selectedTheme },
         label: "SaveTheme",
       })
-      localStorage.setItem("hov_settings", JSON.stringify(settings))
       await refresh()
       setThemeOverride(null)
-      setSaved(true)
-      setTimeout(() => setSaved(false), 3000)
     } catch {
       setSaveError(true)
     }
@@ -157,7 +157,7 @@ export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "
 
         <div className="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
           <div className="flex items-center gap-3 border-b border-white/10 p-6">
-            <Palette className="text-primary h-5 w-5" />
+            <Palette className="text-primary-text h-5 w-5" />
             <div>
               <h2 className="font-semibold text-white">Appearance</h2>
               <p className="text-sm text-white/50">Choose your personal workspace colours.</p>
@@ -429,7 +429,7 @@ export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "
           )}
           {saveError && (
             <span className="text-sm text-red-400" role="alert">
-              Settings could not be saved. Please try again.
+              Local settings saved, but your theme could not be synced. Please try again.
             </span>
           )}
           <button

--- a/app/dashboard/hans/settings/settings-content.tsx
+++ b/app/dashboard/hans/settings/settings-content.tsx
@@ -79,6 +79,16 @@ export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "
   const selectedTheme = themeOverride ?? persistedTheme
 
   useEffect(() => {
+    if (themeOverride) {
+      document.documentElement.dataset.userTheme = themeOverride
+    }
+
+    return () => {
+      document.documentElement.dataset.userTheme = persistedTheme
+    }
+  }, [persistedTheme, themeOverride])
+
+  useEffect(() => {
     apiFetchSafe<{ options?: string[] }>(
       "/api/settings/storage-options",
       { options: [] },
@@ -156,10 +166,7 @@ export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "
           <div className="p-6">
             <UserThemePicker
               value={selectedTheme}
-              onChange={(themeId) => {
-                setThemeOverride(themeId)
-                document.documentElement.dataset.userTheme = themeId
-              }}
+              onChange={setThemeOverride}
             />
           </div>
         </div>

--- a/app/dashboard/hans/settings/settings-content.tsx
+++ b/app/dashboard/hans/settings/settings-content.tsx
@@ -2,10 +2,12 @@
 
 import { useState, useEffect } from "react"
 import DashboardLayout from "@/components/dashboard-layout"
+import { UserThemePicker } from "@/components/user-theme-picker"
 import { useI18n, LanguageSelector } from "@/lib/i18n/context"
 import { usePWA } from "@/lib/hooks/use-pwa"
 import { useAuth } from "@/lib/auth-context"
 import { apiFetch, apiFetchSafe } from "@/lib/api-client"
+import { defaultUserThemeForColor, isUserThemeId, type UserThemeId } from "@/lib/user-themes"
 import {
   User,
   Globe,
@@ -19,6 +21,7 @@ import {
   CheckCircle,
   Trash2,
   Download,
+  Palette,
 } from "lucide-react"
 
 function ToggleSetting({
@@ -53,7 +56,7 @@ function ToggleSetting({
 }
 
 export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "lucky" | "irma" }) {
-  const { user } = useAuth()
+  const { user, refresh } = useAuth()
   const { t } = useI18n()
   const { isInstalled, canInstall, installApp, requestNotificationPermission } = usePWA()
   const [saved, setSaved] = useState(false)
@@ -68,6 +71,12 @@ export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "
   const [storageOptions, setStorageOptions] = useState<string[]>([])
   const [newStorageOption, setNewStorageOption] = useState("")
   const [storageOptionsSaved, setStorageOptionsSaved] = useState(false)
+  const [themeOverride, setThemeOverride] = useState<UserThemeId | null>(null)
+  const [saveError, setSaveError] = useState(false)
+  const persistedTheme = isUserThemeId(user?.themeId)
+    ? user.themeId
+    : defaultUserThemeForColor(user?.color)
+  const selectedTheme = themeOverride ?? persistedTheme
 
   useEffect(() => {
     apiFetchSafe<{ options?: string[] }>(
@@ -77,10 +86,22 @@ export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "
     ).then((d) => setStorageOptions(d?.options || []))
   }, [])
 
-  const handleSave = () => {
-    localStorage.setItem("hov_settings", JSON.stringify(settings))
-    setSaved(true)
-    setTimeout(() => setSaved(false), 3000)
+  const handleSave = async () => {
+    setSaveError(false)
+    try {
+      await apiFetch("/api/users/me", {
+        method: "PATCH",
+        body: { themeId: selectedTheme },
+        label: "SaveTheme",
+      })
+      localStorage.setItem("hov_settings", JSON.stringify(settings))
+      await refresh()
+      setThemeOverride(null)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 3000)
+    } catch {
+      setSaveError(true)
+    }
   }
 
   const handleEnablePush = async () => {
@@ -122,6 +143,25 @@ export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "
         <div>
           <h1 className="text-2xl font-bold text-white">{t("settings.profile")}</h1>
           <p className="mt-1 text-white/60">Manage your account settings and preferences</p>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
+          <div className="flex items-center gap-3 border-b border-white/10 p-6">
+            <Palette className="text-primary h-5 w-5" />
+            <div>
+              <h2 className="font-semibold text-white">Appearance</h2>
+              <p className="text-sm text-white/50">Choose your personal workspace colours.</p>
+            </div>
+          </div>
+          <div className="p-6">
+            <UserThemePicker
+              value={selectedTheme}
+              onChange={(themeId) => {
+                setThemeOverride(themeId)
+                document.documentElement.dataset.userTheme = themeId
+              }}
+            />
+          </div>
         </div>
 
         <div className="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
@@ -378,6 +418,11 @@ export function SettingsPageContent({ persona }: { persona: "hans" | "charl" | "
             <span className="flex items-center gap-2 text-green-400">
               <CheckCircle className="h-4 w-4" />
               Settings saved
+            </span>
+          )}
+          {saveError && (
+            <span className="text-sm text-red-400" role="alert">
+              Settings could not be saved. Please try again.
             </span>
           )}
           <button

--- a/app/dashboard/irma/page.tsx
+++ b/app/dashboard/irma/page.tsx
@@ -31,21 +31,21 @@ function HomePattern() {
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* Heart patterns */}
-      <svg className="text-primary/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
         <path
           d="M50 88 C20 60 5 40 5 25 C5 10 20 5 35 15 C42 20 47 28 50 35 C53 28 58 20 65 15 C80 5 95 10 95 25 C95 40 80 60 50 88 Z"
           fill="currentColor"
         />
       </svg>
       {/* House */}
-      <svg className="text-primary/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
         <polygon points="50,10 90,45 90,90 10,90 10,45" fill="currentColor" />
         <rect x="40" y="60" width="20" height="30" fill="rgba(10,10,15,0.5)" />
         <rect x="60" y="50" width="15" height="15" fill="rgba(10,10,15,0.3)" />
         <rect x="25" y="50" width="15" height="15" fill="rgba(10,10,15,0.3)" />
       </svg>
       {/* Sparkle/Star */}
-      <svg className="text-primary/5 absolute top-1/3 left-1/4 h-32 w-32" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute top-1/3 left-1/4 h-32 w-32" viewBox="0 0 100 100">
         <path d="M50 5 L55 40 L90 50 L55 60 L50 95 L45 60 L10 50 L45 40 Z" fill="currentColor" />
       </svg>
       {/* Baby/Child icon */}
@@ -179,7 +179,7 @@ export default function IrmaDashboard() {
 
       {/* Specialty Tags */}
       <div className="mb-6 flex flex-wrap gap-2">
-        <span className="border-primary/30 bg-primary/20 text-primary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
+        <span className="border-primary/30 bg-primary/20 text-primary-text flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
           <Sparkles className="h-4 w-4" /> Cleaning
         </span>
         <span className="flex items-center gap-2 rounded-full border border-amber-500/30 bg-amber-500/20 px-3 py-1.5 text-sm font-medium text-amber-400">
@@ -204,18 +204,18 @@ export default function IrmaDashboard() {
           data-testid="stat-tasks-today"
         >
           <div className="mb-2 flex items-center gap-3">
-            <ClipboardList className="text-primary h-5 w-5" />
+            <ClipboardList className="text-primary-text h-5 w-5" />
             <p className="text-sm text-purple-200/60">Today&apos;s Tasks</p>
           </div>
           <p className="text-foreground text-2xl font-bold">{loading ? "—" : tasksToday.length}</p>
-          <p className="text-primary text-sm">{loading ? "…" : `${completedToday} completed`}</p>
+          <p className="text-primary-text text-sm">{loading ? "…" : `${completedToday} completed`}</p>
         </div>
         <div
           className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-documents"
         >
           <div className="mb-2 flex items-center gap-3">
-            <FileText className="text-primary h-5 w-5" />
+            <FileText className="text-primary-text h-5 w-5" />
             <p className="text-sm text-purple-200/60">Documents</p>
           </div>
           <p className="text-foreground text-2xl font-bold">{loading ? "—" : documents.length}</p>
@@ -232,7 +232,7 @@ export default function IrmaDashboard() {
           data-testid="stat-weekly"
         >
           <div className="mb-2 flex items-center gap-3">
-            <Calendar className="text-primary h-5 w-5" />
+            <Calendar className="text-primary-text h-5 w-5" />
             <p className="text-sm text-purple-200/60">This Week</p>
           </div>
           <p className="text-foreground text-2xl font-bold">{loading ? "—" : completedThisWeek}</p>
@@ -243,7 +243,7 @@ export default function IrmaDashboard() {
           data-testid="stat-meals"
         >
           <div className="mb-2 flex items-center gap-3">
-            <UtensilsCrossed className="text-primary h-5 w-5" />
+            <UtensilsCrossed className="text-primary-text h-5 w-5" />
             <p className="text-sm text-purple-200/60">Meals Planned</p>
           </div>
           <p className="text-foreground text-2xl font-bold">0</p>
@@ -301,7 +301,7 @@ export default function IrmaDashboard() {
         >
           <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <Home className="text-primary h-5 w-5" />
+              <Home className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">Household Tasks</h3>
                 <p className="text-muted-foreground text-sm">Today&apos;s roster</p>
@@ -334,7 +334,7 @@ export default function IrmaDashboard() {
                   >
                     <Icon className={`h-5 w-5 ${iconColor}`} />
                     <div className="bg-primary/20 flex h-8 w-8 items-center justify-center rounded-lg">
-                      <Sparkles className="text-primary h-4 w-4" />
+                      <Sparkles className="text-primary-text h-4 w-4" />
                     </div>
                     <div className="flex-1">
                       <p
@@ -354,14 +354,14 @@ export default function IrmaDashboard() {
                             : ""}
                       </p>
                     </div>
-                    <ChevronRight className="text-primary/40 group-hover:text-primary/60 h-4 w-4" />
+                    <ChevronRight className="text-primary-text/40 group-hover:text-primary-text/60 h-4 w-4" />
                   </div>
                 )
               })
             )}
           </div>
           <div className="border-primary/20 border-t p-4">
-            <button className="text-primary w-full text-center text-sm font-medium hover:text-purple-300">
+            <button className="text-primary-text w-full text-center text-sm font-medium hover:text-purple-300">
               View weekly schedule
             </button>
           </div>
@@ -374,13 +374,13 @@ export default function IrmaDashboard() {
         >
           <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <UtensilsCrossed className="text-primary h-5 w-5" />
+              <UtensilsCrossed className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">Meal Planning</h3>
                 <p className="text-muted-foreground text-sm">Upcoming meals</p>
               </div>
             </div>
-            <button className="border-primary/30 bg-primary/20 text-primary hover:bg-primary/30 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors">
+            <button className="border-primary/30 bg-primary/20 text-primary-text hover:bg-primary/30 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors">
               + Add Meal
             </button>
           </div>
@@ -399,7 +399,7 @@ export default function IrmaDashboard() {
         >
           <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <FileText className="text-primary h-5 w-5" />
+              <FileText className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">My Documents</h3>
                 <p className="text-muted-foreground text-sm">Signed agreements</p>
@@ -438,7 +438,7 @@ export default function IrmaDashboard() {
                           : (doc.status ?? "Pending")}
                       </p>
                     </div>
-                    <button className="text-primary text-sm hover:text-purple-300">View</button>
+                    <button className="text-primary-text text-sm hover:text-purple-300">View</button>
                   </div>
                 )
               })
@@ -453,7 +453,7 @@ export default function IrmaDashboard() {
         >
           <div className="border-primary/20 border-b p-6">
             <div className="flex items-center gap-3">
-              <Calendar className="text-primary h-5 w-5" />
+              <Calendar className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">This Week&apos;s Schedule</h3>
                 <p className="text-muted-foreground text-sm">Household task roster</p>

--- a/app/dashboard/irma/page.tsx
+++ b/app/dashboard/irma/page.tsx
@@ -31,26 +31,26 @@ function HomePattern() {
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* Heart patterns */}
-      <svg className="absolute top-10 right-10 h-64 w-64 text-purple-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
         <path
           d="M50 88 C20 60 5 40 5 25 C5 10 20 5 35 15 C42 20 47 28 50 35 C53 28 58 20 65 15 C80 5 95 10 95 25 C95 40 80 60 50 88 Z"
           fill="currentColor"
         />
       </svg>
       {/* House */}
-      <svg className="absolute bottom-20 left-10 h-48 w-48 text-purple-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
         <polygon points="50,10 90,45 90,90 10,90 10,45" fill="currentColor" />
         <rect x="40" y="60" width="20" height="30" fill="rgba(10,10,15,0.5)" />
         <rect x="60" y="50" width="15" height="15" fill="rgba(10,10,15,0.3)" />
         <rect x="25" y="50" width="15" height="15" fill="rgba(10,10,15,0.3)" />
       </svg>
       {/* Sparkle/Star */}
-      <svg className="absolute top-1/3 left-1/4 h-32 w-32 text-purple-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute top-1/3 left-1/4 h-32 w-32" viewBox="0 0 100 100">
         <path d="M50 5 L55 40 L90 50 L55 60 L50 95 L45 60 L10 50 L45 40 Z" fill="currentColor" />
       </svg>
       {/* Baby/Child icon */}
       <svg
-        className="absolute right-1/4 bottom-1/4 h-40 w-40 text-pink-500/5"
+        className="text-secondary/5 absolute right-1/4 bottom-1/4 h-40 w-40"
         viewBox="0 0 100 100"
       >
         <circle cx="50" cy="35" r="25" fill="currentColor" />
@@ -71,10 +71,10 @@ function HomePattern() {
 
 function EmptyPanel({ title, action }: { title: string; action?: string }) {
   return (
-    <div className="flex h-full min-h-40 items-center justify-center rounded-xl border border-purple-500/10 bg-purple-950/30 p-6 text-center">
+    <div className="border-primary/10 bg-primary/10 flex h-full min-h-40 items-center justify-center rounded-xl border p-6 text-center">
       <div>
-        <p className="font-medium text-purple-100">{title}</p>
-        {action && <p className="mt-2 text-sm text-purple-200/50">{action}</p>}
+        <p className="text-foreground font-medium">{title}</p>
+        {action && <p className="text-muted-foreground mt-2 text-sm">{action}</p>}
       </div>
     </div>
   )
@@ -157,21 +157,21 @@ export default function IrmaDashboard() {
   return (
     <DashboardLayout persona="irma">
       {/* Persona-specific background */}
-      <div className="fixed inset-0 -z-10 bg-linear-to-br from-purple-950/40 via-[#0a0a0f] to-pink-950/30" />
+      <div className="from-primary/10 to-secondary/10 fixed inset-0 -z-10 bg-linear-to-br via-[#0a0a0f]" />
       <HomePattern />
 
       {/* Welcome Banner */}
       <div
-        className="relative mb-8 overflow-hidden rounded-2xl border border-purple-500/30 bg-linear-to-r from-purple-600/30 to-pink-700/20 p-6 backdrop-blur-sm"
+        className="border-primary/30 from-primary/30 to-secondary/20 relative mb-8 overflow-hidden rounded-2xl border bg-linear-to-r p-6 backdrop-blur-sm"
         data-testid="welcome-banner"
       >
         <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjAgMzIgQzEwIDI0IDUgMTggNSAxMiBDNSA2IDEwIDQgMTUgOCBDMTggMTAgMTkgMTMgMjAgMTUgQzIxIDEzIDIyIDEwIDI1IDggQzMwIDQgMzUgNiAzNSAxMiBDMzUgMTggMzAgMjQgMjAgMzIgWiIgZmlsbD0icmdiYSgxNjgsMTMzLDI0NywwLjA1KSIvPjwvc3ZnPg==')] opacity-50" />
         <div className="relative flex items-center gap-4">
-          <div className="flex h-16 w-16 items-center justify-center rounded-xl border border-purple-500/30 bg-linear-to-br from-purple-500/30 to-pink-500/30 text-3xl">
+          <div className="border-primary/30 from-primary/30 to-secondary/30 flex h-16 w-16 items-center justify-center rounded-xl border bg-linear-to-br text-3xl">
             🏠
           </div>
           <div>
-            <h2 className="text-2xl font-bold text-purple-100">{getGreeting()}, Irma</h2>
+            <h2 className="text-foreground text-2xl font-bold">{getGreeting()}, Irma</h2>
             <p className="text-purple-200/60">Here&apos;s your household overview for today</p>
           </div>
         </div>
@@ -179,13 +179,13 @@ export default function IrmaDashboard() {
 
       {/* Specialty Tags */}
       <div className="mb-6 flex flex-wrap gap-2">
-        <span className="flex items-center gap-2 rounded-full border border-purple-500/30 bg-purple-500/20 px-3 py-1.5 text-sm font-medium text-purple-400">
+        <span className="border-primary/30 bg-primary/20 text-primary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
           <Sparkles className="h-4 w-4" /> Cleaning
         </span>
         <span className="flex items-center gap-2 rounded-full border border-amber-500/30 bg-amber-500/20 px-3 py-1.5 text-sm font-medium text-amber-400">
           <CookingPot className="h-4 w-4" /> Cooking
         </span>
-        <span className="flex items-center gap-2 rounded-full border border-pink-500/30 bg-pink-500/20 px-3 py-1.5 text-sm font-medium text-pink-400">
+        <span className="border-secondary/30 bg-secondary/20 text-secondary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
           <Baby className="h-4 w-4" /> Babysitting
         </span>
       </div>
@@ -200,25 +200,25 @@ export default function IrmaDashboard() {
       {/* Quick Stats */}
       <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
         <div
-          className="rounded-xl border border-purple-500/20 bg-purple-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-tasks-today"
         >
           <div className="mb-2 flex items-center gap-3">
-            <ClipboardList className="h-5 w-5 text-purple-400" />
+            <ClipboardList className="text-primary h-5 w-5" />
             <p className="text-sm text-purple-200/60">Today&apos;s Tasks</p>
           </div>
-          <p className="text-2xl font-bold text-purple-100">{loading ? "—" : tasksToday.length}</p>
-          <p className="text-sm text-purple-400">{loading ? "…" : `${completedToday} completed`}</p>
+          <p className="text-foreground text-2xl font-bold">{loading ? "—" : tasksToday.length}</p>
+          <p className="text-primary text-sm">{loading ? "…" : `${completedToday} completed`}</p>
         </div>
         <div
-          className="rounded-xl border border-purple-500/20 bg-purple-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-documents"
         >
           <div className="mb-2 flex items-center gap-3">
-            <FileText className="h-5 w-5 text-purple-400" />
+            <FileText className="text-primary h-5 w-5" />
             <p className="text-sm text-purple-200/60">Documents</p>
           </div>
-          <p className="text-2xl font-bold text-purple-100">{loading ? "—" : documents.length}</p>
+          <p className="text-foreground text-2xl font-bold">{loading ? "—" : documents.length}</p>
           <p className="text-sm text-green-400">
             {loading
               ? "…"
@@ -228,26 +228,26 @@ export default function IrmaDashboard() {
           </p>
         </div>
         <div
-          className="rounded-xl border border-purple-500/20 bg-purple-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-weekly"
         >
           <div className="mb-2 flex items-center gap-3">
-            <Calendar className="h-5 w-5 text-purple-400" />
+            <Calendar className="text-primary h-5 w-5" />
             <p className="text-sm text-purple-200/60">This Week</p>
           </div>
-          <p className="text-2xl font-bold text-purple-100">{loading ? "—" : completedThisWeek}</p>
-          <p className="text-sm text-purple-200/50">tasks completed</p>
+          <p className="text-foreground text-2xl font-bold">{loading ? "—" : completedThisWeek}</p>
+          <p className="text-muted-foreground text-sm">tasks completed</p>
         </div>
         <div
-          className="rounded-xl border border-purple-500/20 bg-purple-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-meals"
         >
           <div className="mb-2 flex items-center gap-3">
-            <UtensilsCrossed className="h-5 w-5 text-purple-400" />
+            <UtensilsCrossed className="text-primary h-5 w-5" />
             <p className="text-sm text-purple-200/60">Meals Planned</p>
           </div>
-          <p className="text-2xl font-bold text-purple-100">0</p>
-          <p className="text-sm text-purple-200/50">No meal records</p>
+          <p className="text-foreground text-2xl font-bold">0</p>
+          <p className="text-muted-foreground text-sm">No meal records</p>
         </div>
       </div>
 
@@ -255,17 +255,17 @@ export default function IrmaDashboard() {
       <div className="mb-8 grid gap-6 lg:grid-cols-3">
         {/* Weekly Completion */}
         <div
-          className="rounded-2xl border border-purple-500/20 bg-purple-950/40 p-6 backdrop-blur-sm lg:col-span-2"
+          className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm lg:col-span-2"
           data-testid="weekly-completion-chart"
         >
           <div className="mb-6 flex items-center justify-between">
             <div>
-              <h3 className="font-semibold text-purple-100">Weekly Task Completion</h3>
-              <p className="text-sm text-purple-200/50">Tasks completed vs total</p>
+              <h3 className="text-foreground font-semibold">Weekly Task Completion</h3>
+              <p className="text-muted-foreground text-sm">Tasks completed vs total</p>
             </div>
             <div className="text-right">
-              <p className="text-2xl font-bold text-purple-100">—</p>
-              <p className="text-sm text-purple-200/50">No history</p>
+              <p className="text-foreground text-2xl font-bold">—</p>
+              <p className="text-muted-foreground text-sm">No history</p>
             </div>
           </div>
           <div className="h-64">
@@ -278,11 +278,11 @@ export default function IrmaDashboard() {
 
         {/* Task Distribution */}
         <div
-          className="rounded-2xl border border-purple-500/20 bg-purple-950/40 p-6 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm"
           data-testid="task-distribution-chart"
         >
-          <h3 className="mb-2 font-semibold text-purple-100">Task Distribution</h3>
-          <p className="mb-4 text-sm text-purple-200/50">By category this month</p>
+          <h3 className="text-foreground mb-2 font-semibold">Task Distribution</h3>
+          <p className="text-muted-foreground mb-4 text-sm">By category this month</p>
           <div className="h-48">
             <EmptyPanel
               title="No task distribution"
@@ -296,23 +296,23 @@ export default function IrmaDashboard() {
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Household Tasks */}
         <div
-          className="overflow-hidden rounded-2xl border border-purple-500/20 bg-purple-950/40 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
           data-testid="household-tasks"
         >
-          <div className="flex items-center justify-between border-b border-purple-500/20 p-6">
+          <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <Home className="h-5 w-5 text-purple-400" />
+              <Home className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-purple-100">Household Tasks</h3>
-                <p className="text-sm text-purple-200/50">Today&apos;s roster</p>
+                <h3 className="text-foreground font-semibold">Household Tasks</h3>
+                <p className="text-muted-foreground text-sm">Today&apos;s roster</p>
               </div>
             </div>
           </div>
           <div className="space-y-3 p-4">
             {loading ? (
-              <div className="p-4 text-sm text-purple-200/50">Loading tasks…</div>
+              <div className="text-muted-foreground p-4 text-sm">Loading tasks…</div>
             ) : pendingTasks.length === 0 ? (
-              <div className="p-4 text-sm text-purple-200/50">No tasks assigned</div>
+              <div className="text-muted-foreground p-4 text-sm">No tasks assigned</div>
             ) : (
               pendingTasks.map((task) => {
                 const done = isCompleted(task)
@@ -329,17 +329,19 @@ export default function IrmaDashboard() {
                 return (
                   <div
                     key={task.id}
-                    className="group flex cursor-pointer items-center gap-4 rounded-xl border border-purple-500/10 bg-purple-950/50 p-4 transition-colors hover:bg-purple-950/70"
+                    className="group border-primary/10 bg-primary/15 hover:bg-primary/20 flex cursor-pointer items-center gap-4 rounded-xl border p-4 transition-colors"
                     data-testid={`task-${task.id}`}
                   >
                     <Icon className={`h-5 w-5 ${iconColor}`} />
-                    <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-purple-500/20">
-                      <Sparkles className="h-4 w-4 text-purple-400" />
+                    <div className="bg-primary/20 flex h-8 w-8 items-center justify-center rounded-lg">
+                      <Sparkles className="text-primary h-4 w-4" />
                     </div>
                     <div className="flex-1">
                       <p
                         className={
-                          done ? "text-purple-200/50 line-through" : "font-medium text-purple-100"
+                          done
+                            ? "text-muted-foreground line-through"
+                            : "text-foreground font-medium"
                         }
                       >
                         {task.title}
@@ -352,14 +354,14 @@ export default function IrmaDashboard() {
                             : ""}
                       </p>
                     </div>
-                    <ChevronRight className="h-4 w-4 text-purple-400/40 group-hover:text-purple-400/60" />
+                    <ChevronRight className="text-primary/40 group-hover:text-primary/60 h-4 w-4" />
                   </div>
                 )
               })
             )}
           </div>
-          <div className="border-t border-purple-500/20 p-4">
-            <button className="w-full text-center text-sm font-medium text-purple-400 hover:text-purple-300">
+          <div className="border-primary/20 border-t p-4">
+            <button className="text-primary w-full text-center text-sm font-medium hover:text-purple-300">
               View weekly schedule
             </button>
           </div>
@@ -367,18 +369,18 @@ export default function IrmaDashboard() {
 
         {/* Meal Planning */}
         <div
-          className="overflow-hidden rounded-2xl border border-purple-500/20 bg-purple-950/40 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
           data-testid="meal-planning"
         >
-          <div className="flex items-center justify-between border-b border-purple-500/20 p-6">
+          <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <UtensilsCrossed className="h-5 w-5 text-purple-400" />
+              <UtensilsCrossed className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-purple-100">Meal Planning</h3>
-                <p className="text-sm text-purple-200/50">Upcoming meals</p>
+                <h3 className="text-foreground font-semibold">Meal Planning</h3>
+                <p className="text-muted-foreground text-sm">Upcoming meals</p>
               </div>
             </div>
-            <button className="rounded-lg border border-purple-500/30 bg-purple-500/20 px-3 py-1.5 text-sm font-medium text-purple-400 transition-colors hover:bg-purple-500/30">
+            <button className="border-primary/30 bg-primary/20 text-primary hover:bg-primary/30 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors">
               + Add Meal
             </button>
           </div>
@@ -392,23 +394,23 @@ export default function IrmaDashboard() {
 
         {/* My Documents */}
         <div
-          className="overflow-hidden rounded-2xl border border-purple-500/20 bg-purple-950/40 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
           data-testid="my-documents"
         >
-          <div className="flex items-center justify-between border-b border-purple-500/20 p-6">
+          <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <FileText className="h-5 w-5 text-purple-400" />
+              <FileText className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-purple-100">My Documents</h3>
-                <p className="text-sm text-purple-200/50">Signed agreements</p>
+                <h3 className="text-foreground font-semibold">My Documents</h3>
+                <p className="text-muted-foreground text-sm">Signed agreements</p>
               </div>
             </div>
           </div>
           <div className="space-y-3 p-4">
             {loading ? (
-              <div className="p-4 text-sm text-purple-200/50">Loading documents…</div>
+              <div className="text-muted-foreground p-4 text-sm">Loading documents…</div>
             ) : documents.length === 0 ? (
-              <div className="p-4 text-sm text-purple-200/50">No documents</div>
+              <div className="text-muted-foreground p-4 text-sm">No documents</div>
             ) : (
               documents.slice(0, 5).map((doc) => {
                 const name = doc.name ?? doc.title ?? "Document"
@@ -419,7 +421,7 @@ export default function IrmaDashboard() {
                 return (
                   <div
                     key={doc.id}
-                    className="group flex cursor-pointer items-center gap-4 rounded-xl border border-purple-500/10 bg-purple-950/50 p-4 transition-colors hover:bg-purple-950/70"
+                    className="group border-primary/10 bg-primary/15 hover:bg-primary/20 flex cursor-pointer items-center gap-4 rounded-xl border p-4 transition-colors"
                   >
                     <div
                       className={`flex h-10 w-10 items-center justify-center rounded-lg ${isSigned ? "bg-green-500/20" : "bg-amber-500/20"}`}
@@ -429,14 +431,14 @@ export default function IrmaDashboard() {
                       />
                     </div>
                     <div className="flex-1">
-                      <p className="font-medium text-purple-100">{name}</p>
-                      <p className="text-sm text-purple-200/50">
+                      <p className="text-foreground font-medium">{name}</p>
+                      <p className="text-muted-foreground text-sm">
                         {isSigned && (doc.signedAt || doc.lastReview)
                           ? `Signed ${new Date(doc.signedAt ?? doc.lastReview!).toLocaleDateString()}`
                           : (doc.status ?? "Pending")}
                       </p>
                     </div>
-                    <button className="text-sm text-purple-400 hover:text-purple-300">View</button>
+                    <button className="text-primary text-sm hover:text-purple-300">View</button>
                   </div>
                 )
               })
@@ -446,15 +448,15 @@ export default function IrmaDashboard() {
 
         {/* Weekly Schedule Preview */}
         <div
-          className="overflow-hidden rounded-2xl border border-purple-500/20 bg-purple-950/40 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
           data-testid="weekly-schedule"
         >
-          <div className="border-b border-purple-500/20 p-6">
+          <div className="border-primary/20 border-b p-6">
             <div className="flex items-center gap-3">
-              <Calendar className="h-5 w-5 text-purple-400" />
+              <Calendar className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-purple-100">This Week&apos;s Schedule</h3>
-                <p className="text-sm text-purple-200/50">Household task roster</p>
+                <h3 className="text-foreground font-semibold">This Week&apos;s Schedule</h3>
+                <p className="text-muted-foreground text-sm">Household task roster</p>
               </div>
             </div>
           </div>

--- a/app/dashboard/lucky/page.tsx
+++ b/app/dashboard/lucky/page.tsx
@@ -65,21 +65,21 @@ function GardenPattern() {
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* Leaf patterns */}
-      <svg className="text-primary/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
         <path
           d="M50 10 Q80 30 70 60 Q60 80 50 90 Q40 80 30 60 Q20 30 50 10 Z"
           fill="currentColor"
         />
         <path d="M50 20 L50 85" stroke="currentColor" strokeWidth="2" fill="none" />
       </svg>
-      <svg className="text-primary/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
         <ellipse cx="50" cy="40" rx="30" ry="35" fill="currentColor" />
         <path d="M50 75 L50 95" stroke="currentColor" strokeWidth="3" />
         <path d="M50 40 Q30 50 20 70" stroke="currentColor" strokeWidth="1" fill="none" />
         <path d="M50 40 Q70 50 80 70" stroke="currentColor" strokeWidth="1" fill="none" />
       </svg>
       {/* Flower */}
-      <svg className="text-primary/5 absolute top-1/3 left-1/4 h-32 w-32" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute top-1/3 left-1/4 h-32 w-32" viewBox="0 0 100 100">
         {[0, 72, 144, 216, 288].map((angle, i) => (
           <ellipse
             key={i}
@@ -94,7 +94,7 @@ function GardenPattern() {
         <circle cx="50" cy="50" r="12" fill="currentColor" />
       </svg>
       {/* Tree */}
-      <svg className="text-primary/5 absolute right-1/4 bottom-1/4 h-40 w-40" viewBox="0 0 100 100">
+      <svg className="text-primary-text/5 absolute right-1/4 bottom-1/4 h-40 w-40" viewBox="0 0 100 100">
         <polygon points="50,10 80,50 65,50 85,80 15,80 35,50 20,50" fill="currentColor" />
         <rect x="45" y="80" width="10" height="15" fill="currentColor" />
       </svg>
@@ -178,7 +178,7 @@ export default function LuckyDashboard() {
         <div className="relative flex flex-col items-center justify-between gap-4 md:flex-row">
           <div className="flex items-center gap-4">
             <div className="border-primary/30 from-primary/30 to-secondary/30 flex h-16 w-16 items-center justify-center rounded-xl border bg-linear-to-br">
-              <Clock className="text-primary h-8 w-8" />
+              <Clock className="text-primary-text h-8 w-8" />
             </div>
             <div>
               <p className="text-sm text-green-200/60">Today&apos;s Work Time</p>
@@ -200,7 +200,7 @@ export default function LuckyDashboard() {
               className={`flex items-center gap-2 rounded-xl border px-6 py-3 font-medium transition-colors ${
                 isClockRunning
                   ? "border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30"
-                  : "border-primary/30 bg-primary/20 text-primary hover:bg-primary/30"
+                  : "border-primary/30 bg-primary/20 text-primary-text hover:bg-primary/30"
               } `}
             >
               {isClockRunning ? (
@@ -222,7 +222,7 @@ export default function LuckyDashboard() {
       {/* Specialty Tags & Weather */}
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <div className="flex flex-wrap gap-2">
-          <span className="border-primary/30 bg-primary/20 text-primary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
+          <span className="border-primary/30 bg-primary/20 text-primary-text flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
             <Leaf className="h-4 w-4" /> Gardening
           </span>
           <span className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/20 px-3 py-1.5 text-sm font-medium text-blue-400">
@@ -255,7 +255,7 @@ export default function LuckyDashboard() {
         >
           <p className="text-sm text-green-200/60">Active Tasks</p>
           <p className="text-foreground text-2xl font-bold">{tasks.total}</p>
-          <p className="text-primary text-sm">{tasks.completed} completed</p>
+          <p className="text-primary-text text-sm">{tasks.completed} completed</p>
         </div>
         <div
           className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
@@ -335,7 +335,7 @@ export default function LuckyDashboard() {
         >
           <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <ClipboardList className="text-primary h-5 w-5" />
+              <ClipboardList className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">My Tasks</h3>
                 <p className="text-muted-foreground text-sm">Today&apos;s garden work</p>
@@ -357,14 +357,14 @@ export default function LuckyDashboard() {
         >
           <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <DollarSign className="text-primary h-5 w-5" />
+              <DollarSign className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">My Expenses</h3>
                 <p className="text-muted-foreground text-sm">Recent submissions</p>
               </div>
             </div>
             <button
-              className="border-primary/30 bg-primary/20 text-primary hover:bg-primary/30 flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition-colors"
+              className="border-primary/30 bg-primary/20 text-primary-text hover:bg-primary/30 flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition-colors"
               data-testid="new-expense-btn"
             >
               <Plus className="h-4 w-4" />
@@ -424,13 +424,13 @@ export default function LuckyDashboard() {
         >
           <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <Car className="text-primary h-5 w-5" />
+              <Car className="text-primary-text h-5 w-5" />
               <div>
                 <h3 className="text-foreground font-semibold">Vehicles</h3>
                 <p className="text-muted-foreground text-sm">Coming soon</p>
               </div>
             </div>
-            <span className="border-primary/30 bg-primary/20 text-primary rounded-full border px-3 py-1 text-sm font-medium">
+            <span className="border-primary/30 bg-primary/20 text-primary-text rounded-full border px-3 py-1 text-sm font-medium">
               Coming soon
             </span>
           </div>

--- a/app/dashboard/lucky/page.tsx
+++ b/app/dashboard/lucky/page.tsx
@@ -65,21 +65,21 @@ function GardenPattern() {
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* Leaf patterns */}
-      <svg className="absolute top-10 right-10 h-64 w-64 text-green-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute top-10 right-10 h-64 w-64" viewBox="0 0 100 100">
         <path
           d="M50 10 Q80 30 70 60 Q60 80 50 90 Q40 80 30 60 Q20 30 50 10 Z"
           fill="currentColor"
         />
         <path d="M50 20 L50 85" stroke="currentColor" strokeWidth="2" fill="none" />
       </svg>
-      <svg className="absolute bottom-20 left-10 h-48 w-48 text-green-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute bottom-20 left-10 h-48 w-48" viewBox="0 0 100 100">
         <ellipse cx="50" cy="40" rx="30" ry="35" fill="currentColor" />
         <path d="M50 75 L50 95" stroke="currentColor" strokeWidth="3" />
         <path d="M50 40 Q30 50 20 70" stroke="currentColor" strokeWidth="1" fill="none" />
         <path d="M50 40 Q70 50 80 70" stroke="currentColor" strokeWidth="1" fill="none" />
       </svg>
       {/* Flower */}
-      <svg className="absolute top-1/3 left-1/4 h-32 w-32 text-green-500/5" viewBox="0 0 100 100">
+      <svg className="text-primary/5 absolute top-1/3 left-1/4 h-32 w-32" viewBox="0 0 100 100">
         {[0, 72, 144, 216, 288].map((angle, i) => (
           <ellipse
             key={i}
@@ -94,10 +94,7 @@ function GardenPattern() {
         <circle cx="50" cy="50" r="12" fill="currentColor" />
       </svg>
       {/* Tree */}
-      <svg
-        className="absolute right-1/4 bottom-1/4 h-40 w-40 text-green-500/5"
-        viewBox="0 0 100 100"
-      >
+      <svg className="text-primary/5 absolute right-1/4 bottom-1/4 h-40 w-40" viewBox="0 0 100 100">
         <polygon points="50,10 80,50 65,50 85,80 15,80 35,50 20,50" fill="currentColor" />
         <rect x="45" y="80" width="10" height="15" fill="currentColor" />
       </svg>
@@ -117,10 +114,10 @@ function GardenPattern() {
 
 function EmptyPanel({ title, action }: { title: string; action?: string }) {
   return (
-    <div className="flex h-full min-h-40 items-center justify-center rounded-xl border border-green-500/10 bg-green-950/30 p-6 text-center">
+    <div className="border-primary/10 bg-primary/10 flex h-full min-h-40 items-center justify-center rounded-xl border p-6 text-center">
       <div>
-        <p className="font-medium text-green-100">{title}</p>
-        {action && <p className="mt-2 text-sm text-green-200/50">{action}</p>}
+        <p className="text-foreground font-medium">{title}</p>
+        {action && <p className="text-muted-foreground mt-2 text-sm">{action}</p>}
       </div>
     </div>
   )
@@ -169,23 +166,23 @@ export default function LuckyDashboard() {
   return (
     <DashboardLayout persona="lucky">
       {/* Persona-specific background */}
-      <div className="fixed inset-0 -z-10 bg-linear-to-br from-green-950/40 via-[#0a0a0f] to-emerald-950/30" />
+      <div className="from-primary/10 to-secondary/10 fixed inset-0 -z-10 bg-linear-to-br via-[#0a0a0f]" />
       <GardenPattern />
 
       {/* Time Clock Banner */}
       <div
-        className="relative mb-8 overflow-hidden rounded-2xl border border-green-500/30 bg-linear-to-r from-green-600/30 to-emerald-700/20 p-6 backdrop-blur-sm"
+        className="border-primary/30 from-primary/30 to-secondary/20 relative mb-8 overflow-hidden rounded-2xl border bg-linear-to-r p-6 backdrop-blur-sm"
         data-testid="time-clock-banner"
       >
         <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjAgNSBRMzAgMTUgMjUgMjUgUTIwIDM1IDIwIDM1IFEyMCAzNSAxNSAyNSBRMTAgMTUgMjAgNSBaIiBmaWxsPSJyZ2JhKDE2LDE4NSwxMjksMC4wNSkiLz48L3N2Zz4=')] opacity-50" />
         <div className="relative flex flex-col items-center justify-between gap-4 md:flex-row">
           <div className="flex items-center gap-4">
-            <div className="flex h-16 w-16 items-center justify-center rounded-xl border border-green-500/30 bg-linear-to-br from-green-500/30 to-emerald-600/30">
-              <Clock className="h-8 w-8 text-green-400" />
+            <div className="border-primary/30 from-primary/30 to-secondary/30 flex h-16 w-16 items-center justify-center rounded-xl border bg-linear-to-br">
+              <Clock className="text-primary h-8 w-8" />
             </div>
             <div>
               <p className="text-sm text-green-200/60">Today&apos;s Work Time</p>
-              <p className="font-mono text-4xl font-bold text-green-100" data-testid="clock-time">
+              <p className="text-foreground font-mono text-4xl font-bold" data-testid="clock-time">
                 {clockTime}
               </p>
             </div>
@@ -193,7 +190,7 @@ export default function LuckyDashboard() {
           <div className="flex items-center gap-3">
             <div className="mr-4 hidden text-right md:block">
               <p className="text-sm text-green-200/60">Clocked in at</p>
-              <p className="font-medium text-green-100">
+              <p className="text-foreground font-medium">
                 {isClockRunning ? "Manual session" : "Not clocked in"}
               </p>
             </div>
@@ -203,7 +200,7 @@ export default function LuckyDashboard() {
               className={`flex items-center gap-2 rounded-xl border px-6 py-3 font-medium transition-colors ${
                 isClockRunning
                   ? "border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30"
-                  : "border-green-500/30 bg-green-500/20 text-green-400 hover:bg-green-500/30"
+                  : "border-primary/30 bg-primary/20 text-primary hover:bg-primary/30"
               } `}
             >
               {isClockRunning ? (
@@ -225,7 +222,7 @@ export default function LuckyDashboard() {
       {/* Specialty Tags & Weather */}
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <div className="flex flex-wrap gap-2">
-          <span className="flex items-center gap-2 rounded-full border border-green-500/30 bg-green-500/20 px-3 py-1.5 text-sm font-medium text-green-400">
+          <span className="border-primary/30 bg-primary/20 text-primary flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
             <Leaf className="h-4 w-4" /> Gardening
           </span>
           <span className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/20 px-3 py-1.5 text-sm font-medium text-blue-400">
@@ -235,10 +232,10 @@ export default function LuckyDashboard() {
             <Hammer className="h-4 w-4" /> Manual Labour
           </span>
         </div>
-        <div className="flex items-center gap-3 rounded-xl border border-green-500/20 bg-green-950/50 px-4 py-2">
+        <div className="border-primary/20 bg-primary/15 flex items-center gap-3 rounded-xl border px-4 py-2">
           <div>
-            <p className="font-medium text-green-100">{stats?.dataSource ?? "empty"}</p>
-            <p className="text-xs text-green-200/50">Data mode</p>
+            <p className="text-foreground font-medium">{stats?.dataSource ?? "empty"}</p>
+            <p className="text-muted-foreground text-xs">Data mode</p>
           </div>
         </div>
       </div>
@@ -253,38 +250,38 @@ export default function LuckyDashboard() {
       {/* Stats Row */}
       <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
         <div
-          className="rounded-xl border border-green-500/20 bg-green-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-tasks"
         >
           <p className="text-sm text-green-200/60">Active Tasks</p>
-          <p className="text-2xl font-bold text-green-100">{tasks.total}</p>
-          <p className="text-sm text-green-400">{tasks.completed} completed</p>
+          <p className="text-foreground text-2xl font-bold">{tasks.total}</p>
+          <p className="text-primary text-sm">{tasks.completed} completed</p>
         </div>
         <div
-          className="rounded-xl border border-green-500/20 bg-green-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-hours"
         >
           <p className="text-sm text-green-200/60">Hours This Week</p>
-          <p className="text-2xl font-bold text-green-100">0</p>
-          <p className="text-sm text-green-200/50">No time records</p>
+          <p className="text-foreground text-2xl font-bold">0</p>
+          <p className="text-muted-foreground text-sm">No time records</p>
         </div>
         <div
-          className="rounded-xl border border-green-500/20 bg-green-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-expenses"
         >
           <p className="text-sm text-green-200/60">Monthly Expenses</p>
-          <p className="text-2xl font-bold text-green-100">
+          <p className="text-foreground text-2xl font-bold">
             R{expenses.thisMonth.toLocaleString()}
           </p>
           <p className="text-sm text-amber-400">{expenses.pending} pending approval</p>
         </div>
         <div
-          className="rounded-xl border border-green-500/20 bg-green-950/40 p-4 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-xl border p-4 backdrop-blur-sm"
           data-testid="stat-leave"
         >
           <p className="text-sm text-green-200/60">Leave Balance</p>
-          <p className="text-2xl font-bold text-green-100">—</p>
-          <p className="text-sm text-green-200/50">No leave sync</p>
+          <p className="text-foreground text-2xl font-bold">—</p>
+          <p className="text-muted-foreground text-sm">No leave sync</p>
         </div>
       </div>
 
@@ -292,17 +289,17 @@ export default function LuckyDashboard() {
       <div className="mb-8 grid gap-6 lg:grid-cols-3">
         {/* Weekly Hours */}
         <div
-          className="rounded-2xl border border-green-500/20 bg-green-950/40 p-6 backdrop-blur-sm lg:col-span-2"
+          className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm lg:col-span-2"
           data-testid="weekly-hours-chart"
         >
           <div className="mb-6 flex items-center justify-between">
             <div>
-              <h3 className="font-semibold text-green-100">Weekly Hours</h3>
-              <p className="text-sm text-green-200/50">Hours worked per day</p>
+              <h3 className="text-foreground font-semibold">Weekly Hours</h3>
+              <p className="text-muted-foreground text-sm">Hours worked per day</p>
             </div>
             <div className="text-right">
-              <p className="text-2xl font-bold text-green-100">0h</p>
-              <p className="text-sm text-green-200/50">No records</p>
+              <p className="text-foreground text-2xl font-bold">0h</p>
+              <p className="text-muted-foreground text-sm">No records</p>
             </div>
           </div>
           <div className="h-64">
@@ -315,11 +312,11 @@ export default function LuckyDashboard() {
 
         {/* Task Type Distribution */}
         <div
-          className="rounded-2xl border border-green-500/20 bg-green-950/40 p-6 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm"
           data-testid="task-type-chart"
         >
-          <h3 className="mb-2 font-semibold text-green-100">Task Types</h3>
-          <p className="mb-4 text-sm text-green-200/50">This month&apos;s work</p>
+          <h3 className="text-foreground mb-2 font-semibold">Task Types</h3>
+          <p className="text-muted-foreground mb-4 text-sm">This month&apos;s work</p>
           <div className="h-48">
             <EmptyPanel
               title="No task-type data"
@@ -333,15 +330,15 @@ export default function LuckyDashboard() {
       <div className="grid gap-6 lg:grid-cols-2">
         {/* My Tasks */}
         <div
-          className="overflow-hidden rounded-2xl border border-green-500/20 bg-green-950/40 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
           data-testid="my-tasks"
         >
-          <div className="flex items-center justify-between border-b border-green-500/20 p-6">
+          <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <ClipboardList className="h-5 w-5 text-green-400" />
+              <ClipboardList className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-green-100">My Tasks</h3>
-                <p className="text-sm text-green-200/50">Today&apos;s garden work</p>
+                <h3 className="text-foreground font-semibold">My Tasks</h3>
+                <p className="text-muted-foreground text-sm">Today&apos;s garden work</p>
               </div>
             </div>
           </div>
@@ -355,19 +352,19 @@ export default function LuckyDashboard() {
 
         {/* Expenses */}
         <div
-          className="overflow-hidden rounded-2xl border border-green-500/20 bg-green-950/40 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
           data-testid="my-expenses"
         >
-          <div className="flex items-center justify-between border-b border-green-500/20 p-6">
+          <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <DollarSign className="h-5 w-5 text-green-400" />
+              <DollarSign className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-green-100">My Expenses</h3>
-                <p className="text-sm text-green-200/50">Recent submissions</p>
+                <h3 className="text-foreground font-semibold">My Expenses</h3>
+                <p className="text-muted-foreground text-sm">Recent submissions</p>
               </div>
             </div>
             <button
-              className="flex items-center gap-2 rounded-xl border border-green-500/30 bg-green-500/20 px-4 py-2 text-sm font-medium text-green-400 transition-colors hover:bg-green-500/30"
+              className="border-primary/30 bg-primary/20 text-primary hover:bg-primary/30 flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition-colors"
               data-testid="new-expense-btn"
             >
               <Plus className="h-4 w-4" />
@@ -380,9 +377,9 @@ export default function LuckyDashboard() {
               action="Expense submissions will appear here after live records exist."
             />
           </div>
-          <div className="border-t border-green-500/20 p-4">
+          <div className="border-primary/20 border-t p-4">
             <button
-              className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-green-500/30 p-3 text-green-200/60 transition-colors hover:border-green-500/50 hover:text-green-100"
+              className="border-primary/30 hover:border-primary/50 hover:text-foreground flex w-full items-center justify-center gap-2 rounded-xl border border-dashed p-3 text-green-200/60 transition-colors"
               data-testid="upload-receipt-btn"
             >
               <Upload className="h-4 w-4" />
@@ -393,17 +390,17 @@ export default function LuckyDashboard() {
 
         {/* Expenses Trend Chart */}
         <div
-          className="rounded-2xl border border-green-500/20 bg-green-950/40 p-6 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 rounded-2xl border p-6 backdrop-blur-sm"
           data-testid="expenses-trend-chart"
         >
           <div className="mb-6 flex items-center justify-between">
             <div>
-              <h3 className="font-semibold text-green-100">Expenses This Month</h3>
-              <p className="text-sm text-green-200/50">Approved vs Pending</p>
+              <h3 className="text-foreground font-semibold">Expenses This Month</h3>
+              <p className="text-muted-foreground text-sm">Approved vs Pending</p>
             </div>
             <div className="flex items-center gap-4 text-sm">
               <div className="flex items-center gap-2">
-                <div className="h-3 w-3 rounded-full bg-green-500" />
+                <div className="bg-primary h-3 w-3 rounded-full" />
                 <span className="text-green-200/60">Approved</span>
               </div>
               <div className="flex items-center gap-2">
@@ -422,18 +419,18 @@ export default function LuckyDashboard() {
 
         {/* Vehicles */}
         <div
-          className="overflow-hidden rounded-2xl border border-green-500/20 bg-green-950/40 backdrop-blur-sm"
+          className="border-primary/20 bg-primary/10 overflow-hidden rounded-2xl border backdrop-blur-sm"
           data-testid="vehicle-log"
         >
-          <div className="flex items-center justify-between border-b border-green-500/20 p-6">
+          <div className="border-primary/20 flex items-center justify-between border-b p-6">
             <div className="flex items-center gap-3">
-              <Car className="h-5 w-5 text-green-400" />
+              <Car className="text-primary h-5 w-5" />
               <div>
-                <h3 className="font-semibold text-green-100">Vehicles</h3>
-                <p className="text-sm text-green-200/50">Coming soon</p>
+                <h3 className="text-foreground font-semibold">Vehicles</h3>
+                <p className="text-muted-foreground text-sm">Coming soon</p>
               </div>
             </div>
-            <span className="rounded-full border border-green-500/30 bg-green-500/20 px-3 py-1 text-sm font-medium text-green-400">
+            <span className="border-primary/30 bg-primary/20 text-primary rounded-full border px-3 py-1 text-sm font-medium">
               Coming soon
             </span>
           </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,7 @@ label[for] {
   --popover: #FFFFFF;
   --popover-foreground: #1A1A1A;
   --primary: #D4AF37; /* Sigil Gold */
+  --primary-text: #87662D;
   --primary-foreground: #0F0F12; /* Obsidian */
   --secondary: #4B2E83; /* Arcane Violet */
   --secondary-foreground: #F5F1E6; /* Parchment */
@@ -60,6 +61,7 @@ label[for] {
   --popover: #1B1B1F;
   --popover-foreground: #F5F1E6;
   --primary: #D4AF37; /* Sigil Gold */
+  --primary-text: #D4AF37;
   --primary-foreground: #0F0F12;
   --secondary: #4B2E83; /* Arcane Violet */
   --secondary-foreground: #F5F1E6;
@@ -90,6 +92,7 @@ label[for] {
 /* User-selected accents are independent of roles and permissions. */
 html[data-user-theme="sanctum"] {
   --primary: #D4AF37;
+  --primary-text: #D4AF37;
   --primary-foreground: #0F0F12;
   --secondary: #4B2E83;
   --secondary-foreground: #F5F1E6;
@@ -107,6 +110,7 @@ html[data-user-theme="sanctum"] {
 
 html[data-user-theme="ocean"] {
   --primary: #2563EB;
+  --primary-text: #60A5FA;
   --primary-foreground: #F8FAFC;
   --secondary: #0891B2;
   --secondary-foreground: #F8FAFC;
@@ -124,6 +128,7 @@ html[data-user-theme="ocean"] {
 
 html[data-user-theme="ember"] {
   --primary: #F59E0B;
+  --primary-text: #FBBF24;
   --primary-foreground: #1C1917;
   --secondary: #EA580C;
   --secondary-foreground: #FFF7ED;
@@ -141,6 +146,7 @@ html[data-user-theme="ember"] {
 
 html[data-user-theme="garden"] {
   --primary: #22C55E;
+  --primary-text: #4ADE80;
   --primary-foreground: #052E16;
   --secondary: #0D9488;
   --secondary-foreground: #F0FDFA;
@@ -158,6 +164,7 @@ html[data-user-theme="garden"] {
 
 html[data-user-theme="amethyst"] {
   --primary: #9333EA;
+  --primary-text: #C084FC;
   --primary-foreground: #FAF5FF;
   --secondary: #DB2777;
   --secondary-foreground: #FDF2F8;
@@ -194,6 +201,7 @@ html[data-user-theme="amethyst"] {
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
+  --color-primary-text: var(--primary-text);
   --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);

--- a/app/globals.css
+++ b/app/globals.css
@@ -106,18 +106,18 @@ html[data-user-theme="sanctum"] {
 }
 
 html[data-user-theme="ocean"] {
-  --primary: #3B82F6;
+  --primary: #2563EB;
   --primary-foreground: #F8FAFC;
   --secondary: #0891B2;
   --secondary-foreground: #F8FAFC;
   --accent: #6366F1;
   --accent-foreground: #F8FAFC;
   --ring: #60A5FA;
-  --chart-1: #3B82F6;
+  --chart-1: #2563EB;
   --chart-2: #06B6D4;
   --chart-3: #6366F1;
   --chart-4: #22C55E;
-  --sidebar-primary: #3B82F6;
+  --sidebar-primary: #2563EB;
   --sidebar-primary-foreground: #F8FAFC;
   --sidebar-ring: #60A5FA;
 }
@@ -157,18 +157,18 @@ html[data-user-theme="garden"] {
 }
 
 html[data-user-theme="amethyst"] {
-  --primary: #A855F7;
+  --primary: #9333EA;
   --primary-foreground: #FAF5FF;
   --secondary: #DB2777;
   --secondary-foreground: #FDF2F8;
   --accent: #7C3AED;
   --accent-foreground: #F5F3FF;
   --ring: #C084FC;
-  --chart-1: #A855F7;
+  --chart-1: #9333EA;
   --chart-2: #EC4899;
   --chart-3: #8B5CF6;
   --chart-4: #F59E0B;
-  --sidebar-primary: #A855F7;
+  --sidebar-primary: #9333EA;
   --sidebar-primary-foreground: #FAF5FF;
   --sidebar-ring: #C084FC;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -87,6 +87,92 @@ label[for] {
   --sidebar-ring: #D4AF37;
 }
 
+/* User-selected accents are independent of roles and permissions. */
+html[data-user-theme="sanctum"] {
+  --primary: #D4AF37;
+  --primary-foreground: #0F0F12;
+  --secondary: #4B2E83;
+  --secondary-foreground: #F5F1E6;
+  --accent: #8B1E2D;
+  --accent-foreground: #F5F1E6;
+  --ring: #D4AF37;
+  --chart-1: #D4AF37;
+  --chart-2: #8C6A2F;
+  --chart-3: #4B2E83;
+  --chart-4: #8B1E2D;
+  --sidebar-primary: #D4AF37;
+  --sidebar-primary-foreground: #0F0F12;
+  --sidebar-ring: #D4AF37;
+}
+
+html[data-user-theme="ocean"] {
+  --primary: #3B82F6;
+  --primary-foreground: #F8FAFC;
+  --secondary: #0891B2;
+  --secondary-foreground: #F8FAFC;
+  --accent: #6366F1;
+  --accent-foreground: #F8FAFC;
+  --ring: #60A5FA;
+  --chart-1: #3B82F6;
+  --chart-2: #06B6D4;
+  --chart-3: #6366F1;
+  --chart-4: #22C55E;
+  --sidebar-primary: #3B82F6;
+  --sidebar-primary-foreground: #F8FAFC;
+  --sidebar-ring: #60A5FA;
+}
+
+html[data-user-theme="ember"] {
+  --primary: #F59E0B;
+  --primary-foreground: #1C1917;
+  --secondary: #EA580C;
+  --secondary-foreground: #FFF7ED;
+  --accent: #EAB308;
+  --accent-foreground: #1C1917;
+  --ring: #FBBF24;
+  --chart-1: #F59E0B;
+  --chart-2: #F97316;
+  --chart-3: #EAB308;
+  --chart-4: #DC2626;
+  --sidebar-primary: #F59E0B;
+  --sidebar-primary-foreground: #1C1917;
+  --sidebar-ring: #FBBF24;
+}
+
+html[data-user-theme="garden"] {
+  --primary: #22C55E;
+  --primary-foreground: #052E16;
+  --secondary: #0D9488;
+  --secondary-foreground: #F0FDFA;
+  --accent: #84CC16;
+  --accent-foreground: #1A2E05;
+  --ring: #4ADE80;
+  --chart-1: #22C55E;
+  --chart-2: #14B8A6;
+  --chart-3: #84CC16;
+  --chart-4: #EAB308;
+  --sidebar-primary: #22C55E;
+  --sidebar-primary-foreground: #052E16;
+  --sidebar-ring: #4ADE80;
+}
+
+html[data-user-theme="amethyst"] {
+  --primary: #A855F7;
+  --primary-foreground: #FAF5FF;
+  --secondary: #DB2777;
+  --secondary-foreground: #FDF2F8;
+  --accent: #7C3AED;
+  --accent-foreground: #F5F3FF;
+  --ring: #C084FC;
+  --chart-1: #A855F7;
+  --chart-2: #EC4899;
+  --chart-3: #8B5CF6;
+  --chart-4: #F59E0B;
+  --sidebar-primary: #A855F7;
+  --sidebar-primary-foreground: #FAF5FF;
+  --sidebar-ring: #C084FC;
+}
+
 @theme inline {
   --color-obsidian: #0F0F12;
   --color-ink: #1B1B1F;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" className="dark" data-user-theme="sanctum">
       <body className="font-sans antialiased">
         <div className="noise-overlay" aria-hidden="true" />
         <div className="ritual-glow" aria-hidden="true" />

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -76,6 +76,20 @@ export default function OnboardingPage() {
   const [notifPrefs, setNotifPrefs] = useState({ email: true, sms: false, push: true })
   const [twoFaEnabled, setTwoFaEnabled] = useState(false)
   const [selectedTheme, setSelectedTheme] = useState<UserThemeId>("sanctum")
+  const persistedTheme = profileUser
+    ? isUserThemeId(profileUser.themeId)
+      ? profileUser.themeId
+      : defaultUserThemeForColor(profileUser.color)
+    : null
+
+  useEffect(() => {
+    if (!persistedTheme) return
+
+    document.documentElement.dataset.userTheme = selectedTheme
+    return () => {
+      document.documentElement.dataset.userTheme = persistedTheme
+    }
+  }, [persistedTheme, selectedTheme])
 
   useEffect(() => {
     apiFetchSafe<{
@@ -104,7 +118,6 @@ export default function OnboardingPage() {
             ? u.themeId
             : defaultUserThemeForColor(u.color)
           setSelectedTheme(initialTheme)
-          document.documentElement.dataset.userTheme = initialTheme
           setSelectedResponsibilities(new Set(u.responsibilities || []))
           setLoading(false)
           if (data.user.onboardingStatus === "completed") {
@@ -384,10 +397,7 @@ export default function OnboardingPage() {
                 </p>
                 <UserThemePicker
                   value={selectedTheme}
-                  onChange={(themeId) => {
-                    setSelectedTheme(themeId)
-                    document.documentElement.dataset.userTheme = themeId
-                  }}
+                  onChange={setSelectedTheme}
                   compact
                 />
               </div>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -27,7 +27,7 @@ import {
   X,
 } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 const ROLE_LABELS: Record<string, string> = {
   admin: "Administrator",
@@ -76,6 +76,7 @@ export default function OnboardingPage() {
   const [notifPrefs, setNotifPrefs] = useState({ email: true, sms: false, push: true })
   const [twoFaEnabled, setTwoFaEnabled] = useState(false)
   const [selectedTheme, setSelectedTheme] = useState<UserThemeId>("sanctum")
+  const persistedThemeRef = useRef<UserThemeId>("sanctum")
   const persistedTheme = profileUser
     ? isUserThemeId(profileUser.themeId)
       ? profileUser.themeId
@@ -85,9 +86,10 @@ export default function OnboardingPage() {
   useEffect(() => {
     if (!persistedTheme) return
 
+    persistedThemeRef.current = persistedTheme
     document.documentElement.dataset.userTheme = selectedTheme
     return () => {
-      document.documentElement.dataset.userTheme = persistedTheme
+      document.documentElement.dataset.userTheme = persistedThemeRef.current
     }
   }, [persistedTheme, selectedTheme])
 
@@ -243,6 +245,8 @@ export default function OnboardingPage() {
         body: { themeId: selectedTheme },
         label: "OnboardingTheme",
       })
+      persistedThemeRef.current = selectedTheme
+      setFetchedUser((current) => (current ? { ...current, themeId: selectedTheme } : current))
     } catch {
       // Theme selection is optional and must not block onboarding completion.
     }
@@ -262,6 +266,8 @@ export default function OnboardingPage() {
         body: { themeId: selectedTheme },
         label: "OnboardingTheme",
       })
+      persistedThemeRef.current = selectedTheme
+      setFetchedUser((current) => (current ? { ...current, themeId: selectedTheme } : current))
       await refresh()
     } catch {
       // Leaving onboarding remains available if preference persistence is unavailable.

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -230,6 +230,10 @@ export default function OnboardingPage() {
         body: { themeId: selectedTheme },
         label: "OnboardingTheme",
       })
+    } catch {
+      // Theme selection is optional and must not block onboarding completion.
+    }
+    try {
       await apiFetch("/api/users/me/onboard", { method: "POST", label: "Onboard" })
       await refresh()
       router.push(`/dashboard/${profileUser.id}?tutorial=1`)

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ErrorBoundary } from "@/components/error-boundary"
+import { UserThemePicker } from "@/components/user-theme-picker"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -10,6 +11,7 @@ import { apiFetch, apiFetchSafe } from "@/lib/api-client"
 import { useAuth } from "@/lib/auth-context"
 import { logger } from "@/lib/logger"
 import { useLoginModal } from "@/lib/login-modal-context"
+import { defaultUserThemeForColor, isUserThemeId, type UserThemeId } from "@/lib/user-themes"
 import {
   ArrowRight,
   Bell,
@@ -18,6 +20,7 @@ import {
   ChevronDown,
   FileSignature,
   Loader2,
+  Palette,
   Shield,
   User,
   Users,
@@ -37,7 +40,7 @@ const ROLES = ["operator", "employee", "resident"] as const
 
 export default function OnboardingPage() {
   const router = useRouter()
-  const { user, isAuthenticated } = useAuth()
+  const { user, isAuthenticated, refresh } = useAuth()
   const { openLoginModal } = useLoginModal()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
@@ -47,6 +50,8 @@ export default function OnboardingPage() {
     name: string
     role: string
     responsibilities?: string[]
+    color?: string
+    themeId?: UserThemeId
   } | null>(null)
 
   const profileUser = fetchedUser ?? user
@@ -70,6 +75,7 @@ export default function OnboardingPage() {
   const [uploadingPhoto, setUploadingPhoto] = useState(false)
   const [notifPrefs, setNotifPrefs] = useState({ email: true, sms: false, push: true })
   const [twoFaEnabled, setTwoFaEnabled] = useState(false)
+  const [selectedTheme, setSelectedTheme] = useState<UserThemeId>("sanctum")
 
   useEffect(() => {
     apiFetchSafe<{
@@ -78,6 +84,8 @@ export default function OnboardingPage() {
         name: string
         role: string
         responsibilities?: string[]
+        color?: string
+        themeId?: UserThemeId
         onboardingStatus?: string
       }
     } | null>("/api/users/me", null, { label: "UsersMe" })
@@ -88,8 +96,15 @@ export default function OnboardingPage() {
             name: string
             role: string
             responsibilities?: string[]
+            color?: string
+            themeId?: UserThemeId
           }
           setFetchedUser(u)
+          const initialTheme = isUserThemeId(u.themeId)
+            ? u.themeId
+            : defaultUserThemeForColor(u.color)
+          setSelectedTheme(initialTheme)
+          document.documentElement.dataset.userTheme = initialTheme
           setSelectedResponsibilities(new Set(u.responsibilities || []))
           setLoading(false)
           if (data.user.onboardingStatus === "completed") {
@@ -210,14 +225,30 @@ export default function OnboardingPage() {
     if (!profileUser?.id) return
     await handleSaveResponsibilities()
     try {
+      await apiFetch("/api/users/me", {
+        method: "PATCH",
+        body: { themeId: selectedTheme },
+        label: "OnboardingTheme",
+      })
       await apiFetch("/api/users/me/onboard", { method: "POST", label: "Onboard" })
+      await refresh()
       router.push(`/dashboard/${profileUser.id}?tutorial=1`)
     } catch {
       router.push(`/dashboard/${profileUser.id}?tutorial=1`)
     }
   }
 
-  const handleClose = () => {
+  const handleClose = async () => {
+    try {
+      await apiFetch("/api/users/me", {
+        method: "PATCH",
+        body: { themeId: selectedTheme },
+        label: "OnboardingTheme",
+      })
+      await refresh()
+    } catch {
+      // Leaving onboarding remains available if preference persistence is unavailable.
+    }
     router.push(`/dashboard/${profileUser?.id || ""}`)
   }
 
@@ -337,6 +368,24 @@ export default function OnboardingPage() {
                     I confirm this is my correct role
                   </Label>
                 </div>
+              </div>
+
+              <div>
+                <p className="mb-2 flex items-center gap-2 text-sm font-medium text-white/80">
+                  <Palette className="h-4 w-4" />
+                  Choose your workspace theme
+                </p>
+                <p className="mb-3 text-sm text-white/50">
+                  This changes your colours only. Your role and access stay the same.
+                </p>
+                <UserThemePicker
+                  value={selectedTheme}
+                  onChange={(themeId) => {
+                    setSelectedTheme(themeId)
+                    document.documentElement.dataset.userTheme = themeId
+                  }}
+                  compact
+                />
               </div>
 
               <div>

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -145,13 +145,6 @@ export default function DashboardLayout({ children, persona }: DashboardLayoutPr
     isViewingOwnDashboard ? user?.responsibilities : undefined
   )
 
-  const colorClasses = {
-    blue: "bg-primary",
-    amber: "bg-muted",
-    green: "bg-secondary",
-    purple: "bg-accent",
-  }
-
   const handleLogout = () => {
     logout()
   }
@@ -180,7 +173,7 @@ export default function DashboardLayout({ children, persona }: DashboardLayoutPr
           </div>
           <Link href="/" className="flex items-center gap-3 relative z-10">
             <div
-              className={`h-10 w-10 rounded-xl ${colorClasses[personaInfo.color as keyof typeof colorClasses]} flex items-center justify-center`}
+              className="h-10 w-10 rounded-xl bg-primary flex items-center justify-center"
             >
               <span className="font-serif text-2xl leading-none text-primary-foreground">
                 {crest.core}
@@ -218,7 +211,7 @@ export default function DashboardLayout({ children, persona }: DashboardLayoutPr
                             onClick={() => setSidebarOpen(false)}
                             className={`flex items-center gap-3 rounded-lg px-3 py-2 transition-all ${
                               isActive
-                                ? `${colorClasses[personaInfo.color as keyof typeof colorClasses]} text-primary-foreground`
+                                ? "bg-primary text-primary-foreground"
                                 : "text-muted-foreground hover:bg-muted hover:text-foreground"
                             } `}
                           >
@@ -241,7 +234,7 @@ export default function DashboardLayout({ children, persona }: DashboardLayoutPr
                 onClick={() => setSidebarOpen(false)}
                 className={`flex items-center gap-3 rounded-xl px-4 py-3 transition-all ${
                   isActive
-                    ? `${colorClasses[personaInfo.color as keyof typeof colorClasses]} text-primary-foreground`
+                    ? "bg-primary text-primary-foreground"
                     : "text-muted-foreground hover:bg-muted hover:text-foreground"
                 } `}
               >

--- a/components/inventory-photo-capture.tsx
+++ b/components/inventory-photo-capture.tsx
@@ -26,55 +26,15 @@ const QUICK_LOCATIONS = [
 
 type InventoryTone = "blue" | "amber" | "green" | "purple"
 
-const toneClasses: Record<
-  InventoryTone,
-  {
-    border: string
-    panel: string
-    soft: string
-    text: string
-    muted: string
-    button: string
-    focus: string
-  }
-> = {
-  blue: {
-    border: "border-blue-500/25",
-    panel: "bg-blue-950/45",
-    soft: "bg-blue-500/20",
-    text: "text-blue-100",
-    muted: "text-blue-200/55",
-    button: "border-blue-400/40 bg-blue-500 text-white hover:bg-blue-400",
-    focus: "focus:border-blue-300",
-  },
-  amber: {
-    border: "border-amber-500/25",
-    panel: "bg-amber-950/45",
-    soft: "bg-amber-500/20",
-    text: "text-amber-100",
-    muted: "text-amber-200/55",
-    button: "border-amber-400/40 bg-amber-500 text-black hover:bg-amber-400",
-    focus: "focus:border-amber-300",
-  },
-  green: {
-    border: "border-green-500/25",
-    panel: "bg-green-950/45",
-    soft: "bg-green-500/20",
-    text: "text-green-100",
-    muted: "text-green-200/55",
-    button: "border-green-400/40 bg-green-500 text-black hover:bg-green-400",
-    focus: "focus:border-green-300",
-  },
-  purple: {
-    border: "border-purple-500/25",
-    panel: "bg-purple-950/45",
-    soft: "bg-purple-500/20",
-    text: "text-purple-100",
-    muted: "text-purple-200/55",
-    button: "border-purple-400/40 bg-purple-500 text-white hover:bg-purple-400",
-    focus: "focus:border-purple-300",
-  },
-}
+const themeClasses = {
+  border: "border-primary/25",
+  panel: "bg-primary/10",
+  soft: "bg-primary/20",
+  text: "text-foreground",
+  muted: "text-muted-foreground",
+  button: "border-primary/40 bg-primary text-primary-foreground hover:bg-primary/80",
+  focus: "focus:border-primary",
+} as const
 
 interface InventoryPhotoCaptureProps {
   persona: "hans" | "charl" | "lucky" | "irma"
@@ -85,13 +45,11 @@ interface InventoryPhotoCaptureProps {
 }
 
 export function InventoryPhotoCapture({
-  persona,
-  tone,
   defaultCategory = "workshop_consumables",
   defaultLocation = "Workshop Store",
   onSaved,
 }: InventoryPhotoCaptureProps) {
-  const styles = toneClasses[tone]
+  const styles = themeClasses
   const [label, setLabel] = useState("")
   const [category, setCategory] = useState(defaultCategory)
   const [location, setLocation] = useState(defaultLocation)

--- a/components/user-theme-picker.tsx
+++ b/components/user-theme-picker.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useRef, type KeyboardEvent } from "react"
 import { Check } from "lucide-react"
 import { USER_THEME_OPTIONS, type UserThemeId } from "@/lib/user-themes"
 
@@ -16,6 +17,35 @@ export function UserThemePicker({
   disabled = false,
   compact = false,
 }: UserThemePickerProps) {
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([])
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex: number | null = null
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        nextIndex = (index + 1) % USER_THEME_OPTIONS.length
+        break
+      case "ArrowLeft":
+      case "ArrowUp":
+        nextIndex = (index - 1 + USER_THEME_OPTIONS.length) % USER_THEME_OPTIONS.length
+        break
+      case "Home":
+        nextIndex = 0
+        break
+      case "End":
+        nextIndex = USER_THEME_OPTIONS.length - 1
+        break
+      default:
+        return
+    }
+
+    event.preventDefault()
+    const nextTheme = USER_THEME_OPTIONS[nextIndex]
+    onChange(nextTheme.id)
+    optionRefs.current[nextIndex]?.focus()
+  }
+
   return (
     <div
       className={compact ? "grid gap-3 sm:grid-cols-2" : "grid gap-3 sm:grid-cols-2 lg:grid-cols-3"}
@@ -23,16 +53,21 @@ export function UserThemePicker({
       aria-label="Workspace theme"
       data-testid="user-theme-picker"
     >
-      {USER_THEME_OPTIONS.map((theme) => {
+      {USER_THEME_OPTIONS.map((theme, index) => {
         const selected = value === theme.id
         return (
           <button
             key={theme.id}
+            ref={(element) => {
+              optionRefs.current[index] = element
+            }}
             type="button"
             role="radio"
             aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
             disabled={disabled}
             onClick={() => onChange(theme.id)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
             className={`focus-visible:ring-primary relative rounded-xl border p-3 text-left transition-all focus-visible:ring-2 disabled:opacity-50 ${
               selected
                 ? "border-primary bg-primary/15 shadow-[0_0_24px_color-mix(in_srgb,var(--primary)_18%,transparent)]"

--- a/components/user-theme-picker.tsx
+++ b/components/user-theme-picker.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { Check } from "lucide-react"
+import { USER_THEME_OPTIONS, type UserThemeId } from "@/lib/user-themes"
+
+interface UserThemePickerProps {
+  value: UserThemeId
+  onChange: (themeId: UserThemeId) => void
+  disabled?: boolean
+  compact?: boolean
+}
+
+export function UserThemePicker({
+  value,
+  onChange,
+  disabled = false,
+  compact = false,
+}: UserThemePickerProps) {
+  return (
+    <div
+      className={compact ? "grid gap-3 sm:grid-cols-2" : "grid gap-3 sm:grid-cols-2 lg:grid-cols-3"}
+      role="radiogroup"
+      aria-label="Workspace theme"
+      data-testid="user-theme-picker"
+    >
+      {USER_THEME_OPTIONS.map((theme) => {
+        const selected = value === theme.id
+        return (
+          <button
+            key={theme.id}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={disabled}
+            onClick={() => onChange(theme.id)}
+            className={`focus-visible:ring-primary relative rounded-xl border p-3 text-left transition-all focus-visible:ring-2 disabled:opacity-50 ${
+              selected
+                ? "border-primary bg-primary/15 shadow-[0_0_24px_color-mix(in_srgb,var(--primary)_18%,transparent)]"
+                : "border-white/10 bg-white/5 hover:border-white/25 hover:bg-white/10"
+            }`}
+            data-testid={`user-theme-${theme.id}`}
+          >
+            {selected && (
+              <span className="bg-primary text-primary-foreground absolute top-2 right-2 flex h-5 w-5 items-center justify-center rounded-full">
+                <Check className="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
+            )}
+            <span className="mb-3 flex gap-1" aria-hidden="true">
+              {theme.swatches.map((swatch) => (
+                <span
+                  key={swatch}
+                  className="h-6 flex-1 rounded-md"
+                  style={{ backgroundColor: swatch }}
+                />
+              ))}
+            </span>
+            <span className="block pr-6 font-medium text-white">{theme.name}</span>
+            <span className="mt-1 block text-xs text-white/55">{theme.description}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/docs/05-project/2026-07-27-user-selectable-themes.md
+++ b/docs/05-project/2026-07-27-user-selectable-themes.md
@@ -1,0 +1,32 @@
+# User-selectable workspace themes
+
+## Decision
+
+Workspace colour is a personal preference, not a role or permission signal. Users can choose a
+theme during onboarding and change it later in Settings without changing dashboard ownership,
+navigation, responsibilities, or RBAC.
+
+## Implementation
+
+- Five named, accessible dark-first palettes are defined in `lib/user-themes.ts`.
+- The selected `theme_id` is stored on the existing user record and validated at the authenticated
+  `/api/users/me` boundary.
+- Existing users without `theme_id` retain their former persona palette through the legacy `color`
+  mapping; new self-provisioned users start with Sanctum Gold until they choose.
+- `data-user-theme` on the document root drives semantic CSS variables. Dashboard home pages and the
+  shared navigation shell consume `primary`/`secondary` tokens instead of persona-specific dominant
+  colours.
+- Operational meaning remains colour-stable: destructive, warning, success, and data-series colours
+  are not rewritten as personal accents.
+
+## Verification
+
+- `pnpm exec tsc --noEmit`
+- `pnpm run lint`
+- `pnpm run build`
+- `pnpm test -- tests/lib/user-themes.test.ts tests/api/user-theme.test.ts`
+
+The complete unit suite currently has a pre-existing two-test failure in
+`tests/lib/deployment-workflow-contract.test.ts`: its deploy-job substring includes later workflow
+jobs and therefore sees their valid `actions/checkout` steps. The theming tests and the other 413
+tests pass.

--- a/docs/05-project/2026-07-27-user-selectable-themes.md
+++ b/docs/05-project/2026-07-27-user-selectable-themes.md
@@ -24,9 +24,8 @@ navigation, responsibilities, or RBAC.
 - `pnpm exec tsc --noEmit`
 - `pnpm run lint`
 - `pnpm run build`
-- `pnpm test -- tests/lib/user-themes.test.ts tests/api/user-theme.test.ts`
+- `pnpm test -- --run tests/lib/user-theme-contrast.test.ts tests/components/user-theme-picker.test.tsx tests/lib/user-themes.test.ts tests/api/onboarding-feedback.test.ts`
 
-The complete unit suite currently has a pre-existing two-test failure in
-`tests/lib/deployment-workflow-contract.test.ts`: its deploy-job substring includes later workflow
-jobs and therefore sees their valid `actions/checkout` steps. The theming tests and the other 413
-tests pass.
+The focused suite passes 15 tests across four files. The production build generates 125 pages and
+routes. PR #153 also passed Infrastructure Verification, Validate Configuration, Lint, Unit Tests,
+Production Build, E2E Tests, and Pipeline Summary on the final feature head.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,13 +47,13 @@
 
 ## 03-deployment/ -- Deployment and Operations
 
-| Document                                                                                           | Description                                                                      |
-| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| [01-deployment-guide.md](03-deployment/01-deployment-guide.md)                                     | End-to-end Azure deployment: auth, Terraform, DNS, SSL, integrations, secrets    |
-| [02-local-development.md](03-deployment/02-local-development.md)                                   | Docker Compose setup, prerequisites, local vs production comparison              |
-| [03-ci-cd-workflows.md](03-deployment/03-ci-cd-workflows.md)                                       | GitHub Actions workflows: plan, apply, deploy, destroy, checklist                |
-| [04-rollback-procedure.md](03-deployment/04-rollback-procedure.md)                                 | Rollback procedure for Next.js, Functions, Terraform, containers                 |
-| [05-terraform-firewall-troubleshooting.md](03-deployment/05-terraform-firewall-troubleshooting.md) | Key Vault/Storage 403, container IP type, consumption budget, self-hosted runner |
+| Document                                                                                           | Description                                                                               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [01-deployment-guide.md](03-deployment/01-deployment-guide.md)                                     | End-to-end Azure deployment: auth, Terraform, DNS, SSL, integrations, secrets             |
+| [02-local-development.md](03-deployment/02-local-development.md)                                   | Docker Compose setup, prerequisites, local vs production comparison                       |
+| [03-ci-cd-workflows.md](03-deployment/03-ci-cd-workflows.md)                                       | GitHub Actions workflows: plan, apply, deploy, destroy, checklist                         |
+| [04-rollback-procedure.md](03-deployment/04-rollback-procedure.md)                                 | Rollback procedure for Next.js, Functions, Terraform, containers                          |
+| [05-terraform-firewall-troubleshooting.md](03-deployment/05-terraform-firewall-troubleshooting.md) | Key Vault/Storage 403, container IP type, consumption budget, self-hosted runner          |
 | [07-self-hosted-runner-setup.md](03-deployment/07-self-hosted-runner-setup.md)                     | _Historical:_ self-hosted runner setup (no longer in use — workflows use `ubuntu-latest`) |
 
 _Note: 06 reserved for future deployment documentation._
@@ -86,8 +86,9 @@ _Note: 06 reserved for future deployment documentation._
 
 Dated session continuity notes (root cause, files changed, verification, next-owner steps).
 
-| Document                                                                                        | Description                                                                          |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [2026-07-11-mystira-oidc-prod-login-fix.md](handoffs/2026-07-11-mystira-oidc-prod-login-fix.md) | Production login `/api/auth/error` fix — Mystira OIDC app settings + AUTH_TRUST_HOST |
-| [2026-07-20-prod-telemetry-project-store.md](handoffs/2026-07-20-prod-telemetry-project-store.md) | Production telemetry and project datastore remediation handoff                       |
+| Document                                                                                              | Description                                                                          |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [2026-07-11-mystira-oidc-prod-login-fix.md](handoffs/2026-07-11-mystira-oidc-prod-login-fix.md)       | Production login `/api/auth/error` fix — Mystira OIDC app settings + AUTH_TRUST_HOST |
+| [2026-07-20-prod-telemetry-project-store.md](handoffs/2026-07-20-prod-telemetry-project-store.md)     | Production telemetry and project datastore remediation handoff                       |
 | [2026-07-22-project-datastore-ai-hardening.md](handoffs/2026-07-22-project-datastore-ai-hardening.md) | Project datastore API and AI project suggestion hardening closeout                   |
+| [2026-07-28-user-selectable-themes.md](handoffs/2026-07-28-user-selectable-themes.md)                 | User-selectable workspace themes implementation, review, and merge handoff           |

--- a/docs/handoffs/2026-07-28-user-selectable-themes.md
+++ b/docs/handoffs/2026-07-28-user-selectable-themes.md
@@ -1,0 +1,97 @@
+# User-selectable workspace themes merge handoff
+
+- **Date:** 2026-07-28
+- **Repository:** `C:\Users\smitj\repos\house-of-veritas`
+- **Feature branch:** `feat/user-selectable-themes`
+- **Pull request:** [#153 - Add user-selectable workspace themes](https://github.com/neuralliquid/house-of-veritas/pull/153)
+- **Validated feature head:** `97d0abc76c0ea3927ac65546c987cded40b7b68b`
+- **Risk tier:** UI workflow plus authenticated user-preference persistence
+- **Status at handoff publication:** Ready for merge; all required CI checks pass and no unresolved review threads remain.
+
+## Outcome
+
+House of Veritas now treats workspace colour as a personal preference instead of a role or access
+signal. Users can select one of five themes during onboarding and change it later in Settings.
+The selection persists through the authenticated user API and survives reloads while dashboard
+ownership, navigation, responsibilities, and RBAC remain unchanged.
+
+The implementation includes:
+
+- Sanctum, Ocean, Ember, Garden, and Amethyst theme definitions;
+- validated `theme_id` persistence through `/api/users/me`;
+- onboarding and Settings pickers with live preview and rollback of unsaved previews;
+- keyboard-operable radiogroup behavior with roving focus and Arrow/Home/End navigation;
+- separate fill and readable-text accent tokens, with automated WCAG contrast checks;
+- legacy persona-colour fallback for users who do not yet have a stored theme;
+- semantic-token migration of the four dashboard home pages and shared dashboard shell;
+- independent persistence of local Settings when remote theme synchronization fails.
+
+## Review findings closed
+
+Codex bot review identified and the branch addressed:
+
+1. optional theme persistence must not block onboarding completion;
+2. unsaved Settings and onboarding previews must restore the persisted theme;
+3. saved onboarding themes must survive route-transition cleanup;
+4. theme radio controls require standard keyboard navigation;
+5. Ocean and Amethyst filled controls require accessible foreground contrast;
+6. dark-surface accent text requires a token separate from the filled-control colour;
+7. theme swatches must match the applied primary colours; and
+8. local Settings persistence must not depend on the remote theme API.
+
+All nine review threads created across the iterative bot passes were resolved after their fixes
+were pushed. The final requested Codex pass for `97d0abc` was still delayed externally at handoff
+publication; GitHub showed no unresolved review thread, and all known findings were implemented.
+
+## Verification evidence
+
+Local verification on the final feature head:
+
+```text
+pnpm run lint
+pnpm exec tsc --noEmit
+pnpm test -- --run tests/lib/user-theme-contrast.test.ts tests/components/user-theme-picker.test.tsx tests/lib/user-themes.test.ts tests/api/onboarding-feedback.test.ts
+pnpm run build
+```
+
+Results:
+
+- ESLint passed.
+- TypeScript passed.
+- Focused suite passed: 4 files, 15 tests.
+- Production build passed and generated 125 pages/routes.
+- Browser proof confirmed Garden persisted for Hans after reload while admin access and Governance
+  navigation remained present.
+
+GitHub Actions on `97d0abc`:
+
+- Infrastructure Verification: passed
+- Validate Configuration: passed
+- Lint: passed
+- Unit Tests: passed
+- Production Build: passed
+- E2E Tests: passed
+- Pipeline Summary: passed
+
+At the final pre-handoff snapshot, PR #153 was `MERGEABLE`, had `CLEAN` merge state, and had zero
+unresolved review threads.
+
+## Post-merge checks
+
+1. Verify PR #153 records the expected merge commit and merged head.
+2. Verify the merge-triggered deployment workflow completes for that exact merge commit.
+3. Confirm the production health/build endpoint reports the exact merge build before claiming the
+   feature deployed.
+4. With a legitimate user session, select a theme in Settings, save, reload, and confirm the theme
+   persists without changing access or dashboard ownership.
+5. During new-user onboarding, confirm a failed optional theme save cannot leave onboarding pending
+   after the user continues.
+
+Production deployment and authenticated operator acceptance are evidence gates separate from this
+merge handoff. This document does not manufacture or bypass a legitimate session.
+
+## Next owner
+
+The release owner should monitor the merge-triggered deployment, verify exact-build production
+health, and record legitimate authenticated theme persistence when an operator session is
+available. Any failure should be replayed from PR #153, feature head `97d0abc`, and this handoff.

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter } from "next/navigation"
 import { signOut as nextAuthSignOut } from "next-auth/react"
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from "react"
 import { getDashboardPath, isPersonaId } from "@/lib/auth/dashboard-path"
+import { defaultUserThemeForColor, type UserThemeId } from "@/lib/user-themes"
 
 interface User {
   id: string
@@ -13,6 +14,7 @@ interface User {
   role: string
   description: string
   color: string
+  themeId?: UserThemeId
   icon: string
   specialty: string[]
   photoUrl?: string
@@ -62,6 +64,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     checkSession()
   }, [checkSession])
+
+  useEffect(() => {
+    const themeId = user?.themeId ?? defaultUserThemeForColor(user?.color)
+    document.documentElement.dataset.userTheme = themeId
+  }, [user?.color, user?.themeId])
 
   useEffect(() => {
     if (isLoading) return

--- a/lib/db/postgres.ts
+++ b/lib/db/postgres.ts
@@ -82,6 +82,7 @@ export async function ensureSchema(): Promise<void> {
           role TEXT NOT NULL,
           description TEXT DEFAULT '',
           color TEXT DEFAULT 'gray',
+          theme_id TEXT,
           icon TEXT DEFAULT '👤',
           specialty TEXT[] DEFAULT '{}',
           created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -90,6 +91,8 @@ export async function ensureSchema(): Promise<void> {
         CREATE INDEX IF NOT EXISTS idx_users_email ON users(LOWER(email));
         CREATE INDEX IF NOT EXISTS idx_users_phone ON users(phone);
       `)
+
+      await client.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS theme_id TEXT;`)
 
       // Legacy column drop: pre-OIDC databases created `users` with a NOT NULL
       // `password_hash` column. The bcrypt+JWT auth it backed was fully removed

--- a/lib/user-management.ts
+++ b/lib/user-management.ts
@@ -1,5 +1,6 @@
 import { isPostgresConfigured, query, withClient } from "@/lib/db/postgres"
 import { User, UserRole, findUserByIdAsync, getAllUsersAsync } from "@/lib/users"
+import { defaultUserThemeForColor, isUserThemeId } from "@/lib/user-themes"
 
 export type UserStatus = "active" | "inactive" | "onboarding" | "offboarding" | "offboarded"
 
@@ -32,6 +33,7 @@ async function ensureUserManagementSchema(): Promise<void> {
           END IF;
         END $$;
       `)
+      await client.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS theme_id TEXT;`)
       await client.query(`
         DO $$ BEGIN
           IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='users' AND column_name='responsibilities') THEN
@@ -93,6 +95,9 @@ function rowToUserWithManagement(row: Record<string, unknown>): UserWithManageme
     role: row.role as UserRole,
     description: (row.description as string) || "",
     color: (row.color as string) || "gray",
+    themeId: isUserThemeId(row.theme_id)
+      ? row.theme_id
+      : defaultUserThemeForColor(row.color as string | undefined),
     icon: (row.icon as string) || "👤",
     specialty: Array.isArray(row.specialty) ? (row.specialty as string[]) : [],
     photoUrl: row.photo_url as string | undefined,
@@ -124,7 +129,7 @@ export async function getAllUsersWithManagement(): Promise<UserWithManagement[]>
   }
   await ensureUserManagementSchema()
   const { rows } = await query<Record<string, unknown>>(
-    `SELECT id, name, email, phone, role, description, color, icon, specialty,
+    `SELECT id, name, email, phone, role, description, color, theme_id, icon, specialty,
             COALESCE(status, 'active') as status,
             COALESCE(responsibilities::jsonb, '[]')::jsonb as responsibilities,
             COALESCE(onboarding_status, 'pending') as onboarding_status,
@@ -152,7 +157,7 @@ export async function getUserWithManagement(id: string): Promise<UserWithManagem
   }
   await ensureUserManagementSchema()
   const { rows } = await query<Record<string, unknown>>(
-    `SELECT id, name, email, phone, role, description, color, icon, specialty, photo_url,
+    `SELECT id, name, email, phone, role, description, color, theme_id, icon, specialty, photo_url,
             COALESCE(status, 'active') as status,
             COALESCE(responsibilities::jsonb, '[]')::jsonb as responsibilities,
             COALESCE(onboarding_status, 'pending') as onboarding_status,

--- a/lib/user-themes.ts
+++ b/lib/user-themes.ts
@@ -20,7 +20,7 @@ export const USER_THEME_OPTIONS: readonly UserThemeOption[] = [
     id: "ocean",
     name: "Ocean Blue",
     description: "A calm blue and cyan workspace.",
-    swatches: ["#3b82f6", "#06b6d4", "#6366f1"],
+    swatches: ["#2563eb", "#06b6d4", "#6366f1"],
   },
   {
     id: "ember",
@@ -38,7 +38,7 @@ export const USER_THEME_OPTIONS: readonly UserThemeOption[] = [
     id: "amethyst",
     name: "Amethyst",
     description: "Rich purple and rose accents.",
-    swatches: ["#a855f7", "#ec4899", "#8b5cf6"],
+    swatches: ["#9333ea", "#ec4899", "#8b5cf6"],
   },
 ] as const
 

--- a/lib/user-themes.ts
+++ b/lib/user-themes.ts
@@ -1,0 +1,62 @@
+export const USER_THEME_IDS = ["sanctum", "ocean", "ember", "garden", "amethyst"] as const
+
+export type UserThemeId = (typeof USER_THEME_IDS)[number]
+
+export interface UserThemeOption {
+  id: UserThemeId
+  name: string
+  description: string
+  swatches: readonly [string, string, string]
+}
+
+export const USER_THEME_OPTIONS: readonly UserThemeOption[] = [
+  {
+    id: "sanctum",
+    name: "Sanctum Gold",
+    description: "The classic House of Veritas palette.",
+    swatches: ["#d4af37", "#4b2e83", "#8b1e2d"],
+  },
+  {
+    id: "ocean",
+    name: "Ocean Blue",
+    description: "A calm blue and cyan workspace.",
+    swatches: ["#3b82f6", "#06b6d4", "#6366f1"],
+  },
+  {
+    id: "ember",
+    name: "Ember",
+    description: "Warm amber and orange accents.",
+    swatches: ["#f59e0b", "#f97316", "#eab308"],
+  },
+  {
+    id: "garden",
+    name: "Garden",
+    description: "Natural green and teal tones.",
+    swatches: ["#22c55e", "#14b8a6", "#84cc16"],
+  },
+  {
+    id: "amethyst",
+    name: "Amethyst",
+    description: "Rich purple and rose accents.",
+    swatches: ["#a855f7", "#ec4899", "#8b5cf6"],
+  },
+] as const
+
+export function isUserThemeId(value: unknown): value is UserThemeId {
+  return typeof value === "string" && USER_THEME_IDS.some((themeId) => themeId === value)
+}
+
+export function defaultUserThemeForColor(color?: string | null): UserThemeId {
+  switch (color) {
+    case "blue":
+      return "ocean"
+    case "amber":
+      return "ember"
+    case "green":
+      return "garden"
+    case "purple":
+      return "amethyst"
+    default:
+      return "sanctum"
+  }
+}

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,4 +1,5 @@
 import { isPostgresConfigured, query, withClient, ensureSchema } from "@/lib/db/postgres"
+import { defaultUserThemeForColor, isUserThemeId, type UserThemeId } from "@/lib/user-themes"
 
 export interface User {
   id: string
@@ -8,6 +9,7 @@ export interface User {
   role: UserRole
   description: string
   color: string
+  themeId?: UserThemeId
   icon: string
   specialty: string[]
   photoUrl?: string
@@ -27,6 +29,7 @@ const DEMO_SEED_USERS: Record<string, User> = DEMO_USERS_ENABLED
         role: "admin",
         description: "Demo Administrator account",
         color: "blue",
+        themeId: "ocean",
         icon: "🛡️",
         specialty: ["Administration", "Compliance"],
       },
@@ -38,6 +41,7 @@ const DEMO_SEED_USERS: Record<string, User> = DEMO_USERS_ENABLED
         role: "operator",
         description: "Demo Operator account",
         color: "amber",
+        themeId: "ember",
         icon: "🔧",
         specialty: ["Operations", "Maintenance"],
       },
@@ -49,6 +53,7 @@ const DEMO_SEED_USERS: Record<string, User> = DEMO_USERS_ENABLED
         role: "resident",
         description: "Demo Resident account",
         color: "purple",
+        themeId: "amethyst",
         icon: "🏠",
         specialty: ["Household", "Management"],
       },
@@ -60,6 +65,7 @@ const DEMO_SEED_USERS: Record<string, User> = DEMO_USERS_ENABLED
         role: "employee",
         description: "Demo Employee account",
         color: "green",
+        themeId: "garden",
         icon: "👤",
         specialty: ["Tasks", "Support"],
       },
@@ -75,6 +81,7 @@ export const USERS: Record<string, User> = {
     role: "admin",
     description: "Full platform access, approvals, and oversight",
     color: "blue",
+    themeId: "ocean",
     icon: "👔",
     specialty: ["Tech", "Leadership", "Electronics"],
   },
@@ -86,6 +93,7 @@ export const USERS: Record<string, User> = {
     role: "resident",
     description: "Household tasks, documents, limited access",
     color: "purple",
+    themeId: "amethyst",
     icon: "🏠",
     specialty: ["Babysitting", "Cleaning", "Food"],
   },
@@ -97,6 +105,7 @@ export const USERS: Record<string, User> = {
     role: "operator",
     description: "Tasks, assets, time tracking, vehicles coming soon",
     color: "amber",
+    themeId: "ember",
     icon: "🔧",
     specialty: ["Tinkerer", "Electrician", "Plumber", "Magicman"],
   },
@@ -108,6 +117,7 @@ export const USERS: Record<string, User> = {
     role: "employee",
     description: "Tasks, expenses, time tracking, vehicles coming soon",
     color: "green",
+    themeId: "garden",
     icon: "🌿",
     specialty: ["Gardening", "Painting", "Manual Labour"],
   },
@@ -131,6 +141,7 @@ type UserRow = {
   role: string
   description: string
   color: string
+  theme_id?: string | null
   icon: string
   specialty: string[]
   photo_url?: string
@@ -145,6 +156,7 @@ function rowToUser(row: UserRow): User {
     role: row.role as UserRole,
     description: row.description || "",
     color: row.color || "gray",
+    themeId: isUserThemeId(row.theme_id) ? row.theme_id : defaultUserThemeForColor(row.color),
     icon: row.icon || "👤",
     specialty: Array.isArray(row.specialty) ? row.specialty : [],
     photoUrl: row.photo_url,
@@ -158,7 +170,7 @@ export async function findUserByEmailAsync(email: string): Promise<User | undefi
   await ensureUsersSchemaOnce()
   await seedUsersIfEmpty()
   const { rows } = await query<UserRow>(
-    `SELECT id, name, email, phone, role, description, color, icon, specialty
+    `SELECT id, name, email, phone, role, description, color, theme_id, icon, specialty
      FROM users WHERE LOWER(email) = LOWER($1) LIMIT 1`,
     [email]
   )
@@ -194,6 +206,7 @@ export async function findOrCreateOidcUserAsync(
     role: "resident",
     description: "Self-provisioned via Mystira sign-in",
     color: "gray",
+    themeId: "sanctum",
     icon: "👤",
     specialty: [],
   }
@@ -201,8 +214,8 @@ export async function findOrCreateOidcUserAsync(
   if (isPostgresConfigured()) {
     await ensureUsersSchemaOnce()
     await query(
-      `INSERT INTO users (id, name, email, phone, role, description, color, icon, specialty)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      `INSERT INTO users (id, name, email, phone, role, description, color, theme_id, icon, specialty)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
        ON CONFLICT (email) DO NOTHING`,
       [
         user.id,
@@ -212,6 +225,7 @@ export async function findOrCreateOidcUserAsync(
         user.role,
         user.description,
         user.color,
+        user.themeId,
         user.icon,
         user.specialty,
       ]
@@ -232,7 +246,7 @@ export async function getAllUsersAsync(): Promise<User[]> {
   await ensureUsersSchemaOnce()
   await seedUsersIfEmpty()
   const { rows } = await query<UserRow>(
-    `SELECT id, name, email, phone, role, description, color, icon, specialty FROM users`
+    `SELECT id, name, email, phone, role, description, color, theme_id, icon, specialty FROM users`
   )
   return rows.map(rowToUser)
 }
@@ -244,7 +258,7 @@ export async function findUserByIdAsync(id: string): Promise<User | undefined> {
   await ensureUsersSchemaOnce()
   await seedUsersIfEmpty()
   const { rows } = await query<UserRow>(
-    `SELECT id, name, email, phone, role, description, color, icon, specialty, photo_url
+    `SELECT id, name, email, phone, role, description, color, theme_id, icon, specialty, photo_url
      FROM users WHERE LOWER(id) = LOWER($1) LIMIT 1`,
     [id]
   )
@@ -260,8 +274,8 @@ export async function seedUsersIfEmpty(): Promise<void> {
   await withClient(async (client) => {
     for (const user of Object.values(USERS)) {
       await client.query(
-        `INSERT INTO users (id, name, email, phone, role, description, color, icon, specialty)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        `INSERT INTO users (id, name, email, phone, role, description, color, theme_id, icon, specialty)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
          ON CONFLICT (id) DO NOTHING`,
         [
           user.id,
@@ -271,6 +285,7 @@ export async function seedUsersIfEmpty(): Promise<void> {
           user.role,
           user.description,
           user.color,
+          user.themeId,
           user.icon,
           user.specialty,
         ]
@@ -294,7 +309,7 @@ export function findUserByPhone(phone: string): User | undefined {
 
 export async function updateUserProfileAsync(
   id: string,
-  updates: { name?: string; phone?: string; photoUrl?: string }
+  updates: { name?: string; phone?: string; photoUrl?: string; themeId?: UserThemeId }
 ): Promise<User | null> {
   if (isPostgresConfigured()) {
     await ensureUsersSchemaOnce()
@@ -313,6 +328,10 @@ export async function updateUserProfileAsync(
       setClauses.push(`photo_url = $${idx++}`)
       values.push(updates.photoUrl)
     }
+    if (updates.themeId !== undefined) {
+      setClauses.push(`theme_id = $${idx++}`)
+      values.push(updates.themeId)
+    }
     if (setClauses.length === 0) return (await findUserByIdAsync(id)) ?? null
     setClauses.push(`updated_at = NOW()`)
     values.push(id)
@@ -327,6 +346,7 @@ export async function updateUserProfileAsync(
   if (updates.name != null) user.name = updates.name
   if (updates.phone != null) user.phone = updates.phone
   if (updates.photoUrl !== undefined) (user as User).photoUrl = updates.photoUrl
+  if (updates.themeId !== undefined) user.themeId = updates.themeId
   return user
 }
 

--- a/tests/api/user-theme.test.ts
+++ b/tests/api/user-theme.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const updateUserProfileAsync = vi.fn()
+const getUserWithManagement = vi.fn()
+
+vi.mock("@/lib/users", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/users")>()
+  return { ...actual, updateUserProfileAsync }
+})
+
+vi.mock("@/lib/user-management", () => ({ getUserWithManagement }))
+
+const authHeaders = {
+  "x-user-id": "hans",
+  "x-user-role": "admin",
+  "x-user-email": "user@example.com",
+  "Content-Type": "application/json",
+}
+
+describe("PATCH /api/users/me theme", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    updateUserProfileAsync.mockResolvedValue({ id: "hans", themeId: "garden" })
+    getUserWithManagement.mockResolvedValue({
+      id: "hans",
+      name: "Hans",
+      email: "user@example.com",
+      role: "admin",
+      responsibilities: [],
+      themeId: "garden",
+    })
+  })
+
+  it("persists a valid theme for the authenticated user", async () => {
+    const { PATCH } = await import("@/app/api/users/me/route")
+    const response = await PATCH(
+      new Request("http://localhost/api/users/me", {
+        method: "PATCH",
+        headers: authHeaders,
+        body: JSON.stringify({ themeId: "garden" }),
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateUserProfileAsync).toHaveBeenCalledWith("hans", { themeId: "garden" })
+    await expect(response.json()).resolves.toMatchObject({ user: { themeId: "garden" } })
+  })
+
+  it("rejects unknown themes before writing", async () => {
+    const { PATCH } = await import("@/app/api/users/me/route")
+    const response = await PATCH(
+      new Request("http://localhost/api/users/me", {
+        method: "PATCH",
+        headers: authHeaders,
+        body: JSON.stringify({ themeId: "admin-red" }),
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(updateUserProfileAsync).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/user-theme-picker.test.tsx
+++ b/tests/components/user-theme-picker.test.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+import { UserThemePicker } from "@/components/user-theme-picker"
+import type { UserThemeId } from "@/lib/user-themes"
+
+function ControlledThemePicker() {
+  const [theme, setTheme] = useState<UserThemeId>("sanctum")
+  return <UserThemePicker value={theme} onChange={setTheme} />
+}
+
+describe("UserThemePicker", () => {
+  it("uses roving focus and arrow keys for its radio options", async () => {
+    const user = userEvent.setup()
+    render(<ControlledThemePicker />)
+
+    const radios = screen.getAllByRole("radio")
+    expect(radios[0]).toHaveAttribute("tabindex", "0")
+    expect(radios[1]).toHaveAttribute("tabindex", "-1")
+
+    radios[0].focus()
+    await user.keyboard("{ArrowRight}")
+
+    expect(radios[1]).toHaveFocus()
+    expect(radios[1]).toHaveAttribute("aria-checked", "true")
+    expect(radios[0]).toHaveAttribute("tabindex", "-1")
+    expect(radios[1]).toHaveAttribute("tabindex", "0")
+
+    await user.keyboard("{End}")
+    expect(radios[radios.length - 1]).toHaveFocus()
+    expect(radios[radios.length - 1]).toHaveAttribute("aria-checked", "true")
+  })
+})

--- a/tests/lib/user-theme-contrast.test.ts
+++ b/tests/lib/user-theme-contrast.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+import { USER_THEME_IDS } from "@/lib/user-themes"
+
+const css = readFileSync("app/globals.css", "utf8")
+
+function luminance(hex: string) {
+  const channels = hex
+    .match(/[0-9a-f]{2}/gi)!
+    .map((channel) => Number.parseInt(channel, 16) / 255)
+    .map((channel) =>
+      channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+    )
+
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+}
+
+function contrast(first: string, second: string) {
+  const firstLuminance = luminance(first)
+  const secondLuminance = luminance(second)
+  return (
+    (Math.max(firstLuminance, secondLuminance) + 0.05) /
+    (Math.min(firstLuminance, secondLuminance) + 0.05)
+  )
+}
+
+function themeVariable(themeId: string, variable: string) {
+  const block = css.match(
+    new RegExp(`html\\[data-user-theme="${themeId}"\\] \\{([\\s\\S]*?)\\n\\}`)
+  )?.[1]
+  const value = block?.match(new RegExp(`--${variable}:\\s*(#[0-9A-Fa-f]{6})`))?.[1]
+  expect(value, `${themeId} defines --${variable}`).toBeTruthy()
+  return value!
+}
+
+describe("user theme contrast", () => {
+  it.each(USER_THEME_IDS)("keeps %s fills and dark-surface text readable", (themeId) => {
+    const primary = themeVariable(themeId, "primary")
+    const primaryForeground = themeVariable(themeId, "primary-foreground")
+    const primaryText = themeVariable(themeId, "primary-text")
+
+    expect(contrast(primary, primaryForeground)).toBeGreaterThanOrEqual(4.5)
+    expect(contrast(primaryText, "#0F0F12")).toBeGreaterThanOrEqual(4.5)
+  })
+})

--- a/tests/lib/user-themes.test.ts
+++ b/tests/lib/user-themes.test.ts
@@ -22,4 +22,11 @@ describe("user themes", () => {
     expect(defaultUserThemeForColor("purple")).toBe("amethyst")
     expect(defaultUserThemeForColor("gray")).toBe("sanctum")
   })
+
+  it("keeps the picker swatches aligned with accessible primary colors", () => {
+    expect(USER_THEME_OPTIONS.find((theme) => theme.id === "ocean")?.swatches[0]).toBe("#2563eb")
+    expect(USER_THEME_OPTIONS.find((theme) => theme.id === "amethyst")?.swatches[0]).toBe(
+      "#9333ea"
+    )
+  })
 })

--- a/tests/lib/user-themes.test.ts
+++ b/tests/lib/user-themes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { USER_THEME_OPTIONS, defaultUserThemeForColor, isUserThemeId } from "@/lib/user-themes"
+
+describe("user themes", () => {
+  it("exposes unique selectable themes", () => {
+    const ids = USER_THEME_OPTIONS.map((theme) => theme.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids).toEqual(["sanctum", "ocean", "ember", "garden", "amethyst"])
+  })
+
+  it("validates persisted theme identifiers", () => {
+    expect(isUserThemeId("garden")).toBe(true)
+    expect(isUserThemeId("administrator")).toBe(false)
+    expect(isUserThemeId(null)).toBe(false)
+  })
+
+  it("preserves legacy persona palettes for users without a preference", () => {
+    expect(defaultUserThemeForColor("blue")).toBe("ocean")
+    expect(defaultUserThemeForColor("amber")).toBe("ember")
+    expect(defaultUserThemeForColor("green")).toBe("garden")
+    expect(defaultUserThemeForColor("purple")).toBe("amethyst")
+    expect(defaultUserThemeForColor("gray")).toBe("sanctum")
+  })
+})


### PR DESCRIPTION
## What changed

- add five named, dark-first workspace themes with semantic CSS tokens
- let users preview and choose a theme during onboarding and in Settings
- persist the validated preference as `users.theme_id` through the authenticated profile API
- preserve each existing user's current persona palette until they make a choice
- decouple dashboard and navigation accent colours from roles and permissions
- migrate the four dashboard home pages and shared Inventory Capture panel to semantic theme tokens
- retain semantic success, warning, destructive, and data-series colours
- add API/theme tests and a durable project decision note

## User impact

Users can personalize their workspace without changing their role, responsibilities, navigation, or access. New OIDC users start with Sanctum Gold and can choose during onboarding; existing users retain their current visual identity by default.

## Validation

- `pnpm run lint` — passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm run build` — passed, 125 pages generated
- `pnpm test -- tests/lib/user-themes.test.ts tests/api/user-theme.test.ts` — 5/5 passed
- full `pnpm test` — 413/415 passed; the two failures are the existing Windows CRLF-sensitive deployment-workflow substring assertions, unrelated to this diff
- Playwright CLI with a synthetic Auth.js session — picker rendered as an accessible radiogroup; Garden preview set `data-user-theme=garden` and `--primary=#22c55e`; authenticated `PATCH /api/users/me` returned 200; reload retained Garden on `/dashboard/hans`; Hans remained admin with Governance navigation present

## Notes

The schema addition is nullable and idempotent. Missing or invalid stored values fall back to the user's legacy colour mapping; invalid API values are rejected with HTTP 400.
