### PR TITLE
Add recipe guidance persistence boundary

### DIFF
--- a/docs/04-configuration/05-persistence-env.md
+++ b/docs/04-configuration/05-persistence-env.md
@@ -26,7 +26,12 @@ When set, rate limiting uses Redis instead of in-memory storage. Redis is alread
 | `MONGODB_URI` | MongoDB connection string  | `mongodb://<account>.mongo.cosmos.azure.com:10255/?ssl=true&replicaSet=globaldb` |
 | `MONGO_URL`   | Alternative to MONGODB_URI | Same format                                                                      |
 
-When set, kiosk requests (stock orders, salary advances, issue reports) are stored in MongoDB. When PostgreSQL is not configured, the audit log reads from MongoDB. When MongoDB is unavailable, kiosk uses an in-memory fallback. For local development, MongoDB is included in Docker Compose (`config/docker-compose.yml`).
+When set, kiosk requests (stock orders, salary advances, issue reports), recipes, task guidance, and
+versioned recipe guidance documents are stored in MongoDB. Recipe guidance uses the dedicated
+`recipe_guidance_documents` collection. Unlike legacy fallback-oriented stores, this repository
+fails closed outside test/E2E when Mongo is absent unless `ALLOW_DEMO_DATA=true` explicitly enables
+an empty local JSON store. For local development, MongoDB is included in Docker Compose
+(`config/docker-compose.yml`).
 
 ### Cosmos DB Configuration
 
@@ -49,6 +54,7 @@ The application uses a tiered persistence approach:
 Data flows:
 
 - Kiosk requests → MongoDB (with in-memory fallback)
+- Recipe guidance documents → MongoDB (empty memory in tests; explicit-demo JSON only)
 - Audit logs → PostgreSQL → MongoDB fallback (if PostgreSQL unavailable)
 - File uploads → Azure Blob → Local disk fallback
 - Time-clock records → Baserow (when configured)
@@ -59,9 +65,9 @@ Time-clock records are persisted to Baserow when `BASEROW_API_URL`, `BASEROW_TOK
 
 ## File/Image Uploads
 
-| API            | Storage                                                               | Metadata                                                          |
-| -------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `/api/files`   | Azure Blob (asset-photos, invoice-scans, documents) or `/tmp/uploads` | Returned in response only                                         |
-| `/api/uploads` | `/home/hov-uploads` in production; `/tmp/hov-uploads` locally/tests     | PostgreSQL `file_uploads` when `DATABASE_URL` set; else sidecar + in-memory |
+| API            | Storage                                                               | Metadata                                                                    |
+| -------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `/api/files`   | Azure Blob (asset-photos, invoice-scans, documents) or `/tmp/uploads` | Returned in response only                                                   |
+| `/api/uploads` | `/home/hov-uploads` in production; `/tmp/hov-uploads` locally/tests   | PostgreSQL `file_uploads` when `DATABASE_URL` set; else sidecar + in-memory |
 
 **Serving:** Files uploaded via `/api/uploads` are served at `GET /api/uploads/{fileId}`. Files in `/tmp/uploads` (from `/api/files` when Azure not configured) are served at `GET /api/files/serve?category=...&filename=...`.

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -15,6 +15,26 @@ shape while retaining their domain-specific source records.
 - Production guidance requires the configured Mongo datastore. Tests and non-production,
   unconfigured development use JSON files under `data/`.
 
+### Recipe document storage boundary
+
+Recipe guidance documents use the dedicated Mongo collection `recipe_guidance_documents`; they are
+not embedded into `task_guidance`. The richer recipe aggregate owns immutable recipe revision
+manifests, canonical sections, media and image-brief lifecycles, and publication review evidence.
+Keeping it separate prevents those invariants from weakening the smaller, task-oriented
+`GuidancePack` contract.
+
+- Document IDs are unique, and `(recipeId, version)` is a unique version key.
+- Stored values are schema-validated on reads and writes; invalid persisted documents fail closed.
+- Draft and in-review replacements use `updatedAt` optimistic concurrency. Published content is
+  immutable; a published version may only transition to archived without changing its content, and
+  an archived version cannot change.
+- Tests and E2E use an empty in-memory repository. With Mongo unconfigured, ordinary runtime fails
+  closed. Local JSON persistence is available only when `ALLOW_DEMO_DATA=true`; enabling it does not
+  seed any recipe guidance.
+- Existing `task_guidance` records and task bindings remain readable. Migration first inventories
+  recipe-backed legacy packs, verifies their recipe snapshot, and requires a rebuild from the
+  canonical recipe. It never promotes legacy publication or review state automatically.
+
 ## Request flow
 
 1. A resident opens Guidance from a task and captures or chooses a photo.

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -24,6 +24,8 @@ Keeping it separate prevents those invariants from weakening the smaller, task-o
 `GuidancePack` contract.
 
 - Document IDs are unique, and `(recipeId, version)` is a unique version key.
+- Recipe revision IDs and their ordered ingredient/step manifests are immutable within a document
+  version; a canonical recipe change requires a new version.
 - Stored values are schema-validated on reads and writes; invalid persisted documents fail closed.
 - Draft and in-review replacements use `updatedAt` optimistic concurrency. Published content is
   immutable; a published version may only transition to archived without changing its content, and

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -28,12 +28,16 @@ Keeping it separate prevents those invariants from weakening the smaller, task-o
 - Draft and in-review replacements use `updatedAt` optimistic concurrency. Published content is
   immutable; a published version may only transition to archived without changing its content, and
   an archived version cannot change.
+- Every replacement must advance `updatedAt`. Explicit-demo file mutations serialize the complete
+  read/check/write operation within the process so concurrent writers receive the same conflict
+  guarantees as Mongo compare-and-swap updates.
 - Tests and E2E use an empty in-memory repository. With Mongo unconfigured, ordinary runtime fails
   closed. Local JSON persistence is available only when `ALLOW_DEMO_DATA=true`; enabling it does not
   seed any recipe guidance.
 - Existing `task_guidance` records and task bindings remain readable. Migration first inventories
   recipe-backed legacy packs, verifies their recipe snapshot, and requires a rebuild from the
-  canonical recipe. It never promotes legacy publication or review state automatically.
+  canonical recipe. It selects at most one rebuild for each recipe revision and never promotes
+  legacy publication or review state automatically.
 
 ## Request flow
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,4 +93,5 @@ Dated session continuity notes (root cause, files changed, verification, next-ow
 | [2026-07-20-prod-telemetry-project-store.md](handoffs/2026-07-20-prod-telemetry-project-store.md)         | Production telemetry and project datastore remediation handoff                       |
 | [2026-07-22-project-datastore-ai-hardening.md](handoffs/2026-07-22-project-datastore-ai-hardening.md)     | Project datastore API and AI project suggestion hardening closeout                   |
 | [2026-07-28-recipe-guidance-phase1-contracts.md](handoffs/2026-07-28-recipe-guidance-phase1-contracts.md) | Recipe guidance Phase 1 typed document and media contracts                           |
+| [2026-07-29-recipe-guidance-persistence.md](handoffs/2026-07-29-recipe-guidance-persistence.md)           | Dedicated recipe guidance repository and safe migration boundary                     |
 | [2026-07-28-user-selectable-themes.md](handoffs/2026-07-28-user-selectable-themes.md)                     | User-selectable workspace themes implementation, review, and merge handoff           |

--- a/docs/handoffs/2026-07-29-recipe-guidance-persistence.md
+++ b/docs/handoffs/2026-07-29-recipe-guidance-persistence.md
@@ -27,6 +27,8 @@ without rewriting existing task bindings.
   version lookup index.
 - Schema-validates every stored read and write and strips Mongo `_id` fields.
 - Uses `updatedAt` optimistic concurrency for mutable versions.
+- Requires `updatedAt` to advance on every replacement and serializes explicit-demo file mutations
+  across their complete read/check/write sequence.
 - Requires new versions to begin as drafts. Rejects duplicate versions, immutable identity changes,
   direct draft-to-published transitions, published-content changes, and archived-version changes.
 - Keeps tests/E2E empty by default and requires `ALLOW_DEMO_DATA=true` before local JSON persistence
@@ -39,9 +41,11 @@ Migration is inventory and rebuild first, not an in-place collection rewrite:
 1. Read legacy recipe-backed `GuidancePack` records without changing `task_guidance` or bindings.
 2. Reject incoherent source/draft recipe provenance, missing recipes, and stale recipe snapshots.
 3. Skip recipe revisions already present in `recipe_guidance_documents`.
-4. Mark coherent remaining records `rebuild_from_recipe_required` so a later authorized runner can
+4. Select only one rebuild candidate for each recipe revision; classify other matching legacy packs
+   as `duplicate_legacy_revision`.
+5. Mark the selected coherent record `rebuild_from_recipe_required` so a later authorized runner can
    build the canonical nine-section draft from the recipe and route it through human review.
-5. Never copy a legacy `published` status into the richer document or infer missing review/media
+6. Never copy a legacy `published` status into the richer document or infer missing review/media
    evidence.
 
 The planner always returns `writesAuthorized: false`. No production inventory, migration, or write
@@ -69,7 +73,7 @@ pnpm exec tsc --noEmit
 pnpm run lint
 ```
 
