### PR TITLE
Add recipe guidance authoring APIs

### DIFF
--- a/app/api/recipes/[id]/guidance-drafts/[version]/route.ts
+++ b/app/api/recipes/[id]/guidance-drafts/[version]/route.ts
@@ -1,0 +1,139 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { withRole } from "@/lib/auth/rbac"
+import { logger } from "@/lib/logger"
+import {
+  createRecipeRevisionId,
+  parseRecipeGuidanceDocument,
+  recipeGuidanceSectionSchema,
+} from "@/lib/recipe-guidance"
+import {
+  RecipeGuidanceConflictError,
+  getRecipeGuidanceRepository,
+} from "@/lib/repositories/recipe-guidance-repository"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
+
+const sectionUpdateSchema = z
+  .object({
+    expectedUpdatedAt: z.string().datetime({ offset: true }),
+    section: recipeGuidanceSectionSchema
+      .pick({ kind: true, applicability: true, blocks: true })
+      .strict(),
+  })
+  .strict()
+
+function parseVersion(value: string | undefined): number | null {
+  if (!value || !/^[1-9]\d*$/.test(value)) return null
+  const version = Number(value)
+  return Number.isSafeInteger(version) ? version : null
+}
+
+function advanceTimestamp(current: string): string {
+  return new Date(Math.max(Date.now(), new Date(current).getTime() + 1)).toISOString()
+}
+
+export const PATCH = withRole("admin")(async (request, context) => {
+  try {
+    const params = await context.params
+    const recipeId = params?.id
+    const version = parseVersion(params?.version)
+    if (!recipeId) {
+      return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+    }
+    if (version === null) {
+      return NextResponse.json(
+        { error: "A positive guidance version is required" },
+        { status: 400 }
+      )
+    }
+
+    let input: unknown
+    try {
+      input = await request.json()
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return NextResponse.json({ error: "Malformed JSON in request body" }, { status: 400 })
+      }
+      throw error
+    }
+    const parsed = sectionUpdateSchema.safeParse(input)
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid recipe guidance section update" }, { status: 400 })
+    }
+    if (
+      parsed.data.section.blocks.some(
+        (block) => block.type === "text" && block.source !== "reviewed"
+      )
+    ) {
+      return NextResponse.json(
+        { error: "Updated text must be marked as human reviewed" },
+        { status: 400 }
+      )
+    }
+
+    const recipe = await getRecipeById(recipeId)
+    if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+
+    const { repository, mode } = await getRecipeGuidanceRepository()
+    const document = (await repository.listByRecipeId(recipeId)).find(
+      (candidate) => candidate.version === version
+    )
+    if (!document) {
+      return NextResponse.json({ error: "Recipe guidance draft not found" }, { status: 404 })
+    }
+    if (document.status !== "draft" && document.status !== "in_review") {
+      return NextResponse.json(
+        { error: "Only draft or in-review guidance can be updated" },
+        { status: 409 }
+      )
+    }
+    if (document.recipeRevisionId !== createRecipeRevisionId(recipe.id, recipe.updatedAt)) {
+      return NextResponse.json(
+        { error: "Recipe changed; create a new guidance draft" },
+        { status: 409 }
+      )
+    }
+
+    const sectionIndex = document.sections.findIndex(
+      (section) => section.kind === parsed.data.section.kind
+    )
+    const currentSection = document.sections[sectionIndex]
+    if (sectionIndex === -1 || !currentSection) {
+      return NextResponse.json({ error: "Recipe guidance section not found" }, { status: 404 })
+    }
+
+    const sections = [...document.sections]
+    sections[sectionIndex] = {
+      id: currentSection.id,
+      ...parsed.data.section,
+    }
+    const replacement = parseRecipeGuidanceDocument({
+      ...document,
+      sections,
+      updatedAt: advanceTimestamp(document.updatedAt),
+    })
+    if (!replacement) {
+      return NextResponse.json(
+        { error: "Section update conflicts with the guidance document" },
+        { status: 400 }
+      )
+    }
+
+    const updatedDocument = await repository.replace(replacement, parsed.data.expectedUpdatedAt)
+    return NextResponse.json({
+      data: { document: updatedDocument },
+      summary: { mode, version: updatedDocument.version, updatedSection: currentSection.kind },
+    })
+  } catch (error) {
+    if (error instanceof RecipeGuidanceConflictError) {
+      return NextResponse.json(
+        { error: "Recipe guidance changed; refresh and retry" },
+        { status: 409 }
+      )
+    }
+    logger.error("Failed to update recipe guidance section", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Recipe guidance datastore is unavailable" }, { status: 503 })
+  }
+})

