### PR TITLE
Add deterministic recipe guidance preview APIs

### DIFF
--- a/app/api/recipes/[id]/guidance-drafts/preview/route.ts
+++ b/app/api/recipes/[id]/guidance-drafts/preview/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server"
+import { withRole } from "@/lib/auth/rbac"
+import { RecipeGuidanceBuildError, buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
+import { logger } from "@/lib/logger"
+import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
+
+export const POST = withRole("admin")(async (_request, context) => {
+  try {
+    const recipeId = (await context.params)?.id
+    if (!recipeId) {
+      return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+    }
+
+    const recipe = await getRecipeById(recipeId)
+    if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+
+    const { repository, mode } = await getRecipeGuidanceRepository()
+    const existingDocuments = await repository.listByRecipeId(recipeId)
+    const nextVersion = Math.max(0, ...existingDocuments.map((document) => document.version)) + 1
+    const document = buildRecipeGuidanceDraft(recipe, {
+      version: nextVersion,
+      createdBy: context.userId,
+      now: new Date().toISOString(),
+    })
+
+    return NextResponse.json({
+      data: { recipe, document },
+      summary: { mode, persisted: false, nextVersion },
+    })
+  } catch (error) {
+    if (error instanceof RecipeGuidanceBuildError) {
+      return NextResponse.json({ error: "Recipe is incomplete for guidance" }, { status: 422 })
+    }
+    logger.error("Failed to preview recipe guidance draft", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Recipe guidance datastore is unavailable" }, { status: 503 })
+  }
+})

--- a/app/api/recipes/[id]/guidance-drafts/route.ts
+++ b/app/api/recipes/[id]/guidance-drafts/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server"
+import { withRole } from "@/lib/auth/rbac"
+import { logger } from "@/lib/logger"
+import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
+
+export const GET = withRole("admin")(async (_request, context) => {
+  try {
+    const recipeId = (await context.params)?.id
+    if (!recipeId) {
+      return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+    }
+    if (!(await getRecipeById(recipeId))) {
+      return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+    }
+
+    const { repository, mode } = await getRecipeGuidanceRepository()
+    const documents = await repository.listByRecipeId(recipeId)
+    return NextResponse.json({
+      data: { documents },
+      summary: { count: documents.length, mode },
+    })
+  } catch (error) {
+    logger.error("Failed to list recipe guidance drafts", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Recipe guidance datastore is unavailable" }, { status: 503 })
+  }
+})

--- a/app/api/recipes/[id]/guidance/route.ts
+++ b/app/api/recipes/[id]/guidance/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
 import { logger } from "@/lib/logger"
+import { createRecipeRevisionId } from "@/lib/recipe-guidance"
 import { isRecipeAudienceMatch } from "@/lib/recipes"
 import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
 import { getRecipeById } from "@/lib/repositories/recipe-repository"
@@ -43,6 +44,12 @@ export const GET = withRole(
       return NextResponse.json(
         { error: "You do not have access to this guidance" },
         { status: 403 }
+      )
+    }
+    if (document.recipeRevisionId !== createRecipeRevisionId(recipe.id, recipe.updatedAt)) {
+      return NextResponse.json(
+        { error: "Published guidance recipe revision is unavailable" },
+        { status: 409 }
       )
     }
 

--- a/app/api/recipes/[id]/guidance/route.ts
+++ b/app/api/recipes/[id]/guidance/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server"
+import { withRole } from "@/lib/auth/rbac"
+import { logger } from "@/lib/logger"
+import { isRecipeAudienceMatch } from "@/lib/recipes"
+import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
+
+export const GET = withRole(
+  "admin",
+  "operator",
+  "employee",
+  "resident"
+)(async (_request, context) => {
+  try {
+    const recipeId = (await context.params)?.id
+    if (!recipeId) {
+      return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+    }
+
+    const recipe = await getRecipeById(recipeId)
+    if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+    if (context.role !== "admin") {
+      if (recipe.status !== "published") {
+        return NextResponse.json({ error: "Recipe is not published" }, { status: 403 })
+      }
+      if (!isRecipeAudienceMatch(recipe.audienceUserIds, context.userId)) {
+        return NextResponse.json(
+          { error: "You do not have access to this recipe" },
+          { status: 403 }
+        )
+      }
+    }
+
+    const { repository } = await getRecipeGuidanceRepository()
+    const document = await repository.findLatestPublished(recipeId)
+    if (!document) {
+      return NextResponse.json({ error: "Published recipe guidance not found" }, { status: 404 })
+    }
+    if (
+      context.role !== "admin" &&
+      !isRecipeAudienceMatch(document.audienceUserIds, context.userId)
+    ) {
+      return NextResponse.json(
+        { error: "You do not have access to this guidance" },
+        { status: 403 }
+      )
+    }
+
+    return NextResponse.json({
+      data: { recipe, document },
+      summary: { version: document.version },
+    })
+  } catch (error) {
+    logger.error("Failed to read published recipe guidance", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Recipe guidance datastore is unavailable" }, { status: 503 })
+  }
+})

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -53,7 +53,9 @@ image-brief content.
   version with `persisted: false`; it does not call repository create/replace methods.
 - `GET /api/recipes/:id/guidance-drafts` is admin-only and lists stored versions for review.
 - `GET /api/recipes/:id/guidance` returns only the latest published version after checking both the
-  recipe and document audience for non-admin users.
+  recipe and document audience for non-admin users. It returns the recipe alongside the document
+  only when their immutable revision IDs match; until historical recipe snapshots are available, a
+  stale published document fails closed instead of resolving references against newer facts.
 - Preview and published-read responses include the authorized canonical recipe snapshot so clients
   can resolve immutable ingredient and step references without reconstructing facts.
 - Every route fails closed when the dedicated guidance store is unavailable. No route in this slice

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -47,7 +47,8 @@ Keeping it separate prevents those invariants from weakening the smaller, task-o
 It copies canonical ingredient and ordered step IDs, converts recipe timers to seconds, carries the
 bilingual title and summary as recipe-sourced (not human-reviewed) text, and adapts licensed hero
 media into `review_required` or `unavailable` state. It never invents safety, allergen, storage, or
-image-brief content.
+image-brief content. A zero-minute recipe value means no timer and is omitted because guidance timer
+durations must be positive.
 
 - `POST /api/recipes/:id/guidance-drafts/preview` is admin-only and returns the next deterministic
   version with `persisted: false`; it does not call repository create/replace methods.

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -41,6 +41,24 @@ Keeping it separate prevents those invariants from weakening the smaller, task-o
   canonical recipe. It selects at most one rebuild for each recipe revision and never promotes
   legacy publication or review state automatically.
 
+### Deterministic recipe draft and read boundary
+
+`buildRecipeGuidanceDraft()` maps one immutable recipe snapshot into the fixed nine-section order.
+It copies canonical ingredient and ordered step IDs, converts recipe timers to seconds, carries the
+bilingual title and summary as recipe-sourced (not human-reviewed) text, and adapts licensed hero
+media into `review_required` or `unavailable` state. It never invents safety, allergen, storage, or
+image-brief content.
+
+- `POST /api/recipes/:id/guidance-drafts/preview` is admin-only and returns the next deterministic
+  version with `persisted: false`; it does not call repository create/replace methods.
+- `GET /api/recipes/:id/guidance-drafts` is admin-only and lists stored versions for review.
+- `GET /api/recipes/:id/guidance` returns only the latest published version after checking both the
+  recipe and document audience for non-admin users.
+- Preview and published-read responses include the authorized canonical recipe snapshot so clients
+  can resolve immutable ingredient and step references without reconstructing facts.
+- Every route fails closed when the dedicated guidance store is unavailable. No route in this slice
+  performs Sluice work, migration apply, publication, OmniPost actions, or deployment.
+
 ## Request flow
 
 1. A resident opens Guidance from a task and captures or chooses a photo.

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -48,7 +48,8 @@ It copies canonical ingredient and ordered step IDs, converts recipe timers to s
 bilingual title and summary as recipe-sourced (not human-reviewed) text, and adapts licensed hero
 media into `review_required` or `unavailable` state. It never invents safety, allergen, storage, or
 image-brief content. A zero-minute recipe value means no timer and is omitted because guidance timer
-durations must be positive.
+durations must be positive. A zero-serving recipe sentinel is likewise omitted because guidance
+serving counts must be positive; other valid preparation/cooking metrics remain available.
 
 - `POST /api/recipes/:id/guidance-drafts/preview` is admin-only and returns the next deterministic
   version with `persisted: false`; it does not call repository create/replace methods.

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,4 +94,5 @@ Dated session continuity notes (root cause, files changed, verification, next-ow
 | [2026-07-22-project-datastore-ai-hardening.md](handoffs/2026-07-22-project-datastore-ai-hardening.md)     | Project datastore API and AI project suggestion hardening closeout                   |
 | [2026-07-28-recipe-guidance-phase1-contracts.md](handoffs/2026-07-28-recipe-guidance-phase1-contracts.md) | Recipe guidance Phase 1 typed document and media contracts                           |
 | [2026-07-29-recipe-guidance-persistence.md](handoffs/2026-07-29-recipe-guidance-persistence.md)           | Dedicated recipe guidance repository and safe migration boundary                     |
+| [2026-07-29-recipe-guidance-builder-api.md](handoffs/2026-07-29-recipe-guidance-builder-api.md)           | Deterministic recipe draft builder and bounded preview/read APIs                     |
 | [2026-07-28-user-selectable-themes.md](handoffs/2026-07-28-user-selectable-themes.md)                     | User-selectable workspace themes implementation, review, and merge handoff           |

--- a/docs/handoffs/2026-07-29-recipe-guidance-builder-api.md
+++ b/docs/handoffs/2026-07-29-recipe-guidance-builder-api.md
@@ -51,7 +51,7 @@ pnpm exec prettier --check <changed TypeScript and Markdown files>
 git diff --check
 ```
 
-- Focused result after review remediation: 4 files, 51 tests passed.
+- Focused result after review remediation: 4 files, 52 tests passed.
 - Production build passed with all 125 routes generated, including the three new recipe-guidance
   routes.
 - Exact-head review remediation rejects a published read when only a newer recipe revision is
@@ -59,6 +59,7 @@ git diff --check
   facts.
 - Zero-minute recipe values are treated as no timer so valid recipes do not produce an invalid
   guidance timer.
+- Zero-serving recipe sentinels are omitted while valid preparation and cooking metrics remain.
 - Browser verification is not applicable because this slice adds no page or interactive UI.
 - Exact-head CI remains required before merge.
 

--- a/docs/handoffs/2026-07-29-recipe-guidance-builder-api.md
+++ b/docs/handoffs/2026-07-29-recipe-guidance-builder-api.md
@@ -51,12 +51,14 @@ pnpm exec prettier --check <changed TypeScript and Markdown files>
 git diff --check
 ```
 
-- Focused result after exact-revision review remediation: 4 files, 50 tests passed.
+- Focused result after review remediation: 4 files, 51 tests passed.
 - Production build passed with all 125 routes generated, including the three new recipe-guidance
   routes.
 - Exact-head review remediation rejects a published read when only a newer recipe revision is
   available, preventing immutable ingredient and step references from resolving against changed
   facts.
+- Zero-minute recipe values are treated as no timer so valid recipes do not produce an invalid
+  guidance timer.
 - Browser verification is not applicable because this slice adds no page or interactive UI.
 - Exact-head CI remains required before merge.
 

--- a/docs/handoffs/2026-07-29-recipe-guidance-builder-api.md
+++ b/docs/handoffs/2026-07-29-recipe-guidance-builder-api.md
@@ -1,0 +1,72 @@
+# Recipe guidance deterministic builder and read API handoff
+
+- **Date:** 2026-07-29
+- **Repository:** `C:\Users\smitj\repos\house-of-veritas`
+- **Worktree:** `C:\tmp\hov-recipe-guidance-builder-api`
+- **Branch:** `feat/recipe-guidance-builder-api`
+- **Base:** `origin/main` at `4375160b66ac9bece1229413fe77d51c0ccd2869`
+- **Predecessor:** PR [#157](https://github.com/neuralliquid/house-of-veritas/pull/157)
+- **Baton task:** `35ee0bfe-73bf-4d43-b689-320fd1cfc83e`
+- **Risk tier:** API/data workflow; read and non-persisting preview only
+
+## Outcome
+
+Added the deterministic bridge from canonical `RecipeRecord` snapshots to versioned
+`RecipeGuidanceDocument` drafts and exposed bounded preview/read surfaces.
+
+- Builds the fixed nine-section order with stable IDs for an explicit version and timestamp.
+- Preserves immutable recipe revision, ingredient, and ordered step manifests.
+- Carries title and summary in both languages as recipe-sourced text requiring later human review.
+- Converts recipe step timers to structured seconds without changing their meaning.
+- Keeps licensed hero media review-required and creates no image briefs or generated-media claims.
+- Rejects recipes without canonical ingredients or steps and schema-validates the completed draft.
+- Lists stored draft versions for admins without mutating them.
+- Produces an admin-only preview of the next version and explicitly reports `persisted: false`.
+- Returns only the latest published guidance to authorized recipe/document audience members.
+- Includes the authorized recipe snapshot beside reference-based documents for deterministic
+  rendering.
+
+## Changed files
+
+- `lib/recipe-guidance-builder.ts`
+- `app/api/recipes/[id]/guidance-drafts/route.ts`
+- `app/api/recipes/[id]/guidance-drafts/preview/route.ts`
+- `app/api/recipes/[id]/guidance/route.ts`
+- `tests/lib/recipe-guidance-builder.test.ts`
+- `tests/api/recipe-guidance.test.ts`
+- `docs/05-project/task-guidance-architecture.md`
+- `docs/handoffs/2026-07-29-recipe-guidance-builder-api.md`
+- `docs/README.md`
+
+## Verification
+
+Passed locally:
+
+```text
+pnpm exec vitest run tests/lib/recipe-guidance-builder.test.ts tests/api/recipe-guidance.test.ts tests/lib/recipe-guidance.test.ts tests/lib/recipe-guidance-repository.test.ts
+pnpm exec tsc --noEmit
+pnpm run lint
+pnpm run build
+pnpm exec prettier --check <changed TypeScript and Markdown files>
+git diff --check
+```
+
+- Focused result before final closeout: 4 files, 49 tests passed.
+- Production build passed with all 125 routes generated, including the three new recipe-guidance
+  routes.
+- Browser verification is not applicable because this slice adds no page or interactive UI.
+- Exact-head CI remains required before merge.
+
+## Residual boundary and next slice
+
+No preview is persisted. No authoring update, review transition, publication, migration apply,
+Sluice request, public package, OmniPost action, or deployment is implemented. The next bounded
+slice can add explicit draft creation and reviewed section updates with optimistic concurrency, or
+build the text-first author/reader rendering against these read contracts.
+
+## Trace envelope
+
+- **Task:** `35ee0bfe-73bf-4d43-b689-320fd1cfc83e`
+- **Routing:** Veritas Ledger/data, Gateway/routes, Journey/Compass workflow, Proof/verification
+- **External effects:** Baton and GitHub workflow only; no data, provider, publication, or deploy
+  effects

--- a/docs/handoffs/2026-07-29-recipe-guidance-builder-api.md
+++ b/docs/handoffs/2026-07-29-recipe-guidance-builder-api.md
@@ -24,7 +24,7 @@ Added the deterministic bridge from canonical `RecipeRecord` snapshots to versio
 - Produces an admin-only preview of the next version and explicitly reports `persisted: false`.
 - Returns only the latest published guidance to authorized recipe/document audience members.
 - Includes the authorized recipe snapshot beside reference-based documents for deterministic
-  rendering.
+  rendering, and fails closed if that snapshot no longer matches the published document revision.
 
 ## Changed files
 
@@ -51,9 +51,12 @@ pnpm exec prettier --check <changed TypeScript and Markdown files>
 git diff --check
 ```
 
-- Focused result before final closeout: 4 files, 49 tests passed.
+- Focused result after exact-revision review remediation: 4 files, 50 tests passed.
 - Production build passed with all 125 routes generated, including the three new recipe-guidance
   routes.
+- Exact-head review remediation rejects a published read when only a newer recipe revision is
+  available, preventing immutable ingredient and step references from resolving against changed
+  facts.
 - Browser verification is not applicable because this slice adds no page or interactive UI.
 - Exact-head CI remains required before merge.
 

--- a/lib/recipe-guidance-builder.ts
+++ b/lib/recipe-guidance-builder.ts
@@ -36,6 +36,7 @@ function buildSections(
     let blocks: RecipeGuidanceBlock[] = []
 
     if (kind === "identity") {
+      const servings = recipe.servings === 0 ? undefined : recipe.servings
       applicability = "required"
       blocks = [
         {
@@ -55,14 +56,14 @@ function buildSections(
         },
       ]
       if (
-        recipe.servings !== undefined ||
+        servings !== undefined ||
         recipe.prepMinutes !== undefined ||
         recipe.cookMinutes !== undefined
       ) {
         blocks.push({
           id: `${id}:metrics`,
           type: "metrics",
-          servings: recipe.servings,
+          ...(servings === undefined ? {} : { servings }),
           prepMinutes: recipe.prepMinutes,
           cookMinutes: recipe.cookMinutes,
         })

--- a/lib/recipe-guidance-builder.ts
+++ b/lib/recipe-guidance-builder.ts
@@ -1,0 +1,159 @@
+import {
+  RECIPE_GUIDANCE_SECTION_KINDS,
+  createRecipeRevisionId,
+  parseRecipeGuidanceDocument,
+  recipeHeroToReviewRequiredMedia,
+  type RecipeGuidanceBlock,
+  type RecipeGuidanceDocument,
+  type RecipeGuidanceSection,
+  type RecipeGuidanceSectionKind,
+} from "@/lib/recipe-guidance"
+import type { RecipeRecord } from "@/lib/recipes"
+
+export interface BuildRecipeGuidanceDraftOptions {
+  version: number
+  createdBy: string
+  now: string
+}
+
+export class RecipeGuidanceBuildError extends Error {}
+
+function sectionId(documentId: string, kind: RecipeGuidanceSectionKind): string {
+  return `${documentId}:section:${kind}`
+}
+
+function buildSections(
+  recipe: RecipeRecord,
+  documentId: string,
+  recipeRevisionId: string,
+  heroAssetId: string
+): RecipeGuidanceSection[] {
+  const steps = recipe.steps.slice().sort((left, right) => left.order - right.order)
+
+  return RECIPE_GUIDANCE_SECTION_KINDS.map((kind) => {
+    const id = sectionId(documentId, kind)
+    let applicability: RecipeGuidanceSection["applicability"] = "optional"
+    let blocks: RecipeGuidanceBlock[] = []
+
+    if (kind === "identity") {
+      applicability = "required"
+      blocks = [
+        {
+          id: `${id}:title`,
+          type: "text",
+          source: "recipe",
+          text: { en: recipe.titleEn, af: recipe.titleAf },
+        },
+        {
+          id: `${id}:summary`,
+          type: "text",
+          source: "recipe",
+          text: {
+            en: recipe.summaryEn ?? recipe.titleEn,
+            af: recipe.summaryAf ?? recipe.titleAf,
+          },
+        },
+      ]
+      if (
+        recipe.servings !== undefined ||
+        recipe.prepMinutes !== undefined ||
+        recipe.cookMinutes !== undefined
+      ) {
+        blocks.push({
+          id: `${id}:metrics`,
+          type: "metrics",
+          servings: recipe.servings,
+          prepMinutes: recipe.prepMinutes,
+          cookMinutes: recipe.cookMinutes,
+        })
+      }
+    } else if (kind === "hero") {
+      blocks = [{ id: `${id}:media`, type: "media_reference", mediaAssetId: heroAssetId }]
+    } else if (kind === "ingredients") {
+      applicability = "required"
+      blocks = [
+        {
+          id: `${id}:ingredients`,
+          type: "ingredient_references",
+          recipeRevisionId,
+          ingredientIds: recipe.ingredients.map((ingredient) => ingredient.id),
+        },
+      ]
+    } else if (kind === "cooking") {
+      applicability = "required"
+      blocks = steps.map((step, index) => ({
+        id: `${id}:step:${index + 1}`,
+        type: "step_reference",
+        recipeRevisionId,
+        recipeStepId: step.id,
+        ...(step.timerMinutes === undefined
+          ? {}
+          : { timer: { minimumSeconds: step.timerMinutes * 60 } }),
+      }))
+    } else if (kind === "provenance_and_feedback") {
+      applicability = "required"
+      blocks = [
+        {
+          id: `${id}:attribution`,
+          type: "text",
+          source: "recipe",
+          text: {
+            en: recipe.image.attributionText,
+            af: recipe.image.attributionText,
+          },
+        },
+      ]
+    }
+
+    return { id, kind, applicability, blocks }
+  })
+}
+
+export function buildRecipeGuidanceDraft(
+  recipe: RecipeRecord,
+  options: BuildRecipeGuidanceDraftOptions
+): RecipeGuidanceDocument {
+  if (!Number.isInteger(options.version) || options.version < 1) {
+    throw new RecipeGuidanceBuildError("Recipe guidance version must be a positive integer")
+  }
+  if (recipe.ingredients.length === 0 || recipe.steps.length === 0) {
+    throw new RecipeGuidanceBuildError("Recipe guidance requires canonical ingredients and steps")
+  }
+
+  const documentId = `${recipe.id}:guidance:${options.version}`
+  const recipeRevisionId = createRecipeRevisionId(recipe.id, recipe.updatedAt)
+  const heroSectionId = sectionId(documentId, "hero")
+  const heroAsset = {
+    ...recipeHeroToReviewRequiredMedia(recipe, heroSectionId),
+    id: `${documentId}:hero`,
+  }
+  const audienceUserIds =
+    recipe.audienceUserIds.length > 0 ? [...new Set(recipe.audienceUserIds)] : [recipe.ownerUserId]
+
+  const draft = parseRecipeGuidanceDocument({
+    id: documentId,
+    recipeId: recipe.id,
+    recipeRevisionId,
+    recipeUpdatedAt: recipe.updatedAt,
+    recipeIngredientIds: recipe.ingredients.map((ingredient) => ingredient.id),
+    recipeStepIds: recipe.steps
+      .slice()
+      .sort((left, right) => left.order - right.order)
+      .map((step) => step.id),
+    version: options.version,
+    status: "draft",
+    ownerUserId: recipe.ownerUserId,
+    audienceUserIds,
+    sections: buildSections(recipe, documentId, recipeRevisionId, heroAsset.id),
+    mediaAssets: [heroAsset],
+    imageBriefs: [],
+    createdBy: options.createdBy,
+    createdAt: options.now,
+    updatedAt: options.now,
+  })
+
+  if (!draft) {
+    throw new RecipeGuidanceBuildError("Canonical recipe guidance draft is invalid")
+  }
+  return draft
+}

--- a/lib/recipe-guidance-builder.ts
+++ b/lib/recipe-guidance-builder.ts
@@ -86,7 +86,7 @@ function buildSections(
         type: "step_reference",
         recipeRevisionId,
         recipeStepId: step.id,
-        ...(step.timerMinutes === undefined
+        ...(step.timerMinutes === undefined || step.timerMinutes === 0
           ? {}
           : { timer: { minimumSeconds: step.timerMinutes * 60 } }),
       }))

--- a/tests/api/recipe-guidance.test.ts
+++ b/tests/api/recipe-guidance.test.ts
@@ -154,4 +154,22 @@ describe("recipe guidance APIs", () => {
     expect(response.status).toBe(403)
     expect(repository.findLatestPublished).not.toHaveBeenCalled()
   })
+
+  it("fails closed instead of pairing a document with a newer recipe revision", async () => {
+    vi.mocked(getRecipeById).mockResolvedValue({
+      ...recipe,
+      ingredients: [{ id: "ingredient-new", name: "Updated rice" }],
+      updatedAt: "2026-07-29T10:00:00.000Z",
+    })
+
+    const response = await readPublished(
+      requestFor("/api/recipes/recipe-1/guidance", "irma", "resident"),
+      routeContext
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: "Published guidance recipe revision is unavailable",
+    })
+  })
 })

--- a/tests/api/recipe-guidance.test.ts
+++ b/tests/api/recipe-guidance.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { GET as listDrafts } from "@/app/api/recipes/[id]/guidance-drafts/route"
+import { POST as previewDraft } from "@/app/api/recipes/[id]/guidance-drafts/preview/route"
+import { GET as readPublished } from "@/app/api/recipes/[id]/guidance/route"
+import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
+import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
+import type { RecipeRecord } from "@/lib/recipes"
+
+vi.mock("@/lib/repositories/recipe-guidance-repository", () => ({
+  getRecipeGuidanceRepository: vi.fn(),
+}))
+
+vi.mock("@/lib/repositories/recipe-repository", () => ({
+  getRecipeById: vi.fn(),
+}))
+
+const routeContext = { params: Promise.resolve({ id: "recipe-1" }) }
+const recipe: RecipeRecord = {
+  id: "recipe-1",
+  status: "published",
+  ownerUserId: "hans",
+  audienceUserIds: ["hans", "irma"],
+  titleEn: "Household supper",
+  titleAf: "Huishoudelike aandete",
+  image: {
+    url: "https://images.example/recipe.jpg",
+    source: "Example library",
+    license: "CC BY 4.0",
+    attributionText: "Example Author, CC BY 4.0",
+    retrievedAt: "2026-07-28",
+  },
+  ingredients: [{ id: "ingredient-1", name: "Rice" }],
+  steps: [
+    {
+      id: "step-1",
+      order: 1,
+      instructionEn: "Cook the rice.",
+      instructionAf: "Kook die rys.",
+    },
+  ],
+  createdAt: "2026-07-28T09:00:00.000Z",
+  updatedAt: "2026-07-29T09:00:00.000Z",
+}
+const existingDocument = buildRecipeGuidanceDraft(recipe, {
+  version: 2,
+  createdBy: "hans",
+  now: "2026-07-29T09:30:00.000Z",
+})
+const repository = {
+  listByRecipeId: vi.fn(),
+  findById: vi.fn(),
+  findLatestPublished: vi.fn(),
+  create: vi.fn(),
+  replace: vi.fn(),
+}
+
+function requestFor(path: string, userId: string, role: string, method = "GET") {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: {
+      "x-user-id": userId,
+      "x-user-role": role,
+      "x-user-email": `${userId}@example.com`,
+    },
+  })
+}
+
+describe("recipe guidance APIs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getRecipeById).mockResolvedValue(recipe)
+    repository.listByRecipeId.mockResolvedValue([existingDocument])
+    repository.findLatestPublished.mockResolvedValue(existingDocument)
+    vi.mocked(getRecipeGuidanceRepository).mockResolvedValue({
+      repository,
+      mode: "memory",
+    })
+  })
+
+  it("returns admin-only stored draft versions", async () => {
+    const response = await listDrafts(
+      requestFor("/api/recipes/recipe-1/guidance-drafts", "hans", "admin"),
+      routeContext
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        documents: [
+          {
+            id: existingDocument.id,
+            recipeId: existingDocument.recipeId,
+            version: existingDocument.version,
+          },
+        ],
+      },
+      summary: { count: 1, mode: "memory" },
+    })
+  })
+
+  it("builds a non-persisting preview at the next version", async () => {
+    const response = await previewDraft(
+      requestFor("/api/recipes/recipe-1/guidance-drafts/preview", "hans", "admin", "POST"),
+      routeContext
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data.recipe).toEqual(recipe)
+    expect(body.data.document).toMatchObject({
+      recipeId: "recipe-1",
+      version: 3,
+      status: "draft",
+    })
+    expect(body.summary).toEqual({ mode: "memory", persisted: false, nextVersion: 3 })
+    expect(repository.create).not.toHaveBeenCalled()
+  })
+
+  it("does not expose draft listing or preview to residents", async () => {
+    const listResponse = await listDrafts(
+      requestFor("/api/recipes/recipe-1/guidance-drafts", "irma", "resident"),
+      routeContext
+    )
+    const previewResponse = await previewDraft(
+      requestFor("/api/recipes/recipe-1/guidance-drafts/preview", "irma", "resident", "POST"),
+      routeContext
+    )
+
+    expect(listResponse.status).toBe(403)
+    expect(previewResponse.status).toBe(403)
+    expect(getRecipeGuidanceRepository).not.toHaveBeenCalled()
+  })
+
+  it("returns the latest published guidance to an authorized recipe audience member", async () => {
+    const response = await readPublished(
+      requestFor("/api/recipes/recipe-1/guidance", "irma", "resident"),
+      routeContext
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      data: { recipe: { id: recipe.id }, document: { id: existingDocument.id } },
+      summary: { version: 2 },
+    })
+  })
+
+  it("checks recipe audience before reading guidance state", async () => {
+    const response = await readPublished(
+      requestFor("/api/recipes/recipe-1/guidance", "lucky", "employee"),
+      routeContext
+    )
+
+    expect(response.status).toBe(403)
+    expect(repository.findLatestPublished).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/recipe-guidance-builder.test.ts
+++ b/tests/lib/recipe-guidance-builder.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest"
+import { RecipeGuidanceBuildError, buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
+import { RECIPE_GUIDANCE_SECTION_KINDS } from "@/lib/recipe-guidance"
+import type { RecipeRecord } from "@/lib/recipes"
+
+const now = "2026-07-29T10:00:00.000Z"
+
+const recipe: RecipeRecord = {
+  id: "recipe-1",
+  status: "published",
+  ownerUserId: "hans",
+  audienceUserIds: ["irma", "hans"],
+  titleEn: "Household supper",
+  summaryEn: "A practical supper.",
+  titleAf: "Huishoudelike aandete",
+  summaryAf: "'n Praktiese aandete.",
+  servings: 4,
+  prepMinutes: 10,
+  cookMinutes: 20,
+  image: {
+    url: "https://images.example/recipe.jpg",
+    source: "Example library",
+    author: "Example Author",
+    license: "CC BY 4.0",
+    attributionText: "Example Author, CC BY 4.0",
+    retrievedAt: "2026-07-28",
+  },
+  ingredients: [
+    { id: "ingredient-1", name: "Rice", quantity: 2, unit: "cups" },
+    { id: "ingredient-2", name: "Eggs", quantity: 4 },
+  ],
+  steps: [
+    {
+      id: "step-2",
+      order: 2,
+      instructionEn: "Serve.",
+      instructionAf: "Bedien.",
+    },
+    {
+      id: "step-1",
+      order: 1,
+      instructionEn: "Cook the rice.",
+      instructionAf: "Kook die rys.",
+      timerMinutes: 10,
+    },
+  ],
+  createdAt: "2026-07-28T09:00:00.000Z",
+  updatedAt: "2026-07-29T09:00:00.000Z",
+}
+
+describe("buildRecipeGuidanceDraft", () => {
+  it("builds the same canonical document for the same explicit inputs", () => {
+    const options = { version: 2, createdBy: "hans", now }
+
+    expect(buildRecipeGuidanceDraft(recipe, options)).toEqual(
+      buildRecipeGuidanceDraft(recipe, options)
+    )
+  })
+
+  it("preserves the immutable recipe manifests and fixed section order", () => {
+    const document = buildRecipeGuidanceDraft(recipe, {
+      version: 2,
+      createdBy: "hans",
+      now,
+    })
+
+    expect(document.recipeRevisionId).toBe(`recipe-1@${recipe.updatedAt}`)
+    expect(document.recipeIngredientIds).toEqual(["ingredient-1", "ingredient-2"])
+    expect(document.recipeStepIds).toEqual(["step-1", "step-2"])
+    expect(document.sections.map((section) => section.kind)).toEqual(RECIPE_GUIDANCE_SECTION_KINDS)
+    expect(document.sections.find((section) => section.kind === "ingredients")?.blocks).toEqual([
+      expect.objectContaining({
+        type: "ingredient_references",
+        ingredientIds: ["ingredient-1", "ingredient-2"],
+      }),
+    ])
+  })
+
+  it("maps ordered steps and timers without inventing reviewed prose", () => {
+    const document = buildRecipeGuidanceDraft(recipe, {
+      version: 1,
+      createdBy: "hans",
+      now,
+    })
+    const identity = document.sections.find((section) => section.kind === "identity")
+    const cooking = document.sections.find((section) => section.kind === "cooking")
+
+    expect(identity?.blocks).toEqual([
+      expect.objectContaining({
+        type: "text",
+        source: "recipe",
+        text: { en: recipe.titleEn, af: recipe.titleAf },
+      }),
+      expect.objectContaining({
+        type: "text",
+        source: "recipe",
+        text: { en: recipe.summaryEn, af: recipe.summaryAf },
+      }),
+      expect.objectContaining({ type: "metrics" }),
+    ])
+    expect(cooking?.blocks).toEqual([
+      expect.objectContaining({
+        type: "step_reference",
+        recipeStepId: "step-1",
+        timer: { minimumSeconds: 600 },
+      }),
+      expect.objectContaining({ type: "step_reference", recipeStepId: "step-2" }),
+    ])
+  })
+
+  it("keeps licensed hero media review-required", () => {
+    const document = buildRecipeGuidanceDraft(recipe, {
+      version: 1,
+      createdBy: "hans",
+      now,
+    })
+
+    expect(document.mediaAssets).toEqual([
+      expect.objectContaining({
+        role: "hero",
+        status: "review_required",
+        source: expect.objectContaining({ type: "licensed", license: "CC BY 4.0" }),
+      }),
+    ])
+    expect(document.imageBriefs).toEqual([])
+  })
+
+  it("rejects recipes that cannot supply canonical ingredient and step references", () => {
+    expect(() =>
+      buildRecipeGuidanceDraft(
+        { ...recipe, ingredients: [] },
+        { version: 1, createdBy: "hans", now }
+      )
+    ).toThrow(RecipeGuidanceBuildError)
+  })
+})

--- a/tests/lib/recipe-guidance-builder.test.ts
+++ b/tests/lib/recipe-guidance-builder.test.ts
@@ -141,6 +141,18 @@ describe("buildRecipeGuidanceDraft", () => {
     expect(cooking?.blocks[0]).not.toHaveProperty("timer")
   })
 
+  it("omits a zero-serving sentinel while preserving other metrics", () => {
+    const document = buildRecipeGuidanceDraft(
+      { ...recipe, servings: 0 },
+      { version: 1, createdBy: "hans", now }
+    )
+    const identity = document.sections.find((section) => section.kind === "identity")
+    const metrics = identity?.blocks.find((block) => block.type === "metrics")
+
+    expect(metrics).toMatchObject({ prepMinutes: 10, cookMinutes: 20 })
+    expect(metrics).not.toHaveProperty("servings")
+  })
+
   it("rejects recipes that cannot supply canonical ingredient and step references", () => {
     expect(() =>
       buildRecipeGuidanceDraft(

--- a/tests/lib/recipe-guidance-builder.test.ts
+++ b/tests/lib/recipe-guidance-builder.test.ts
@@ -125,6 +125,22 @@ describe("buildRecipeGuidanceDraft", () => {
     expect(document.imageBriefs).toEqual([])
   })
 
+  it("treats a canonical zero-minute value as no timer", () => {
+    const document = buildRecipeGuidanceDraft(
+      {
+        ...recipe,
+        steps: [{ ...recipe.steps[0], timerMinutes: 0 }],
+      },
+      { version: 1, createdBy: "hans", now }
+    )
+    const cooking = document.sections.find((section) => section.kind === "cooking")
+
+    expect(cooking?.blocks).toEqual([
+      expect.objectContaining({ type: "step_reference", recipeStepId: "step-2" }),
+    ])
+    expect(cooking?.blocks[0]).not.toHaveProperty("timer")
+  })
+
   it("rejects recipes that cannot supply canonical ingredient and step references", () => {
     expect(() =>
       buildRecipeGuidanceDraft(


### PR DESCRIPTION
## Summary

- add a deterministic, schema-validated builder from canonical recipe snapshots to fixed nine-section recipe guidance drafts
- add admin-only stored-version listing and non-persisting next-version preview APIs
- add an audience-checked latest-published guidance read API
- return the authorized recipe snapshot only when it matches the published document revision
- document the API, persistence, review, and provider boundaries

## Why

PR #157 established the dedicated recipe-guidance repository and immutable migration boundary, but there was no safe bridge from a canonical recipe to the richer document or a bounded way to preview/read those documents.

This slice maps only trusted recipe facts. It does not invent safety, allergen, storage, reviewed text, image briefs, or generated-media claims.

## Impact

- preview is admin-only and explicitly reports `persisted: false`
- draft listing is admin-only
- published reads require both recipe and document audience access for non-admin users
- published reads fail closed when only a newer recipe revision is available
- zero-minute and zero-serving recipe sentinels are omitted because guidance durations/counts must be positive
- missing guidance storage fails closed
- no repository create/replace, Sluice/provider call, migration apply, publication, OmniPost action, demo-data default, deployment, or production write is added

## Validation

- `pnpm exec vitest run tests/lib/recipe-guidance-builder.test.ts tests/api/recipe-guidance.test.ts tests/lib/recipe-guidance.test.ts tests/lib/recipe-guidance-repository.test.ts` — 52/52 passed
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build` — 125 routes generated, including all three new routes
- focused Prettier and `git diff --check`

## Review remediation

- fail published reads closed when the current recipe revision does not match the immutable guidance document, preventing reference blocks from resolving against changed ingredients or steps
- omit a guidance timer when the canonical recipe contains the API-valid zero-minute sentinel
- omit the API-valid zero-serving sentinel while preserving valid preparation/cooking metrics

## Handoff

- Baton: `35ee0bfe-73bf-4d43-b689-320fd1cfc83e`
- predecessor: #157
- durable handoff: `docs/handoffs/2026-07-29-recipe-guidance-builder-api.md`