-- Focused result: 3 files, 37 tests passed.
+- Focused result after review remediation: 3 files, 42 tests passed.
 - The first worktree dependency install timed out and left partial links. Those generated links were
   replaced with a local junction to the primary checkout's lockfile-matching `node_modules`; no
   package or lockfile changed.
@@ -78,6 +82,9 @@ pnpm run lint
   types for unchanged `app/api/ai/refine-description/route.ts`; the route has no feature diff. Treat
   this as a local tooling/pre-existing route-contract warning and rely on exact-head CI for the
   canonical production-build gate.
+- Review remediation added regression coverage for reused/stale concurrency tokens, concurrent
+  demo-file mutations, Mongo duplicate and zero-match conflicts, invalid Mongo documents, and
+  duplicate legacy packs for one recipe revision.
 
 ## Next slice
 

--- a/docs/handoffs/2026-07-29-recipe-guidance-persistence.md
+++ b/docs/handoffs/2026-07-29-recipe-guidance-persistence.md
@@ -30,7 +30,8 @@ without rewriting existing task bindings.
 - Requires `updatedAt` to advance on every replacement and serializes explicit-demo file mutations
   across their complete read/check/write sequence.
 - Requires new versions to begin as drafts. Rejects duplicate versions, immutable identity changes,
-  direct draft-to-published transitions, published-content changes, and archived-version changes.
+  recipe-manifest changes, direct draft-to-published transitions, published-content changes, and
+  archived-version changes.
 - Keeps tests/E2E empty by default and requires `ALLOW_DEMO_DATA=true` before local JSON persistence
   is available without Mongo. The flag enables storage, not seed content.
 