--- a/app/api/recipes/[id]/guidance-drafts/route.ts
+++ b/app/api/recipes/[id]/guidance-drafts/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server"
 import { withRole } from "@/lib/auth/rbac"
+import { RecipeGuidanceBuildError, buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
 import { logger } from "@/lib/logger"
-import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
+import {
+  RecipeGuidanceConflictError,
+  getRecipeGuidanceRepository,
+} from "@/lib/repositories/recipe-guidance-repository"
 import { getRecipeById } from "@/lib/repositories/recipe-repository"
 
 export const GET = withRole("admin")(async (_request, context) => {
@@ -22,6 +26,50 @@ export const GET = withRole("admin")(async (_request, context) => {
     })
   } catch (error) {
     logger.error("Failed to list recipe guidance drafts", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Recipe guidance datastore is unavailable" }, { status: 503 })
+  }
+})
+
+export const POST = withRole("admin")(async (_request, context) => {
+  try {
+    const recipeId = (await context.params)?.id
+    if (!recipeId) {
+      return NextResponse.json({ error: "Recipe ID is required" }, { status: 400 })
+    }
+
+    const recipe = await getRecipeById(recipeId)
+    if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+
+    const { repository, mode } = await getRecipeGuidanceRepository()
+    const existingDocuments = await repository.listByRecipeId(recipeId)
+    const nextVersion = Math.max(0, ...existingDocuments.map((document) => document.version)) + 1
+    const document = buildRecipeGuidanceDraft(recipe, {
+      version: nextVersion,
+      createdBy: context.userId,
+      now: new Date().toISOString(),
+    })
+    const persistedDocument = await repository.create(document)
+
+    return NextResponse.json(
+      {
+        data: { recipe, document: persistedDocument },
+        summary: { mode, persisted: true, version: persistedDocument.version },
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    if (error instanceof RecipeGuidanceBuildError) {
+      return NextResponse.json({ error: "Recipe is incomplete for guidance" }, { status: 422 })
+    }
+    if (error instanceof RecipeGuidanceConflictError) {
+      return NextResponse.json(
+        { error: "Recipe guidance version already exists; refresh and retry" },
+        { status: 409 }
+      )
+    }
+    logger.error("Failed to create recipe guidance draft", {
       error: error instanceof Error ? error.message : String(error),
     })
     return NextResponse.json({ error: "Recipe guidance datastore is unavailable" }, { status: 503 })

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -54,14 +54,24 @@ serving counts must be positive; other valid preparation/cooking metrics remain 
 - `POST /api/recipes/:id/guidance-drafts/preview` is admin-only and returns the next deterministic
   version with `persisted: false`; it does not call repository create/replace methods.
 - `GET /api/recipes/:id/guidance-drafts` is admin-only and lists stored versions for review.
+- `POST /api/recipes/:id/guidance-drafts` is admin-only and explicitly persists the next
+  deterministic version. The repository's unique `(recipeId, version)` key closes concurrent
+  creation races with a refreshable conflict; preview remains non-persisting.
+- `PATCH /api/recipes/:id/guidance-drafts/:version` is admin-only and replaces one named section of
+  a `draft` or `in_review` document. The request supplies `expectedUpdatedAt`; the server preserves
+  the stable section ID, advances `updatedAt`, schema-validates the complete aggregate, and uses the
+  repository compare-and-swap replacement. Updated text must be explicitly human-reviewed.
+- Section updates fail closed if the canonical recipe has changed since the immutable draft
+  snapshot. Clients must create a new version rather than editing old ingredient or step facts.
 - `GET /api/recipes/:id/guidance` returns only the latest published version after checking both the
   recipe and document audience for non-admin users. It returns the recipe alongside the document
   only when their immutable revision IDs match; until historical recipe snapshots are available, a
   stale published document fails closed instead of resolving references against newer facts.
 - Preview and published-read responses include the authorized canonical recipe snapshot so clients
   can resolve immutable ingredient and step references without reconstructing facts.
-- Every route fails closed when the dedicated guidance store is unavailable. No route in this slice
-  performs Sluice work, migration apply, publication, OmniPost actions, or deployment.
+- Every route fails closed when the dedicated guidance store is unavailable. Draft creation and
+  section replacement do not transition review/publication state and perform no Sluice work,
+  migration apply, publication, OmniPost action, or deployment.
 
 ## Request flow
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,4 +95,5 @@ Dated session continuity notes (root cause, files changed, verification, next-ow
 | [2026-07-28-recipe-guidance-phase1-contracts.md](handoffs/2026-07-28-recipe-guidance-phase1-contracts.md) | Recipe guidance Phase 1 typed document and media contracts                           |
 | [2026-07-29-recipe-guidance-persistence.md](handoffs/2026-07-29-recipe-guidance-persistence.md)           | Dedicated recipe guidance repository and safe migration boundary                     |
 | [2026-07-29-recipe-guidance-builder-api.md](handoffs/2026-07-29-recipe-guidance-builder-api.md)           | Deterministic recipe draft builder and bounded preview/read APIs                     |
+| [2026-07-29-recipe-guidance-authoring-api.md](handoffs/2026-07-29-recipe-guidance-authoring-api.md)       | Explicit recipe draft creation and optimistic reviewed-section updates               |
 | [2026-07-28-user-selectable-themes.md](handoffs/2026-07-28-user-selectable-themes.md)                     | User-selectable workspace themes implementation, review, and merge handoff           |

--- a/docs/handoffs/2026-07-29-recipe-guidance-authoring-api.md
+++ b/docs/handoffs/2026-07-29-recipe-guidance-authoring-api.md
@@ -1,0 +1,74 @@
+# Recipe guidance draft creation and section authoring API handoff
+
+- **Date:** 2026-07-29
+- **Repository:** `C:\Users\smitj\repos\house-of-veritas`
+- **Worktree:** `C:\tmp\hov-recipe-guidance-authoring-api`
+- **Branch:** `feat/recipe-guidance-authoring-api`
+- **Base:** `origin/main` at `be1e13fc83b37d3eb761c36c049189a8337aed58`
+- **Predecessor:** PR [#158](https://github.com/neuralliquid/house-of-veritas/pull/158)
+- **Baton task:** `618c898e-b945-4dbe-8551-9a62727aaf0e`
+- **Risk tier:** API/data/auth workflow; bounded admin authoring only
+
+## Outcome
+
+Added the explicit persistence and reviewed-section authoring surfaces after the deterministic
+preview/read slice.
+
+- `POST /api/recipes/:id/guidance-drafts` builds and persists the next deterministic version.
+- Concurrent next-version creation returns a refreshable conflict through the repository's unique
+  version constraint.
+- `PATCH /api/recipes/:id/guidance-drafts/:version` replaces one section in a draft or in-review
+  document while preserving the section's stable ID.
+- Patch requests require `expectedUpdatedAt`; successful replacements advance `updatedAt` and use
+  the repository compare-and-swap contract.
+- Updated text must be explicitly marked `reviewed`; recipe-sourced text is rejected by this human
+  authoring endpoint.
+- The complete document is schema-validated before persistence, so foreign recipe references,
+  duplicate IDs, invalid media links, and other cross-aggregate violations fail closed.
+- A draft whose immutable recipe revision is no longer current cannot be edited; the author must
+  create a new version from the current recipe.
+- Both write surfaces are admin-only and authorization runs before recipe or draft state is read.
+
+## Changed files
+
+- `app/api/recipes/[id]/guidance-drafts/route.ts`
+- `app/api/recipes/[id]/guidance-drafts/[version]/route.ts`
+- `tests/api/recipe-guidance.test.ts`
+- `docs/05-project/task-guidance-architecture.md`
+- `docs/handoffs/2026-07-29-recipe-guidance-authoring-api.md`
+- `docs/README.md`
+
+## Verification
+
+Passed locally:
+
+```text
+pnpm exec vitest run tests/api/recipe-guidance.test.ts tests/lib/recipe-guidance.test.ts tests/lib/recipe-guidance-repository.test.ts tests/lib/recipe-guidance-builder.test.ts
+pnpm exec tsc --noEmit
+pnpm run lint
+pnpm run build
+pnpm exec prettier --check <changed TypeScript and Markdown files>
+git diff --check
+```
+
+- Focused result: 4 files, 59 tests passed.
+- TypeScript, full repository lint, Prettier, and diff checks passed.
+- Production build passed with all 125 routes generated, including the new versioned draft route.
+- Browser verification is not applicable because this slice adds no page or interactive UI.
+- Exact-head CI and review remain required before merge.
+
+## Residual boundary and next slice
+
+This slice does not transition a document into review, record document-level review evidence,
+publish or archive a version, create or approve image briefs, call Sluice, apply migrations, create
+public packages, invoke OmniPost, or deploy. The next bounded slice can add explicit review-state
+transitions and publication completeness gates, or build the text-first author/reader UI against
+the current contracts.
+
+## Trace envelope
+
+- **Task:** `618c898e-b945-4dbe-8551-9a62727aaf0e`
+- **Routing:** Veritas Gateway/routes, Ledger/data, Shield/auth, Proof/verification,
+  Journey/Compass workflow
+- **External effects:** Baton and GitHub workflow only; no provider, publication, migration, or
+  deploy effects

--- a/tests/api/recipe-guidance.test.ts
+++ b/tests/api/recipe-guidance.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { GET as listDrafts } from "@/app/api/recipes/[id]/guidance-drafts/route"
+import {
+  GET as listDrafts,
+  POST as createDraft,
+} from "@/app/api/recipes/[id]/guidance-drafts/route"
+import { PATCH as updateDraftSection } from "@/app/api/recipes/[id]/guidance-drafts/[version]/route"
 import { POST as previewDraft } from "@/app/api/recipes/[id]/guidance-drafts/preview/route"
 import { GET as readPublished } from "@/app/api/recipes/[id]/guidance/route"
 import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
@@ -7,7 +11,8 @@ import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-
 import { getRecipeById } from "@/lib/repositories/recipe-repository"
 import type { RecipeRecord } from "@/lib/recipes"
 
-vi.mock("@/lib/repositories/recipe-guidance-repository", () => ({
+vi.mock("@/lib/repositories/recipe-guidance-repository", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/repositories/recipe-guidance-repository")>()),
   getRecipeGuidanceRepository: vi.fn(),
 }))
 
@@ -16,6 +21,7 @@ vi.mock("@/lib/repositories/recipe-repository", () => ({
 }))
 
 const routeContext = { params: Promise.resolve({ id: "recipe-1" }) }
+const versionRouteContext = { params: Promise.resolve({ id: "recipe-1", version: "2" }) }
 const recipe: RecipeRecord = {
   id: "recipe-1",
   status: "published",
@@ -66,12 +72,27 @@ function requestFor(path: string, userId: string, role: string, method = "GET") 
   })
 }
 
+function jsonRequestFor(path: string, userId: string, role: string, method: string, body: unknown) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: {
+      "content-type": "application/json",
+      "x-user-id": userId,
+      "x-user-role": role,
+      "x-user-email": `${userId}@example.com`,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
 describe("recipe guidance APIs", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(getRecipeById).mockResolvedValue(recipe)
     repository.listByRecipeId.mockResolvedValue([existingDocument])
     repository.findLatestPublished.mockResolvedValue(existingDocument)
+    repository.create.mockImplementation(async (document) => document)
+    repository.replace.mockImplementation(async (document) => document)
     vi.mocked(getRecipeGuidanceRepository).mockResolvedValue({
       repository,
       mode: "memory",
@@ -117,6 +138,173 @@ describe("recipe guidance APIs", () => {
     expect(repository.create).not.toHaveBeenCalled()
   })
 
+  it("persists an explicit deterministic draft at the next version", async () => {
+    const response = await createDraft(
+      requestFor("/api/recipes/recipe-1/guidance-drafts", "hans", "admin", "POST"),
+      routeContext
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(body.data.recipe).toEqual(recipe)
+    expect(body.data.document).toMatchObject({
+      recipeId: "recipe-1",
+      version: 3,
+      status: "draft",
+      createdBy: "hans",
+    })
+    expect(body.summary).toEqual({ mode: "memory", persisted: true, version: 3 })
+    expect(repository.create).toHaveBeenCalledOnce()
+  })
+
+  it("returns a refreshable conflict when concurrent draft creation wins", async () => {
+    const { RecipeGuidanceConflictError } =
+      await import("@/lib/repositories/recipe-guidance-repository")
+    repository.create.mockRejectedValueOnce(new RecipeGuidanceConflictError("duplicate"))
+
+    const response = await createDraft(
+      requestFor("/api/recipes/recipe-1/guidance-drafts", "hans", "admin", "POST"),
+      routeContext
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: "Recipe guidance version already exists; refresh and retry",
+    })
+  })
+
+  it("updates one human-reviewed section with optimistic concurrency", async () => {
+    const identity = existingDocument.sections.find((section) => section.kind === "identity")!
+    const reviewedBlocks = identity.blocks.map((block) =>
+      block.type === "text" ? { ...block, source: "reviewed" as const } : block
+    )
+
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: existingDocument.updatedAt,
+        section: {
+          kind: "identity",
+          applicability: "required",
+          blocks: reviewedBlocks,
+        },
+      }),
+      versionRouteContext
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.summary).toEqual({ mode: "memory", version: 2, updatedSection: "identity" })
+    expect(repository.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: existingDocument.id,
+        sections: expect.arrayContaining([
+          expect.objectContaining({ id: identity.id, kind: "identity", blocks: reviewedBlocks }),
+        ]),
+      }),
+      existingDocument.updatedAt
+    )
+    const replacement = repository.replace.mock.calls[0][0]
+    expect(new Date(replacement.updatedAt).getTime()).toBeGreaterThan(
+      new Date(existingDocument.updatedAt).getTime()
+    )
+  })
+
+  it("rejects recipe-sourced text through the reviewed section endpoint", async () => {
+    const identity = existingDocument.sections.find((section) => section.kind === "identity")!
+
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: existingDocument.updatedAt,
+        section: {
+          kind: "identity",
+          applicability: "required",
+          blocks: identity.blocks,
+        },
+      }),
+      versionRouteContext
+    )
+
+    expect(response.status).toBe(400)
+    expect(repository.replace).not.toHaveBeenCalled()
+  })
+
+  it("rejects section blocks that conflict with the immutable recipe manifest", async () => {
+    const cooking = existingDocument.sections.find((section) => section.kind === "cooking")!
+    const invalidBlocks = cooking.blocks.map((block) =>
+      block.type === "step_reference"
+        ? { ...block, recipeStepId: "step-from-another-recipe" }
+        : block
+    )
+
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: existingDocument.updatedAt,
+        section: {
+          kind: "cooking",
+          applicability: "required",
+          blocks: invalidBlocks,
+        },
+      }),
+      versionRouteContext
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: "Section update conflicts with the guidance document",
+    })
+    expect(repository.replace).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when the recipe changed after the draft snapshot", async () => {
+    vi.mocked(getRecipeById).mockResolvedValue({
+      ...recipe,
+      updatedAt: "2026-07-29T10:00:00.000Z",
+    })
+    const cooking = existingDocument.sections.find((section) => section.kind === "cooking")!
+
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: existingDocument.updatedAt,
+        section: {
+          kind: "cooking",
+          applicability: "required",
+          blocks: cooking.blocks,
+        },
+      }),
+      versionRouteContext
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: "Recipe changed; create a new guidance draft",
+    })
+    expect(repository.replace).not.toHaveBeenCalled()
+  })
+
+  it("maps stale optimistic concurrency tokens to a refreshable conflict", async () => {
+    const { RecipeGuidanceConflictError } =
+      await import("@/lib/repositories/recipe-guidance-repository")
+    repository.replace.mockRejectedValueOnce(new RecipeGuidanceConflictError("stale"))
+    const cooking = existingDocument.sections.find((section) => section.kind === "cooking")!
+
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: existingDocument.updatedAt,
+        section: {
+          kind: "cooking",
+          applicability: "required",
+          blocks: cooking.blocks,
+        },
+      }),
+      versionRouteContext
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: "Recipe guidance changed; refresh and retry",
+    })
+  })
+
   it("does not expose draft listing or preview to residents", async () => {
     const listResponse = await listDrafts(
       requestFor("/api/recipes/recipe-1/guidance-drafts", "irma", "resident"),
@@ -126,9 +314,19 @@ describe("recipe guidance APIs", () => {
       requestFor("/api/recipes/recipe-1/guidance-drafts/preview", "irma", "resident", "POST"),
       routeContext
     )
+    const createResponse = await createDraft(
+      requestFor("/api/recipes/recipe-1/guidance-drafts", "irma", "resident", "POST"),
+      routeContext
+    )
+    const updateResponse = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "irma", "resident", "PATCH", {}),
+      versionRouteContext
+    )
 
     expect(listResponse.status).toBe(403)
     expect(previewResponse.status).toBe(403)
+    expect(createResponse.status).toBe(403)
+    expect(updateResponse.status).toBe(403)
     expect(getRecipeGuidanceRepository).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary

- persist the next deterministic recipe guidance draft through the admin-only collection route
- add an admin-only versioned PATCH route for one reviewed section at a time
- enforce optimistic concurrency, immutable recipe revision matching, stable section IDs, and full-document schema validation
- document the authoring boundary and durable handoff

## Why

PR #158 established deterministic previews and read surfaces but intentionally performed no authoring writes. This bounded successor exposes the repository's existing create/replace contracts without adding review transitions, publication, Sluice, migration apply, OmniPost, or deployment behavior.

## Impact

Admins can explicitly create a draft and save a human-reviewed section. Concurrent creation or stale section edits return refreshable 409 responses. Non-admin users are rejected before recipe or draft state is read, and stale recipe snapshots must be rebuilt as a new version.

## Validation

- `pnpm exec vitest run tests/api/recipe-guidance.test.ts tests/lib/recipe-guidance.test.ts tests/lib/recipe-guidance-repository.test.ts tests/lib/recipe-guidance-builder.test.ts` (59 passed)
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build` (125 routes)
- focused Prettier check
- `git diff --check`

Browser verification is not applicable because this PR adds no page or interactive UI.