@@ -73,7 +74,7 @@ pnpm exec tsc --noEmit
 pnpm run lint
 ```
 
-- Focused result after review remediation: 3 files, 42 tests passed.
+- Focused result after the final manifest-immutability remediation: 3 files, 43 tests passed.
 - The first worktree dependency install timed out and left partial links. Those generated links were
   replaced with a local junction to the primary checkout's lockfile-matching `node_modules`; no
   package or lockfile changed.

--- a/docs/handoffs/2026-07-29-recipe-guidance-persistence.md
+++ b/docs/handoffs/2026-07-29-recipe-guidance-persistence.md
@@ -1,0 +1,94 @@
+# Recipe guidance persistence and migration handoff
+
+- **Date:** 2026-07-29
+- **Repository:** `C:\Users\smitj\repos\house-of-veritas`
+- **Worktree:** `C:\tmp\hov-recipe-guidance-persistence`
+- **Branch:** `feat/recipe-guidance-persistence`
+- **Base:** `origin/main` at `686d4954c069d2f2b5aa934e6b7e9e3624d885c8`
+- **Predecessor:** PR [#156](https://github.com/neuralliquid/house-of-veritas/pull/156)
+- **Baton task:** `3a36dc41-3376-441a-a11d-f2b5bef648c4`
+- **Risk tier:** API/data workflow; no production migration or deployment
+
+## Decision
+
+Use a dedicated `recipe_guidance_documents` collection behind a recipe-guidance repository.
+Do not extend `task_guidance` with the richer aggregate.
+
+`GuidancePack` remains the compact task attachment/read model. `RecipeGuidanceDocument` has a
+different lifecycle and stronger invariants: immutable recipe revision manifests, canonical
+section ordering, image briefs, media provenance, review gates, and publishable versions. A
+separate collection keeps both contracts narrow, allows independent indexes, and permits rollback
+without rewriting existing task bindings.
+
+## Implemented boundary
+
+- Added memory, explicit-demo file, and Mongo implementations behind one repository contract.
+- Added unique Mongo indexes for document identity and `(recipeId, version)`, plus the published
+  version lookup index.
+- Schema-validates every stored read and write and strips Mongo `_id` fields.
+- Uses `updatedAt` optimistic concurrency for mutable versions.
+- Requires new versions to begin as drafts. Rejects duplicate versions, immutable identity changes,
+  direct draft-to-published transitions, published-content changes, and archived-version changes.
+- Keeps tests/E2E empty by default and requires `ALLOW_DEMO_DATA=true` before local JSON persistence
+  is available without Mongo. The flag enables storage, not seed content.
+
+## Migration strategy
+
+Migration is inventory and rebuild first, not an in-place collection rewrite:
+
+1. Read legacy recipe-backed `GuidancePack` records without changing `task_guidance` or bindings.
+2. Reject incoherent source/draft recipe provenance, missing recipes, and stale recipe snapshots.
+3. Skip recipe revisions already present in `recipe_guidance_documents`.
+4. Mark coherent remaining records `rebuild_from_recipe_required` so a later authorized runner can
+   build the canonical nine-section draft from the recipe and route it through human review.
+5. Never copy a legacy `published` status into the richer document or infer missing review/media
+   evidence.
+
+The planner always returns `writesAuthorized: false`. No production inventory, migration, or write
+was run in this slice.
+
+## Changed files
+
+- `lib/repositories/recipe-guidance-repository.ts`
+- `lib/recipe-guidance-migration.ts`
+- `tests/lib/recipe-guidance-repository.test.ts`
+- `tests/lib/recipe-guidance-migration.test.ts`
+- `docs/05-project/task-guidance-architecture.md`
+- `docs/04-configuration/05-persistence-env.md`
+- `docs/handoffs/2026-07-29-recipe-guidance-persistence.md`
+- `docs/README.md`
+
+## Verification
+
+Passed before final closeout:
+
+```text
+pnpm exec prettier --check <four new TypeScript files>
+pnpm exec vitest run tests/lib/recipe-guidance-repository.test.ts tests/lib/recipe-guidance-migration.test.ts tests/lib/recipe-guidance.test.ts
+pnpm exec tsc --noEmit
+pnpm run lint
+```
+
+- Focused result: 3 files, 37 tests passed.
+- The first worktree dependency install timed out and left partial links. Those generated links were
+  replaced with a local junction to the primary checkout's lockfile-matching `node_modules`; no
+  package or lockfile changed.
+- `pnpm run build` could not complete under that junction. Turbopack rejected the external dependency
+  junction before compilation. The webpack fallback compiled successfully, then failed on generated
+  types for unchanged `app/api/ai/refine-description/route.ts`; the route has no feature diff. Treat
+  this as a local tooling/pre-existing route-contract warning and rely on exact-head CI for the
+  canonical production-build gate.
+
+## Next slice
+
+Build the deterministic canonical draft builder and preview/read API against this repository. Keep
+Sluice generation, bulk migration apply, public publishing, OmniPost, and deployment out of scope.
+Any future migration apply must require explicit authorization, record per-item outcomes, be
+idempotent, and preserve the legacy records until acceptance is complete.
+
+## Trace envelope
+
+- **Task:** `3a36dc41-3376-441a-a11d-f2b5bef648c4`
+- **Routing:** Veritas Ledger/data persistence, Shield/fail-closed provenance, Proof/tests
+- **Gates:** focused tests, TypeScript, formatting, lint; build warning recorded above
+- **External effects:** Baton task/relation only; no database, Sluice, deployment, or production writes

--- a/lib/recipe-guidance-migration.ts
+++ b/lib/recipe-guidance-migration.ts
@@ -4,6 +4,7 @@ import type { RecipeRecord } from "@/lib/recipes"
 
 export const RECIPE_GUIDANCE_MIGRATION_REASONS = [
   "already_present",
+  "duplicate_legacy_revision",
   "rebuild_from_recipe_required",
   "invalid_recipe_provenance",
   "recipe_not_found",
@@ -15,6 +16,7 @@ export type RecipeGuidanceMigrationReason = (typeof RECIPE_GUIDANCE_MIGRATION_RE
 export interface RecipeGuidanceMigrationCandidate {
   legacyGuidancePackId: string
   recipeId?: string
+  recipeRevisionId?: string
   reason: RecipeGuidanceMigrationReason
   migratable: boolean
 }
@@ -31,6 +33,10 @@ export function planRecipeGuidanceMigration(params: {
   existingDocuments: RecipeGuidanceDocument[]
 }): RecipeGuidanceMigrationPlan {
   const recipesById = new Map(params.recipes.map((recipe) => [recipe.id, recipe]))
+  const existingRevisions = new Set(
+    params.existingDocuments.map((document) => document.recipeRevisionId)
+  )
+  const selectedRevisions = new Set<string>()
   const candidates = params.legacyGuidance
     .filter(
       (guidance) =>
@@ -74,24 +80,33 @@ export function planRecipeGuidanceMigration(params: {
         }
       }
 
-      if (
-        params.existingDocuments.some(
-          (document) =>
-            document.recipeId === recipeId &&
-            document.recipeRevisionId === guidance.sourceRecipeRevisionId
-        )
-      ) {
+      const recipeRevisionId = guidance.sourceRecipeRevisionId as string
+
+      if (existingRevisions.has(recipeRevisionId)) {
         return {
           legacyGuidancePackId: guidance.id,
           recipeId,
+          recipeRevisionId,
           reason: "already_present",
           migratable: false,
         }
       }
 
+      if (selectedRevisions.has(recipeRevisionId)) {
+        return {
+          legacyGuidancePackId: guidance.id,
+          recipeId,
+          recipeRevisionId,
+          reason: "duplicate_legacy_revision",
+          migratable: false,
+        }
+      }
+      selectedRevisions.add(recipeRevisionId)
+
       return {
         legacyGuidancePackId: guidance.id,
         recipeId,
+        recipeRevisionId,
         reason: "rebuild_from_recipe_required",
         migratable: true,
       }

--- a/lib/recipe-guidance-migration.ts
+++ b/lib/recipe-guidance-migration.ts
@@ -1,0 +1,108 @@
+import { guidanceMatchesRecipeSnapshot, type GuidancePack } from "@/lib/guidance"
+import type { RecipeGuidanceDocument } from "@/lib/recipe-guidance"
+import type { RecipeRecord } from "@/lib/recipes"
+
+export const RECIPE_GUIDANCE_MIGRATION_REASONS = [
+  "already_present",
+  "rebuild_from_recipe_required",
+  "invalid_recipe_provenance",
+  "recipe_not_found",
+  "recipe_snapshot_mismatch",
+] as const
+
+export type RecipeGuidanceMigrationReason = (typeof RECIPE_GUIDANCE_MIGRATION_REASONS)[number]
+
+export interface RecipeGuidanceMigrationCandidate {
+  legacyGuidancePackId: string
+  recipeId?: string
+  reason: RecipeGuidanceMigrationReason
+  migratable: boolean
+}
+
+export interface RecipeGuidanceMigrationPlan {
+  candidates: RecipeGuidanceMigrationCandidate[]
+  counts: Record<RecipeGuidanceMigrationReason, number>
+  writesAuthorized: false
+}
+
+export function planRecipeGuidanceMigration(params: {
+  legacyGuidance: GuidancePack[]
+  recipes: RecipeRecord[]
+  existingDocuments: RecipeGuidanceDocument[]
+}): RecipeGuidanceMigrationPlan {
+  const recipesById = new Map(params.recipes.map((recipe) => [recipe.id, recipe]))
+  const candidates = params.legacyGuidance
+    .filter(
+      (guidance) =>
+        guidance.kind === "recipe" ||
+        guidance.source.type === "recipe" ||
+        guidance.source.recipeId !== undefined ||
+        guidance.sourceRecipeId !== undefined
+    )
+    .map((guidance): RecipeGuidanceMigrationCandidate => {
+      const recipeId = guidance.sourceRecipeId ?? guidance.source.recipeId
+      if (
+        !recipeId ||
+        guidance.source.type !== "recipe" ||
+        guidance.source.recipeId !== recipeId ||
+        guidance.sourceRecipeId !== recipeId
+      ) {
+        return {
+          legacyGuidancePackId: guidance.id,
+          recipeId,
+          reason: "invalid_recipe_provenance",
+          migratable: false,
+        }
+      }
+
+      const recipe = recipesById.get(recipeId)
+      if (!recipe) {
+        return {
+          legacyGuidancePackId: guidance.id,
+          recipeId,
+          reason: "recipe_not_found",
+          migratable: false,
+        }
+      }
+
+      if (!guidanceMatchesRecipeSnapshot(guidance, recipe)) {
+        return {
+          legacyGuidancePackId: guidance.id,
+          recipeId,
+          reason: "recipe_snapshot_mismatch",
+          migratable: false,
+        }
+      }
+
+      if (
+        params.existingDocuments.some(
+          (document) =>
+            document.recipeId === recipeId &&
+            document.recipeRevisionId === guidance.sourceRecipeRevisionId
+        )
+      ) {
+        return {
+          legacyGuidancePackId: guidance.id,
+          recipeId,
+          reason: "already_present",
+          migratable: false,
+        }
+      }
+
+      return {
+        legacyGuidancePackId: guidance.id,
+        recipeId,
+        reason: "rebuild_from_recipe_required",
+        migratable: true,
+      }
+    })
+
+  const counts = Object.fromEntries(
+    RECIPE_GUIDANCE_MIGRATION_REASONS.map((reason) => [
+      reason,
+      candidates.filter((candidate) => candidate.reason === reason).length,
+    ])
+  ) as Record<RecipeGuidanceMigrationReason, number>
+
+  return { candidates, counts, writesAuthorized: false }
+}

--- a/lib/repositories/recipe-guidance-repository.ts
+++ b/lib/repositories/recipe-guidance-repository.ts
@@ -81,6 +81,11 @@ function assertReplacementAllowed(
   if (current.updatedAt !== expectedUpdatedAt) {
     throw new RecipeGuidanceConflictError("Recipe guidance changed before this update")
   }
+  if (new Date(next.updatedAt).getTime() <= new Date(current.updatedAt).getTime()) {
+    throw new RecipeGuidanceConflictError(
+      "Recipe guidance updatedAt must advance on every replacement"
+    )
+  }
   if (
     current.id !== next.id ||
     current.recipeId !== next.recipeId ||
@@ -171,6 +176,17 @@ async function writeFileDocuments(documents: RecipeGuidanceDocument[]): Promise<
   await rename(temporaryFile, RECIPE_GUIDANCE_FILE)
 }
 
+let fileMutationQueue: Promise<void> = Promise.resolve()
+
+function serializeFileMutation<T>(mutation: () => Promise<T>): Promise<T> {
+  const operation = fileMutationQueue.then(mutation, mutation)
+  fileMutationQueue = operation.then(
+    () => undefined,
+    () => undefined
+  )
+  return operation
+}
+
 function createFileRepository(): RecipeGuidanceRepository {
   return {
     async listByRecipeId(recipeId) {
@@ -189,28 +205,34 @@ function createFileRepository(): RecipeGuidanceRepository {
       )
     },
     async create(input) {
-      const document = validateWrite(input)
-      assertNewDraft(document)
-      const documents = await readFileDocuments()
-      const duplicate = documents.some(
-        (item) =>
-          item.id === document.id ||
-          (item.recipeId === document.recipeId && item.version === document.version)
-      )
-      if (duplicate) throw new RecipeGuidanceConflictError("Recipe guidance version already exists")
-      documents.push(document)
-      await writeFileDocuments(documents)
-      return clone(document)
+      return serializeFileMutation(async () => {
+        const document = validateWrite(input)
+        assertNewDraft(document)
+        const documents = await readFileDocuments()
+        const duplicate = documents.some(
+          (item) =>
+            item.id === document.id ||
+            (item.recipeId === document.recipeId && item.version === document.version)
+        )
+        if (duplicate) {
+          throw new RecipeGuidanceConflictError("Recipe guidance version already exists")
+        }
+        documents.push(document)
+        await writeFileDocuments(documents)
+        return clone(document)
+      })
     },
     async replace(input, expectedUpdatedAt) {
-      const document = validateWrite(input)
-      const documents = await readFileDocuments()
-      const index = documents.findIndex((item) => item.id === document.id)
-      if (index === -1) throw new RecipeGuidanceConflictError("Recipe guidance was not found")
-      assertReplacementAllowed(documents[index], document, expectedUpdatedAt)
-      documents[index] = document
-      await writeFileDocuments(documents)
-      return clone(document)
+      return serializeFileMutation(async () => {
+        const document = validateWrite(input)
+        const documents = await readFileDocuments()
+        const index = documents.findIndex((item) => item.id === document.id)
+        if (index === -1) throw new RecipeGuidanceConflictError("Recipe guidance was not found")
+        assertReplacementAllowed(documents[index], document, expectedUpdatedAt)
+        documents[index] = document
+        await writeFileDocuments(documents)
+        return clone(document)
+      })
     },
   }
 }
@@ -311,6 +333,7 @@ export async function getRecipeGuidanceRepository(): Promise<{
 
 export function resetRecipeGuidanceRepositoryForTests(): void {
   memoryDocuments = []
+  fileMutationQueue = Promise.resolve()
   cachedRepository = null
   cachedMode = null
 }

--- a/lib/repositories/recipe-guidance-repository.ts
+++ b/lib/repositories/recipe-guidance-repository.ts
@@ -1,0 +1,316 @@
+import { randomUUID } from "crypto"
+import { mkdir, readFile, rename, writeFile } from "fs/promises"
+import { dirname, join } from "path"
+import type { Collection, ObjectId } from "mongodb"
+import { getCollection, isMongoConfigured, withoutMongoId } from "@/lib/db/mongodb"
+import { parseRecipeGuidanceDocument, type RecipeGuidanceDocument } from "@/lib/recipe-guidance"
+
+export const RECIPE_GUIDANCE_COLLECTION = "recipe_guidance_documents"
+
+const RECIPE_GUIDANCE_FILE = join(process.cwd(), "data", "recipe-guidance-documents.json")
+
+type RecipeGuidanceMongoDocument = RecipeGuidanceDocument & { _id?: ObjectId }
+export type RecipeGuidanceRepositoryMode = "memory" | "file" | "mongodb"
+
+export class RecipeGuidanceConflictError extends Error {}
+export class RecipeGuidanceIntegrityError extends Error {}
+export class RecipeGuidanceStoreUnavailableError extends Error {}
+
+export interface RecipeGuidanceRepository {
+  listByRecipeId(recipeId: string): Promise<RecipeGuidanceDocument[]>
+  findById(id: string): Promise<RecipeGuidanceDocument | null>
+  findLatestPublished(recipeId: string): Promise<RecipeGuidanceDocument | null>
+  create(document: RecipeGuidanceDocument): Promise<RecipeGuidanceDocument>
+  replace(
+    document: RecipeGuidanceDocument,
+    expectedUpdatedAt: string
+  ): Promise<RecipeGuidanceDocument>
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function parseStoredDocument(input: unknown): RecipeGuidanceDocument {
+  const document = parseRecipeGuidanceDocument(input)
+  if (!document) {
+    throw new RecipeGuidanceIntegrityError("Stored recipe guidance is invalid")
+  }
+  return document
+}
+
+function parseStoredDocuments(input: unknown): RecipeGuidanceDocument[] {
+  if (!Array.isArray(input)) {
+    throw new RecipeGuidanceIntegrityError("Recipe guidance store must contain a list")
+  }
+  return input.map(parseStoredDocument)
+}
+
+function validateWrite(document: RecipeGuidanceDocument): RecipeGuidanceDocument {
+  const parsed = parseRecipeGuidanceDocument(document)
+  if (!parsed) {
+    throw new RecipeGuidanceIntegrityError("Recipe guidance write is invalid")
+  }
+  return parsed
+}
+
+function sortVersions(documents: RecipeGuidanceDocument[]): RecipeGuidanceDocument[] {
+  return [...documents].sort((left, right) => right.version - left.version)
+}
+
+function isDuplicateKeyError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === 11000
+}
+
+function archivalContent(document: RecipeGuidanceDocument): string {
+  const { status, updatedAt, ...content } = document
+  return JSON.stringify(content)
+}
+
+function assertNewDraft(document: RecipeGuidanceDocument): void {
+  if (document.status !== "draft") {
+    throw new RecipeGuidanceConflictError("New recipe guidance versions must begin as drafts")
+  }
+}
+
+function assertReplacementAllowed(
+  current: RecipeGuidanceDocument,
+  next: RecipeGuidanceDocument,
+  expectedUpdatedAt: string
+): void {
+  if (current.updatedAt !== expectedUpdatedAt) {
+    throw new RecipeGuidanceConflictError("Recipe guidance changed before this update")
+  }
+  if (
+    current.id !== next.id ||
+    current.recipeId !== next.recipeId ||
+    current.recipeRevisionId !== next.recipeRevisionId ||
+    current.version !== next.version ||
+    current.createdAt !== next.createdAt ||
+    current.createdBy !== next.createdBy
+  ) {
+    throw new RecipeGuidanceConflictError("Immutable recipe guidance identity changed")
+  }
+  if (current.status === "archived") {
+    throw new RecipeGuidanceConflictError(
+      "Published and archived recipe guidance versions are immutable"
+    )
+  }
+  if (current.status === "published") {
+    if (next.status !== "archived" || archivalContent(current) !== archivalContent(next)) {
+      throw new RecipeGuidanceConflictError(
+        "Published recipe guidance content is immutable and may only be archived"
+      )
+    }
+    return
+  }
+  if (current.status === "draft" && next.status === "published") {
+    throw new RecipeGuidanceConflictError("Recipe guidance must enter review before publication")
+  }
+  if (next.status === "archived") {
+    throw new RecipeGuidanceConflictError("Only published recipe guidance can be archived")
+  }
+}
+
+function createMemoryRepository(
+  getDocuments: () => RecipeGuidanceDocument[]
+): RecipeGuidanceRepository {
+  return {
+    async listByRecipeId(recipeId) {
+      return sortVersions(getDocuments().filter((item) => item.recipeId === recipeId)).map(clone)
+    },
+    async findById(id) {
+      const document = getDocuments().find((item) => item.id === id)
+      return document ? clone(document) : null
+    },
+    async findLatestPublished(recipeId) {
+      const document = sortVersions(
+        getDocuments().filter((item) => item.recipeId === recipeId && item.status === "published")
+      )[0]
+      return document ? clone(document) : null
+    },
+    async create(input) {
+      const document = validateWrite(input)
+      assertNewDraft(document)
+      const duplicate = getDocuments().some(
+        (item) =>
+          item.id === document.id ||
+          (item.recipeId === document.recipeId && item.version === document.version)
+      )
+      if (duplicate) throw new RecipeGuidanceConflictError("Recipe guidance version already exists")
+      getDocuments().push(clone(document))
+      return clone(document)
+    },
+    async replace(input, expectedUpdatedAt) {
+      const document = validateWrite(input)
+      const index = getDocuments().findIndex((item) => item.id === document.id)
+      if (index === -1) throw new RecipeGuidanceConflictError("Recipe guidance was not found")
+      assertReplacementAllowed(getDocuments()[index], document, expectedUpdatedAt)
+      getDocuments()[index] = clone(document)
+      return clone(document)
+    },
+  }
+}
+
+async function readFileDocuments(): Promise<RecipeGuidanceDocument[]> {
+  try {
+    return parseStoredDocuments(JSON.parse(await readFile(RECIPE_GUIDANCE_FILE, "utf-8")))
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return []
+    }
+    if (error instanceof RecipeGuidanceIntegrityError) throw error
+    throw new RecipeGuidanceIntegrityError("Recipe guidance demo store could not be read")
+  }
+}
+
+async function writeFileDocuments(documents: RecipeGuidanceDocument[]): Promise<void> {
+  await mkdir(dirname(RECIPE_GUIDANCE_FILE), { recursive: true })
+  const temporaryFile = `${RECIPE_GUIDANCE_FILE}.${randomUUID()}.tmp`
+  await writeFile(temporaryFile, JSON.stringify(documents, null, 2), "utf-8")
+  await rename(temporaryFile, RECIPE_GUIDANCE_FILE)
+}
+
+function createFileRepository(): RecipeGuidanceRepository {
+  return {
+    async listByRecipeId(recipeId) {
+      return sortVersions((await readFileDocuments()).filter((item) => item.recipeId === recipeId))
+    },
+    async findById(id) {
+      return (await readFileDocuments()).find((item) => item.id === id) ?? null
+    },
+    async findLatestPublished(recipeId) {
+      return (
+        sortVersions(
+          (await readFileDocuments()).filter(
+            (item) => item.recipeId === recipeId && item.status === "published"
+          )
+        )[0] ?? null
+      )
+    },
+    async create(input) {
+      const document = validateWrite(input)
+      assertNewDraft(document)
+      const documents = await readFileDocuments()
+      const duplicate = documents.some(
+        (item) =>
+          item.id === document.id ||
+          (item.recipeId === document.recipeId && item.version === document.version)
+      )
+      if (duplicate) throw new RecipeGuidanceConflictError("Recipe guidance version already exists")
+      documents.push(document)
+      await writeFileDocuments(documents)
+      return clone(document)
+    },
+    async replace(input, expectedUpdatedAt) {
+      const document = validateWrite(input)
+      const documents = await readFileDocuments()
+      const index = documents.findIndex((item) => item.id === document.id)
+      if (index === -1) throw new RecipeGuidanceConflictError("Recipe guidance was not found")
+      assertReplacementAllowed(documents[index], document, expectedUpdatedAt)
+      documents[index] = document
+      await writeFileDocuments(documents)
+      return clone(document)
+    },
+  }
+}
+
+async function createMongoRepository(): Promise<RecipeGuidanceRepository> {
+  const collection: Collection<RecipeGuidanceMongoDocument> =
+    await getCollection<RecipeGuidanceMongoDocument>(RECIPE_GUIDANCE_COLLECTION)
+  await Promise.all([
+    collection.createIndex({ id: 1 }, { unique: true }),
+    collection.createIndex({ recipeId: 1, version: 1 }, { unique: true }),
+    collection.createIndex({ recipeId: 1, status: 1, version: -1 }),
+  ])
+
+  return {
+    async listByRecipeId(recipeId) {
+      const documents = await collection.find({ recipeId }).sort({ version: -1 }).toArray()
+      return documents.map((item) => parseStoredDocument(withoutMongoId(item)))
+    },
+    async findById(id) {
+      const document = await collection.findOne({ id })
+      return document ? parseStoredDocument(withoutMongoId(document)) : null
+    },
+    async findLatestPublished(recipeId) {
+      const document = await collection.findOne(
+        { recipeId, status: "published" },
+        { sort: { version: -1 } }
+      )
+      return document ? parseStoredDocument(withoutMongoId(document)) : null
+    },
+    async create(input) {
+      const document = validateWrite(input)
+      assertNewDraft(document)
+      try {
+        await collection.insertOne(document)
+      } catch (error) {
+        if (isDuplicateKeyError(error)) {
+          throw new RecipeGuidanceConflictError("Recipe guidance version already exists")
+        }
+        throw error
+      }
+      return clone(document)
+    },
+    async replace(input, expectedUpdatedAt) {
+      const document = validateWrite(input)
+      const current = await collection.findOne({ id: document.id })
+      if (!current) throw new RecipeGuidanceConflictError("Recipe guidance was not found")
+      assertReplacementAllowed(
+        parseStoredDocument(withoutMongoId(current)),
+        document,
+        expectedUpdatedAt
+      )
+      const result = await collection.replaceOne(
+        { id: document.id, updatedAt: expectedUpdatedAt },
+        document
+      )
+      if (result.matchedCount === 0) {
+        throw new RecipeGuidanceConflictError("Recipe guidance changed before this update")
+      }
+      return clone(document)
+    },
+  }
+}
+
+let memoryDocuments: RecipeGuidanceDocument[] = []
+let cachedRepository: RecipeGuidanceRepository | null = null
+let cachedMode: RecipeGuidanceRepositoryMode | null = null
+
+export async function getRecipeGuidanceRepository(): Promise<{
+  repository: RecipeGuidanceRepository
+  mode: RecipeGuidanceRepositoryMode
+}> {
+  if (cachedRepository && cachedMode) return { repository: cachedRepository, mode: cachedMode }
+
+  const isTestMode =
+    process.env.NODE_ENV === "test" || process.env.E2E_TEST === "1" || process.env.CI === "true"
+  if (isTestMode) {
+    cachedRepository = createMemoryRepository(() => memoryDocuments)
+    cachedMode = "memory"
+    return { repository: cachedRepository, mode: cachedMode }
+  }
+
+  if (isMongoConfigured()) {
+    cachedRepository = await createMongoRepository()
+    cachedMode = "mongodb"
+    return { repository: cachedRepository, mode: cachedMode }
+  }
+
+  if (process.env.ALLOW_DEMO_DATA === "true") {
+    cachedRepository = createFileRepository()
+    cachedMode = "file"
+    return { repository: cachedRepository, mode: cachedMode }
+  }
+
+  throw new RecipeGuidanceStoreUnavailableError(
+    "Recipe guidance datastore is not configured. Set MONGODB_URI or explicitly enable demo data."
+  )
+}
+
+export function resetRecipeGuidanceRepositoryForTests(): void {
+  memoryDocuments = []
+  cachedRepository = null
+  cachedMode = null
+}

--- a/lib/repositories/recipe-guidance-repository.ts
+++ b/lib/repositories/recipe-guidance-repository.ts
@@ -90,6 +90,8 @@ function assertReplacementAllowed(
     current.id !== next.id ||
     current.recipeId !== next.recipeId ||
     current.recipeRevisionId !== next.recipeRevisionId ||
+    JSON.stringify(current.recipeIngredientIds) !== JSON.stringify(next.recipeIngredientIds) ||
+    JSON.stringify(current.recipeStepIds) !== JSON.stringify(next.recipeStepIds) ||
     current.version !== next.version ||
     current.createdAt !== next.createdAt ||
     current.createdBy !== next.createdBy

--- a/tests/lib/recipe-guidance-migration.test.ts
+++ b/tests/lib/recipe-guidance-migration.test.ts
@@ -101,6 +101,7 @@ describe("recipe guidance migration planning", () => {
       {
         legacyGuidancePackId: "legacy-guidance-1",
         recipeId: "recipe-1",
+        recipeRevisionId: `recipe-1@${now}`,
         reason: "rebuild_from_recipe_required",
         migratable: true,
       },
@@ -117,6 +118,25 @@ describe("recipe guidance migration planning", () => {
     })
 
     expect(plan.candidates[0]).toMatchObject({ reason: "already_present", migratable: false })
+  })
+
+  it("selects only one rebuild for duplicate legacy packs of the same recipe revision", () => {
+    const recipe = buildRecipe()
+    const legacy = buildLegacyGuidance(recipe)
+    const plan = planRecipeGuidanceMigration({
+      legacyGuidance: [legacy, { ...legacy, id: "legacy-guidance-2" }],
+      recipes: [recipe],
+      existingDocuments: [],
+    })
+
+    expect(plan.candidates.map(({ reason, migratable }) => ({ reason, migratable }))).toEqual([
+      { reason: "rebuild_from_recipe_required", migratable: true },
+      { reason: "duplicate_legacy_revision", migratable: false },
+    ])
+    expect(reasonCounts(plan)).toEqual([
+      ["duplicate_legacy_revision", 1],
+      ["rebuild_from_recipe_required", 1],
+    ])
   })
 
   it("blocks missing recipes, incoherent provenance, and stale snapshots", () => {

--- a/tests/lib/recipe-guidance-migration.test.ts
+++ b/tests/lib/recipe-guidance-migration.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest"
+import { recipeToGuidanceDraft, type GuidancePack } from "@/lib/guidance"
+import {
+  planRecipeGuidanceMigration,
+  type RecipeGuidanceMigrationReason,
+} from "@/lib/recipe-guidance-migration"
+import { RECIPE_GUIDANCE_SECTION_KINDS, type RecipeGuidanceDocument } from "@/lib/recipe-guidance"
+import type { RecipeRecord } from "@/lib/recipes"
+
+const now = "2026-07-29T08:00:00.000Z"
+
+function buildRecipe(): RecipeRecord {
+  return {
+    id: "recipe-1",
+    status: "published",
+    ownerUserId: "hans",
+    audienceUserIds: ["irma"],
+    titleEn: "Fried rice",
+    titleAf: "Gebraaide rys",
+    summaryEn: "A quick meal.",
+    summaryAf: "'n Vinnige maaltyd.",
+    image: {
+      url: "/rice.jpg",
+      source: "House",
+      license: "Owned",
+      attributionText: "House",
+      retrievedAt: "2026-07-29",
+    },
+    ingredients: [{ id: "rice", quantity: "2", unit: "cups", name: "rice" }],
+    steps: [
+      {
+        id: "cook",
+        order: 1,
+        instructionEn: "Cook the rice.",
+        instructionAf: "Kook die rys.",
+      },
+    ],
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function buildLegacyGuidance(recipe: RecipeRecord): GuidancePack {
+  const draft = recipeToGuidanceDraft(recipe, "en")
+  return {
+    ...draft,
+    id: "legacy-guidance-1",
+    version: 1,
+    status: "published",
+    steps: draft.steps.map((step) => ({ ...step, id: `legacy-step-${step.order}` })),
+    source: { type: "recipe", recipeId: recipe.id },
+    createdBy: "hans",
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function buildExistingDocument(recipe: RecipeRecord): RecipeGuidanceDocument {
+  return {
+    id: "recipe-1:guidance:1",
+    recipeId: recipe.id,
+    recipeRevisionId: `${recipe.id}@${recipe.updatedAt}`,
+    recipeUpdatedAt: recipe.updatedAt,
+    recipeIngredientIds: recipe.ingredients.map((ingredient) => ingredient.id),
+    recipeStepIds: recipe.steps.map((step) => step.id),
+    version: 1,
+    status: "draft",
+    ownerUserId: recipe.ownerUserId,
+    audienceUserIds: recipe.audienceUserIds,
+    sections: RECIPE_GUIDANCE_SECTION_KINDS.map((kind) => ({
+      id: `section:${kind}`,
+      kind,
+      applicability: "required",
+      blocks: [],
+    })),
+    mediaAssets: [],
+    imageBriefs: [],
+    createdBy: "hans",
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function reasonCounts(plan: ReturnType<typeof planRecipeGuidanceMigration>) {
+  return Object.entries(plan.counts).filter(([, count]) => count > 0) as Array<
+    [RecipeGuidanceMigrationReason, number]
+  >
+}
+
+describe("recipe guidance migration planning", () => {
+  it("requires a canonical rebuild and never authorizes writes", () => {
+    const recipe = buildRecipe()
+    const plan = planRecipeGuidanceMigration({
+      legacyGuidance: [buildLegacyGuidance(recipe)],
+      recipes: [recipe],
+      existingDocuments: [],
+    })
+
+    expect(plan.writesAuthorized).toBe(false)
+    expect(plan.candidates).toEqual([
+      {
+        legacyGuidancePackId: "legacy-guidance-1",
+        recipeId: "recipe-1",
+        reason: "rebuild_from_recipe_required",
+        migratable: true,
+      },
+    ])
+    expect(reasonCounts(plan)).toEqual([["rebuild_from_recipe_required", 1]])
+  })
+
+  it("does not duplicate a recipe revision already present in the new collection", () => {
+    const recipe = buildRecipe()
+    const plan = planRecipeGuidanceMigration({
+      legacyGuidance: [buildLegacyGuidance(recipe)],
+      recipes: [recipe],
+      existingDocuments: [buildExistingDocument(recipe)],
+    })
+
+    expect(plan.candidates[0]).toMatchObject({ reason: "already_present", migratable: false })
+  })
+
+  it("blocks missing recipes, incoherent provenance, and stale snapshots", () => {
+    const recipe = buildRecipe()
+    const valid = buildLegacyGuidance(recipe)
+    const incoherent = {
+      ...valid,
+      id: "legacy-invalid",
+      source: { type: "manual" as const, recipeId: recipe.id },
+    }
+    const stale = {
+      ...valid,
+      id: "legacy-stale",
+      sourceRecipeRevisionId: "recipe-1@2026-07-28T08:00:00.000Z",
+    }
+
+    const plan = planRecipeGuidanceMigration({
+      legacyGuidance: [
+        incoherent,
+        {
+          ...valid,
+          id: "legacy-missing",
+          sourceRecipeId: "missing",
+          source: { type: "recipe", recipeId: "missing" },
+        },
+        stale,
+      ],
+      recipes: [recipe],
+      existingDocuments: [],
+    })
+
+    expect(plan.candidates.map((candidate) => candidate.reason)).toEqual([
+      "invalid_recipe_provenance",
+      "recipe_not_found",
+      "recipe_snapshot_mismatch",
+    ])
+  })
+})

--- a/tests/lib/recipe-guidance-repository.test.ts
+++ b/tests/lib/recipe-guidance-repository.test.ts
@@ -1,10 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { rm } from "fs/promises"
+import { join } from "path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { RECIPE_GUIDANCE_SECTION_KINDS } from "@/lib/recipe-guidance"
 
 const mongoMocks = vi.hoisted(() => ({
   configured: false,
   createIndex: vi.fn(),
+  findOne: vi.fn(),
   getCollection: vi.fn(),
+  insertOne: vi.fn(),
+  replaceOne: vi.fn(),
 }))
 
 vi.mock("@/lib/db/mongodb", () => ({
@@ -19,12 +24,14 @@ vi.mock("@/lib/db/mongodb", () => ({
 import {
   RECIPE_GUIDANCE_COLLECTION,
   RecipeGuidanceConflictError,
+  RecipeGuidanceIntegrityError,
   RecipeGuidanceStoreUnavailableError,
   getRecipeGuidanceRepository,
   resetRecipeGuidanceRepositoryForTests,
 } from "@/lib/repositories/recipe-guidance-repository"
 
 const now = "2026-07-29T08:00:00.000Z"
+const demoFile = join(process.cwd(), "data", "recipe-guidance-documents.json")
 
 function buildDocument() {
   return {
@@ -53,7 +60,8 @@ function buildDocument() {
 }
 
 describe("recipe guidance repository", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await rm(demoFile, { force: true })
     vi.unstubAllEnvs()
     vi.stubEnv("NODE_ENV", "test")
     vi.stubEnv("CI", "")
@@ -61,8 +69,15 @@ describe("recipe guidance repository", () => {
     vi.stubEnv("ALLOW_DEMO_DATA", "false")
     mongoMocks.configured = false
     mongoMocks.createIndex.mockReset().mockResolvedValue("index")
+    mongoMocks.findOne.mockReset()
     mongoMocks.getCollection.mockReset()
+    mongoMocks.insertOne.mockReset()
+    mongoMocks.replaceOne.mockReset()
     resetRecipeGuidanceRepositoryForTests()
+  })
+
+  afterEach(async () => {
+    await rm(demoFile, { force: true })
   })
 
   it("starts empty in test mode and stores independent document copies", async () => {
@@ -95,6 +110,30 @@ describe("recipe guidance repository", () => {
     ).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
   })
 
+  it("advances the concurrency token and rejects its reuse", async () => {
+    const { repository } = await getRecipeGuidanceRepository()
+    const document = buildDocument()
+    await repository.create(document)
+
+    await expect(
+      repository.replace({ ...document, status: "in_review" }, document.updatedAt)
+    ).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
+
+    const firstUpdate = {
+      ...document,
+      status: "in_review" as const,
+      updatedAt: "2026-07-29T08:01:00.000Z",
+    }
+    await expect(repository.replace(firstUpdate, document.updatedAt)).resolves.toEqual(firstUpdate)
+
+    await expect(
+      repository.replace(
+        { ...firstUpdate, updatedAt: "2026-07-29T08:02:00.000Z" },
+        document.updatedAt
+      )
+    ).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
+  })
+
   it("requires every new version to begin as a draft", async () => {
     const { repository } = await getRecipeGuidanceRepository()
 
@@ -123,6 +162,34 @@ describe("recipe guidance repository", () => {
     expect(await repository.listByRecipeId("missing")).toEqual([])
   })
 
+  it("serializes concurrent demo-file creates and compare-and-swap updates", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("ALLOW_DEMO_DATA", "true")
+    resetRecipeGuidanceRepositoryForTests()
+    const { repository } = await getRecipeGuidanceRepository()
+    const document = buildDocument()
+    const secondVersion = { ...document, id: "recipe-1:guidance:2", version: 2 }
+
+    await Promise.all([repository.create(document), repository.create(secondVersion)])
+    expect(await repository.listByRecipeId(document.recipeId)).toHaveLength(2)
+
+    const results = await Promise.allSettled([
+      repository.replace(
+        { ...document, status: "in_review", updatedAt: "2026-07-29T08:01:00.000Z" },
+        document.updatedAt
+      ),
+      repository.replace(
+        { ...document, status: "in_review", updatedAt: "2026-07-29T08:02:00.000Z" },
+        document.updatedAt
+      ),
+    ])
+
+    expect(results.map((result) => result.status)).toEqual(["fulfilled", "rejected"])
+    expect(results[1].status === "rejected" ? results[1].reason : null).toBeInstanceOf(
+      RecipeGuidanceConflictError
+    )
+  })
+
   it("uses the dedicated live collection and creates version indexes", async () => {
     vi.stubEnv("NODE_ENV", "production")
     mongoMocks.configured = true
@@ -142,5 +209,47 @@ describe("recipe guidance repository", () => {
       status: 1,
       version: -1,
     })
+  })
+
+  it("maps Mongo duplicate and zero-match compare-and-swap results to conflicts", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    mongoMocks.configured = true
+    mongoMocks.getCollection.mockResolvedValue({
+      createIndex: mongoMocks.createIndex,
+      findOne: mongoMocks.findOne,
+      insertOne: mongoMocks.insertOne,
+      replaceOne: mongoMocks.replaceOne,
+    })
+    resetRecipeGuidanceRepositoryForTests()
+    const { repository } = await getRecipeGuidanceRepository()
+    const document = buildDocument()
+
+    mongoMocks.insertOne.mockRejectedValueOnce({ code: 11000 })
+    await expect(repository.create(document)).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
+
+    mongoMocks.findOne.mockResolvedValueOnce(document)
+    mongoMocks.replaceOne.mockResolvedValueOnce({ matchedCount: 0 })
+    await expect(
+      repository.replace(
+        { ...document, status: "in_review", updatedAt: "2026-07-29T08:01:00.000Z" },
+        document.updatedAt
+      )
+    ).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
+  })
+
+  it("fails closed when Mongo returns an invalid stored document", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    mongoMocks.configured = true
+    mongoMocks.findOne.mockResolvedValueOnce({ id: "invalid" })
+    mongoMocks.getCollection.mockResolvedValue({
+      createIndex: mongoMocks.createIndex,
+      findOne: mongoMocks.findOne,
+    })
+    resetRecipeGuidanceRepositoryForTests()
+    const { repository } = await getRecipeGuidanceRepository()
+
+    await expect(repository.findById("invalid")).rejects.toBeInstanceOf(
+      RecipeGuidanceIntegrityError
+    )
   })
 })

--- a/tests/lib/recipe-guidance-repository.test.ts
+++ b/tests/lib/recipe-guidance-repository.test.ts
@@ -134,6 +134,33 @@ describe("recipe guidance repository", () => {
     ).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
   })
 
+  it("keeps recipe ingredient and step manifests immutable within a version", async () => {
+    const { repository } = await getRecipeGuidanceRepository()
+    const document = buildDocument()
+    await repository.create(document)
+
+    await expect(
+      repository.replace(
+        {
+          ...document,
+          recipeIngredientIds: ["invented-ingredient"],
+          updatedAt: "2026-07-29T08:01:00.000Z",
+        },
+        document.updatedAt
+      )
+    ).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
+    await expect(
+      repository.replace(
+        {
+          ...document,
+          recipeStepIds: ["invented-step"],
+          updatedAt: "2026-07-29T08:01:00.000Z",
+        },
+        document.updatedAt
+      )
+    ).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
+  })
+
   it("requires every new version to begin as a draft", async () => {
     const { repository } = await getRecipeGuidanceRepository()
 

--- a/tests/lib/recipe-guidance-repository.test.ts
+++ b/tests/lib/recipe-guidance-repository.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { RECIPE_GUIDANCE_SECTION_KINDS } from "@/lib/recipe-guidance"
+
+const mongoMocks = vi.hoisted(() => ({
+  configured: false,
+  createIndex: vi.fn(),
+  getCollection: vi.fn(),
+}))
+
+vi.mock("@/lib/db/mongodb", () => ({
+  getCollection: mongoMocks.getCollection,
+  isMongoConfigured: () => mongoMocks.configured,
+  withoutMongoId: <T extends { _id?: unknown }>(document: T) => {
+    const { _id, ...rest } = document
+    return rest
+  },
+}))
+
+import {
+  RECIPE_GUIDANCE_COLLECTION,
+  RecipeGuidanceConflictError,
+  RecipeGuidanceStoreUnavailableError,
+  getRecipeGuidanceRepository,
+  resetRecipeGuidanceRepositoryForTests,
+} from "@/lib/repositories/recipe-guidance-repository"
+
+const now = "2026-07-29T08:00:00.000Z"
+
+function buildDocument() {
+  return {
+    id: "recipe-1:guidance:1",
+    recipeId: "recipe-1",
+    recipeRevisionId: `recipe-1@${now}`,
+    recipeUpdatedAt: now,
+    recipeIngredientIds: ["ingredient-1"],
+    recipeStepIds: ["step-1"],
+    version: 1,
+    status: "draft" as const,
+    ownerUserId: "hans",
+    audienceUserIds: ["irma"],
+    sections: RECIPE_GUIDANCE_SECTION_KINDS.map((kind) => ({
+      id: `section:${kind}`,
+      kind,
+      applicability: "required" as const,
+      blocks: [],
+    })),
+    mediaAssets: [],
+    imageBriefs: [],
+    createdBy: "hans",
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+describe("recipe guidance repository", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+    vi.stubEnv("NODE_ENV", "test")
+    vi.stubEnv("CI", "")
+    vi.stubEnv("E2E_TEST", "")
+    vi.stubEnv("ALLOW_DEMO_DATA", "false")
+    mongoMocks.configured = false
+    mongoMocks.createIndex.mockReset().mockResolvedValue("index")
+    mongoMocks.getCollection.mockReset()
+    resetRecipeGuidanceRepositoryForTests()
+  })
+
+  it("starts empty in test mode and stores independent document copies", async () => {
+    const { repository, mode } = await getRecipeGuidanceRepository()
+    const document = buildDocument()
+
+    expect(mode).toBe("memory")
+    expect(await repository.listByRecipeId(document.recipeId)).toEqual([])
+
+    const stored = await repository.create(document)
+    stored.ownerUserId = "changed-outside-repository"
+
+    expect((await repository.findById(document.id))?.ownerUserId).toBe("hans")
+    expect(await repository.listByRecipeId(document.recipeId)).toHaveLength(1)
+  })
+
+  it("rejects duplicate versions and stale replacements", async () => {
+    const { repository } = await getRecipeGuidanceRepository()
+    const document = buildDocument()
+    await repository.create(document)
+
+    await expect(repository.create({ ...document, id: "another-id" })).rejects.toBeInstanceOf(
+      RecipeGuidanceConflictError
+    )
+    await expect(
+      repository.replace(
+        { ...document, status: "in_review", updatedAt: "2026-07-29T08:01:00.000Z" },
+        "2026-07-29T07:59:00.000Z"
+      )
+    ).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
+  })
+
+  it("requires every new version to begin as a draft", async () => {
+    const { repository } = await getRecipeGuidanceRepository()
+
+    await expect(
+      repository.create({ ...buildDocument(), status: "in_review" })
+    ).rejects.toBeInstanceOf(RecipeGuidanceConflictError)
+  })
+
+  it("fails closed when ordinary runtime has neither Mongo nor explicit demo mode", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    resetRecipeGuidanceRepositoryForTests()
+
+    await expect(getRecipeGuidanceRepository()).rejects.toBeInstanceOf(
+      RecipeGuidanceStoreUnavailableError
+    )
+  })
+
+  it("uses an empty file store only when demo data is explicitly enabled", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("ALLOW_DEMO_DATA", "true")
+    resetRecipeGuidanceRepositoryForTests()
+
+    const { repository, mode } = await getRecipeGuidanceRepository()
+
+    expect(mode).toBe("file")
+    expect(await repository.listByRecipeId("missing")).toEqual([])
+  })
+
+  it("uses the dedicated live collection and creates version indexes", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    mongoMocks.configured = true
+    mongoMocks.getCollection.mockResolvedValue({ createIndex: mongoMocks.createIndex })
+    resetRecipeGuidanceRepositoryForTests()
+
+    const { mode } = await getRecipeGuidanceRepository()
+
+    expect(mode).toBe("mongodb")
+    expect(mongoMocks.getCollection).toHaveBeenCalledWith(RECIPE_GUIDANCE_COLLECTION)
+    expect(mongoMocks.createIndex).toHaveBeenCalledWith(
+      { recipeId: 1, version: 1 },
+      { unique: true }
+    )
+    expect(mongoMocks.createIndex).toHaveBeenCalledWith({
+      recipeId: 1,
+      status: 1,
+      version: -1,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add a dedicated `recipe_guidance_documents` repository with empty test memory, explicit-demo JSON, and live Mongo modes
- validate stored documents on read/write, enforce unique version indexes, advancing optimistic concurrency tokens, draft-first creation, and immutable published content
- serialize explicit-demo file mutations across read/check/write so concurrent requests preserve conflict guarantees
- add a read-only legacy migration planner that validates provenance/snapshots and selects only one canonical rebuild per recipe revision
- document the collection decision, runtime modes, migration boundary, and next slice

## Why

PR #156 established a richer recipe document aggregate with immutable recipe revision manifests, canonical sections, media lifecycles, and publication evidence. Storing those records in the existing compact `task_guidance` collection would couple two different lifecycles and weaken rollback and validation boundaries.

This slice therefore keeps `task_guidance` and its bindings unchanged and readable while giving recipe documents an independent collection and migration path.

## Impact

- ordinary runtime without Mongo fails closed for recipe documents
- tests/E2E start with an empty in-memory store
- local JSON persistence requires explicit `ALLOW_DEMO_DATA=true` and does not seed content
- no migration apply, production data write, API/UI route, Sluice call, generation enablement, publication, OmniPost action, or deployment is introduced

## Validation

Passed on review-remediation head `44b1805`:

- `pnpm exec vitest run tests/lib/recipe-guidance-repository.test.ts tests/lib/recipe-guidance-migration.test.ts tests/lib/recipe-guidance.test.ts` (42/42)
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- focused Prettier
- `git diff --check`

All seven CI checks passed on predecessor head `bc8d85f`; exact-head CI for `44b1805` is running.

## Review remediation

Addressed all three actionable Codex/subagent clusters:

- reject replacements unless `updatedAt` strictly advances, preventing CAS token reuse
- serialize explicit-demo file create/replace read-check-write sequences
- deduplicate migration rebuild candidates by immutable recipe revision

Expanded production-adapter coverage for Mongo duplicate-key mapping, parsed reads, invalid stored documents, and zero-match compare-and-swap conflicts.

## Build boundary

The isolated worktree dependency install timed out, so validation used a junction to the primary checkout's lockfile-matching `node_modules`; no package or lockfile changed. Default Turbopack rejected that external junction before compilation. `next build --webpack` compiled successfully, then failed generated route types for unchanged `app/api/ai/refine-description/route.ts`, with an optional OpenTelemetry warning from the shared dependency layout. Exact-head CI is the canonical production-build gate; CI Production Build passed on the predecessor head.

## Migration safety

The planner always returns `writesAuthorized: false`. Coherent legacy recipe guidance selects one `rebuild_from_recipe_required` candidate per revision; duplicate packs are classified `duplicate_legacy_revision`, missing recipes/incoherent provenance/stale snapshots are blocked, and already-present recipe revisions are skipped. No legacy `published` state is copied.

Baton: `3a36dc41-3376-441a-a11d-f2b5bef648c4`

Predecessor: #156