### PR TITLE
Add recipe guidance authoring and reader UI

### DIFF
--- a/components/recipes/published-recipe-guidance.tsx
+++ b/components/recipes/published-recipe-guidance.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { ApiError, apiFetch } from "@/lib/api-client"
+import type { RecipeGuidanceDocument } from "@/lib/recipe-guidance"
+import type { RecipeRecord } from "@/lib/recipes"
+import { Loader2, RefreshCw } from "lucide-react"
+import { useCallback, useEffect, useState } from "react"
+import {
+  RecipeGuidanceDocumentView,
+  type RecipeGuidanceLanguageMode,
+} from "./recipe-guidance-document-view"
+
+interface PublishedGuidanceResponse {
+  data: {
+    recipe: RecipeRecord
+    document: RecipeGuidanceDocument
+  }
+}
+
+function errorText(error: unknown) {
+  if (
+    error instanceof ApiError &&
+    error.body &&
+    typeof error.body === "object" &&
+    "error" in error.body &&
+    typeof error.body.error === "string"
+  ) {
+    return error.body.error
+  }
+  return error instanceof Error ? error.message : "Published guidance is unavailable"
+}
+
+export function PublishedRecipeGuidance({
+  recipeId,
+  language,
+}: {
+  recipeId: string
+  language: RecipeGuidanceLanguageMode
+}) {
+  const [response, setResponse] = useState<PublishedGuidanceResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
+  const [notPublished, setNotPublished] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError("")
+    setNotPublished(false)
+    try {
+      const next = await apiFetch<PublishedGuidanceResponse>(`/api/recipes/${recipeId}/guidance`, {
+        label: "PublishedRecipeGuidance",
+      })
+      setResponse(next)
+    } catch (loadError) {
+      setResponse(null)
+      if (loadError instanceof ApiError && loadError.status === 404) {
+        setNotPublished(true)
+      } else {
+        setError(errorText(loadError))
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [recipeId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (loading) {
+    return (
+      <div className="border-border bg-card text-muted-foreground flex items-center gap-2 rounded-2xl border p-5 text-sm">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading reviewed kitchen guidance…
+      </div>
+    )
+  }
+
+  if (notPublished) {
+    return (
+      <div className="border-border bg-card text-muted-foreground rounded-2xl border p-5 text-sm">
+        Reviewed guidance has not been published for this recipe yet. The canonical recipe remains
+        available below.
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="border-destructive/30 bg-destructive/10 rounded-2xl border p-5 text-sm">
+        <p className="text-destructive">{error}</p>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="border-border bg-background mt-3 inline-flex items-center gap-2 rounded-lg border px-3 py-2"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  return response ? (
+    <RecipeGuidanceDocumentView
+      document={response.data.document}
+      recipe={response.data.recipe}
+      language={language}
+      heading="Irma’s kitchen view"
+    />
+  ) : null
+}

--- a/components/recipes/recipe-catalog-client.tsx
+++ b/components/recipes/recipe-catalog-client.tsx
@@ -505,10 +505,18 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
 
           <section className="space-y-6">
             {selectedRecipe && isAdmin && (
-              <RecipeGuidanceWorkspace recipe={selectedRecipe} language={language} />
+              <RecipeGuidanceWorkspace
+                key={selectedRecipe.id}
+                recipe={selectedRecipe}
+                language={language}
+              />
             )}
             {selectedRecipe && persona === "irma" && !isAdmin && (
-              <PublishedRecipeGuidance recipeId={selectedRecipe.id} language={language} />
+              <PublishedRecipeGuidance
+                key={selectedRecipe.id}
+                recipeId={selectedRecipe.id}
+                language={language}
+              />
             )}
             {selectedRecipe ? (
               <article className="border-border bg-card rounded-2xl border">

--- a/components/recipes/recipe-catalog-client.tsx
+++ b/components/recipes/recipe-catalog-client.tsx
@@ -2,6 +2,8 @@
 
 import { useAuth } from "@/lib/auth-context"
 import { apiFetch } from "@/lib/api-client"
+import { PublishedRecipeGuidance } from "@/components/recipes/published-recipe-guidance"
+import { RecipeGuidanceWorkspace } from "@/components/recipes/recipe-guidance-workspace"
 import {
   type RecipeIngredient,
   type RecipeRecord,
@@ -502,6 +504,12 @@ export default function RecipeCatalogClient({ persona }: { persona: Persona }) {
           </aside>
 
           <section className="space-y-6">
+            {selectedRecipe && isAdmin && (
+              <RecipeGuidanceWorkspace recipe={selectedRecipe} language={language} />
+            )}
+            {selectedRecipe && persona === "irma" && !isAdmin && (
+              <PublishedRecipeGuidance recipeId={selectedRecipe.id} language={language} />
+            )}
             {selectedRecipe ? (
               <article className="border-border bg-card rounded-2xl border">
                 <div className="border-border border-b p-5">

--- a/components/recipes/recipe-guidance-document-view.tsx
+++ b/components/recipes/recipe-guidance-document-view.tsx
@@ -1,0 +1,344 @@
+"use client"
+
+import type {
+  RecipeGuidanceBlock,
+  RecipeGuidanceDocument,
+  RecipeGuidanceSectionKind,
+  RecipeMediaAsset,
+} from "@/lib/recipe-guidance"
+import type { RecipeIngredient, RecipeRecord, RecipeStep } from "@/lib/recipes"
+import { CheckCircle2, Clock4, ImageOff, Info, ShieldAlert } from "lucide-react"
+import Image from "next/image"
+import { useState } from "react"
+
+export type RecipeGuidanceLanguageMode = "en" | "af" | "both"
+
+const SECTION_LABELS: Record<RecipeGuidanceSectionKind, { en: string; af: string }> = {
+  identity: { en: "Recipe overview", af: "Resep-oorsig" },
+  hero: { en: "Finished dish", af: "Voltooide gereg" },
+  before_start: { en: "Before you start", af: "Voor jy begin" },
+  ingredients: { en: "Ingredients", af: "Bestanddele" },
+  preparation: { en: "Preparation", af: "Voorbereiding" },
+  cooking: { en: "Cooking", af: "Kook" },
+  finish_and_serve: { en: "Finish and serve", af: "Voltooi en bedien" },
+  storage_and_reheating: { en: "Storage and reheating", af: "Berging en herverhitting" },
+  provenance_and_feedback: { en: "Source and feedback", af: "Bron en terugvoer" },
+}
+
+function localizedText(text: { en: string; af: string }, language: RecipeGuidanceLanguageMode) {
+  if (language === "en") return <p className="whitespace-pre-line">{text.en}</p>
+  if (language === "af") return <p className="whitespace-pre-line">{text.af}</p>
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      <div>
+        <p className="text-muted-foreground mb-1 text-xs font-semibold uppercase">English</p>
+        <p className="whitespace-pre-line">{text.en}</p>
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-1 text-xs font-semibold uppercase">Afrikaans</p>
+        <p className="whitespace-pre-line">{text.af}</p>
+      </div>
+    </div>
+  )
+}
+
+function sectionLabel(kind: RecipeGuidanceSectionKind, language: RecipeGuidanceLanguageMode) {
+  const label = SECTION_LABELS[kind]
+  if (language === "en") return label.en
+  if (language === "af") return label.af
+  return `${label.en} / ${label.af}`
+}
+
+function ingredientLine(ingredient: RecipeIngredient) {
+  return [
+    ingredient.quantity,
+    ingredient.unit,
+    ingredient.name,
+    ingredient.preparationNote ? `· ${ingredient.preparationNote}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+}
+
+function timerText(minimumSeconds: number, maximumSeconds?: number) {
+  const format = (seconds: number) =>
+    seconds % 60 === 0 ? `${seconds / 60} min` : `${seconds} sec`
+  return maximumSeconds && maximumSeconds !== minimumSeconds
+    ? `${format(minimumSeconds)}–${format(maximumSeconds)}`
+    : format(minimumSeconds)
+}
+
+function assetUrl(asset: RecipeMediaAsset) {
+  return asset.status === "approved" ? asset.storage?.url : undefined
+}
+
+function GuidanceMedia({
+  asset,
+  language,
+}: {
+  asset: RecipeMediaAsset
+  language: RecipeGuidanceLanguageMode
+}) {
+  const url = assetUrl(asset)
+  if (!url || !asset.altText) {
+    return (
+      <div className="border-border bg-muted/30 text-muted-foreground flex min-h-32 items-center justify-center gap-2 rounded-xl border border-dashed p-5 text-sm">
+        <ImageOff className="h-4 w-4" />
+        Media is not available in this published version.
+      </div>
+    )
+  }
+
+  const alt =
+    language === "af"
+      ? asset.altText.af
+      : language === "en"
+        ? asset.altText.en
+        : `${asset.altText.en} / ${asset.altText.af}`
+
+  return (
+    <figure className="space-y-2">
+      <Image
+        src={url}
+        alt={alt}
+        width={960}
+        height={540}
+        className="border-border max-h-[28rem] w-full rounded-xl border object-cover"
+      />
+      {asset.source?.type === "licensed" && (
+        <figcaption className="text-muted-foreground text-xs">
+          {asset.source.attributionText} · {asset.source.license}
+        </figcaption>
+      )}
+    </figure>
+  )
+}
+
+function GuidanceBlock({
+  block,
+  recipe,
+  document,
+  language,
+  checkedIngredients,
+  toggleIngredient,
+}: {
+  block: RecipeGuidanceBlock
+  recipe: RecipeRecord
+  document: RecipeGuidanceDocument
+  language: RecipeGuidanceLanguageMode
+  checkedIngredients: Record<string, boolean>
+  toggleIngredient: (ingredientId: string) => void
+}) {
+  if (block.type === "text") {
+    return (
+      <div className="text-foreground text-sm leading-6">{localizedText(block.text, language)}</div>
+    )
+  }
+
+  if (block.type === "notice") {
+    const Icon =
+      block.noticeType === "safety" || block.noticeType === "allergen" ? ShieldAlert : Info
+    return (
+      <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4">
+        <p className="mb-2 flex items-center gap-2 text-sm font-semibold text-amber-700 dark:text-amber-300">
+          <Icon className="h-4 w-4" />
+          {block.noticeType.replaceAll("_", " ")}
+        </p>
+        <div className="text-sm leading-6">{localizedText(block.text, language)}</div>
+      </div>
+    )
+  }
+
+  if (block.type === "metrics") {
+    return (
+      <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
+        {block.servings !== undefined && (
+          <div className="bg-muted/40 rounded-lg p-3">
+            <dt className="text-muted-foreground">Servings</dt>
+            <dd className="text-foreground mt-1 font-semibold">{block.servings}</dd>
+          </div>
+        )}
+        {block.prepMinutes !== undefined && (
+          <div className="bg-muted/40 rounded-lg p-3">
+            <dt className="text-muted-foreground">Preparation</dt>
+            <dd className="text-foreground mt-1 font-semibold">{block.prepMinutes} min</dd>
+          </div>
+        )}
+        {block.cookMinutes !== undefined && (
+          <div className="bg-muted/40 rounded-lg p-3">
+            <dt className="text-muted-foreground">Cooking</dt>
+            <dd className="text-foreground mt-1 font-semibold">{block.cookMinutes} min</dd>
+          </div>
+        )}
+      </dl>
+    )
+  }
+
+  if (block.type === "ingredient_references") {
+    const ingredientsById = new Map(
+      recipe.ingredients.map((ingredient) => [ingredient.id, ingredient])
+    )
+    return (
+      <ul className="space-y-2">
+        {block.ingredientIds.map((ingredientId) => {
+          const ingredient = ingredientsById.get(ingredientId)
+          if (!ingredient) return null
+          return (
+            <li key={ingredient.id}>
+              <label className="border-border flex min-h-11 cursor-pointer items-start gap-3 rounded-lg border p-3 text-sm">
+                <input
+                  type="checkbox"
+                  checked={Boolean(checkedIngredients[ingredient.id])}
+                  onChange={() => toggleIngredient(ingredient.id)}
+                  className="mt-0.5 h-4 w-4"
+                />
+                <span
+                  className={
+                    checkedIngredients[ingredient.id] ? "text-muted-foreground line-through" : ""
+                  }
+                >
+                  {ingredientLine(ingredient)}
+                </span>
+              </label>
+            </li>
+          )
+        })}
+      </ul>
+    )
+  }
+
+  if (block.type === "step_reference") {
+    const step = recipe.steps.find((candidate) => candidate.id === block.recipeStepId)
+    if (!step) return null
+    return <GuidanceStep step={step} block={block} language={language} />
+  }
+
+  const asset = document.mediaAssets.find((candidate) => candidate.id === block.mediaAssetId)
+  return asset ? <GuidanceMedia asset={asset} language={language} /> : null
+}
+
+function GuidanceStep({
+  step,
+  block,
+  language,
+}: {
+  step: RecipeStep
+  block: Extract<RecipeGuidanceBlock, { type: "step_reference" }>
+  language: RecipeGuidanceLanguageMode
+}) {
+  const text = {
+    en: step.instructionEn,
+    af: step.instructionAf,
+  }
+  return (
+    <div className="border-border rounded-xl border p-4">
+      <p className="text-muted-foreground mb-2 text-xs font-semibold uppercase">
+        Step {step.order}
+      </p>
+      <div className="text-sm leading-6">{localizedText(text, language)}</div>
+      {block.timer && (
+        <p className="text-muted-foreground mt-3 inline-flex items-center gap-2 text-xs">
+          <Clock4 className="h-3.5 w-3.5" />
+          {timerText(block.timer.minimumSeconds, block.timer.maximumSeconds)}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function RecipeGuidanceDocumentView({
+  document,
+  recipe,
+  language,
+  heading,
+}: {
+  document: RecipeGuidanceDocument
+  recipe: RecipeRecord
+  language: RecipeGuidanceLanguageMode
+  heading?: string
+}) {
+  const [ingredientChecks, setIngredientChecks] = useState<{
+    recipeId: string
+    values: Record<string, boolean>
+  }>({ recipeId: recipe.id, values: {} })
+  const checkedIngredients = ingredientChecks.recipeId === recipe.id ? ingredientChecks.values : {}
+
+  return (
+    <article
+      className="border-border bg-card overflow-hidden rounded-2xl border"
+      data-testid="recipe-guidance-document"
+    >
+      <header className="border-border bg-primary/5 border-b p-5 sm:p-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-primary text-xs font-semibold tracking-[0.18em] uppercase">
+              {heading ?? "Kitchen guidance"}
+            </p>
+            <h2 className="text-foreground mt-2 text-2xl font-semibold sm:text-3xl">
+              {language === "af"
+                ? recipe.titleAf
+                : language === "en"
+                  ? recipe.titleEn
+                  : `${recipe.titleEn} / ${recipe.titleAf}`}
+            </h2>
+          </div>
+          <span className="border-border bg-background rounded-full border px-3 py-1 text-xs font-medium uppercase">
+            v{document.version} · {document.status.replace("_", " ")}
+          </span>
+        </div>
+        {document.status === "published" && (
+          <p className="mt-3 flex items-center gap-2 text-xs text-emerald-700 dark:text-emerald-300">
+            <CheckCircle2 className="h-4 w-4" />
+            Reviewed and published for this recipe revision
+          </p>
+        )}
+      </header>
+
+      <div className="divide-border divide-y">
+        {document.sections
+          .filter((section) => section.applicability !== "not_applicable")
+          .map((section) => (
+            <section key={section.id} className="space-y-4 p-5 sm:p-6">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-foreground text-lg font-semibold">
+                  {sectionLabel(section.kind, language)}
+                </h3>
+                {section.applicability === "optional" && (
+                  <span className="text-muted-foreground text-xs uppercase">Optional</span>
+                )}
+              </div>
+              {section.blocks.length === 0 ? (
+                <p className="text-muted-foreground text-sm">
+                  No reviewed guidance in this section.
+                </p>
+              ) : (
+                <div className="space-y-4">
+                  {section.blocks.map((block) => (
+                    <GuidanceBlock
+                      key={block.id}
+                      block={block}
+                      recipe={recipe}
+                      document={document}
+                      language={language}
+                      checkedIngredients={checkedIngredients}
+                      toggleIngredient={(ingredientId) =>
+                        setIngredientChecks((current) => ({
+                          recipeId: recipe.id,
+                          values: {
+                            ...(current.recipeId === recipe.id ? current.values : {}),
+                            [ingredientId]: !(
+                              current.recipeId === recipe.id && current.values[ingredientId]
+                            ),
+                          },
+                        }))
+                      }
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          ))}
+      </div>
+    </article>
+  )
+}

--- a/components/recipes/recipe-guidance-workspace.tsx
+++ b/components/recipes/recipe-guidance-workspace.tsx
@@ -117,11 +117,13 @@ function SectionEditor({
   section,
   disabled,
   busy,
+  removableMediaAssetIds,
   onSave,
 }: {
   section: RecipeGuidanceSection
   disabled: boolean
   busy: boolean
+  removableMediaAssetIds: ReadonlySet<string>
   onSave: (section: RecipeGuidanceSection) => Promise<void>
 }) {
   const [draft, setDraft] = useState(section)
@@ -145,7 +147,7 @@ function SectionEditor({
 
   const addReviewedParagraph = () => {
     const newBlock: RecipeGuidanceBlock = {
-      id: `${section.id}-reviewed-${Date.now()}`,
+      id: `${section.id}-reviewed-${globalThis.crypto.randomUUID()}`,
       type: "text",
       source: "reviewed",
       text: { en: "", af: "" },
@@ -238,9 +240,20 @@ function SectionEditor({
           ) : (
             <div
               key={block.id}
-              className="border-border text-muted-foreground rounded-lg border border-dashed p-3 text-xs"
+              className="border-border text-muted-foreground flex items-center justify-between gap-3 rounded-lg border border-dashed p-3 text-xs"
             >
-              {blockDescription(block)}
+              <span>{blockDescription(block)}</span>
+              {block.type === "media_reference" &&
+                removableMediaAssetIds.has(block.mediaAssetId) && (
+                  <button
+                    type="button"
+                    onClick={() => removeBlock(index)}
+                    disabled={disabled}
+                    className="text-destructive shrink-0 font-semibold disabled:opacity-50"
+                  >
+                    Remove rejected media reference
+                  </button>
+                )}
             </div>
           )
         )}
@@ -614,6 +627,15 @@ export function RecipeGuidanceWorkspace({
   const reviewConfirmed = reviewChecks.bilingual && reviewChecks.safety && reviewChecks.provenance
   const unavailableAssets =
     selectedDocument?.mediaAssets.filter((asset) => asset.status === "unavailable") ?? []
+  const rejectedMediaAssetIds = useMemo(
+    () =>
+      new Set(
+        selectedDocument?.mediaAssets
+          .filter((asset) => asset.status === "rejected")
+          .map((asset) => asset.id) ?? []
+      ),
+    [selectedDocument]
+  )
 
   return (
     <section
@@ -723,6 +745,7 @@ export function RecipeGuidanceWorkspace({
                       section={section}
                       disabled={!editable || Boolean(busy)}
                       busy={busy === `section-${section.id}`}
+                      removableMediaAssetIds={rejectedMediaAssetIds}
                       onSave={saveSection}
                     />
                   ))}

--- a/components/recipes/recipe-guidance-workspace.tsx
+++ b/components/recipes/recipe-guidance-workspace.tsx
@@ -1,0 +1,898 @@
+"use client"
+
+import { ApiError, apiFetch } from "@/lib/api-client"
+import {
+  type RecipeGuidanceBlock,
+  type RecipeGuidanceDocument,
+  type RecipeGuidanceReviewEvidence,
+  type RecipeGuidanceSection,
+  type RecipeGuidanceSectionKind,
+  type RecipeMediaAsset,
+} from "@/lib/recipe-guidance"
+import type { RecipeRecord } from "@/lib/recipes"
+import {
+  AlertTriangle,
+  Archive,
+  Check,
+  CheckCircle2,
+  ClipboardCheck,
+  Eye,
+  FilePlus2,
+  Loader2,
+  RefreshCw,
+  Save,
+  Send,
+} from "lucide-react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import {
+  RecipeGuidanceDocumentView,
+  type RecipeGuidanceLanguageMode,
+} from "./recipe-guidance-document-view"
+
+interface GuidanceListResponse {
+  data: { documents: RecipeGuidanceDocument[] }
+}
+
+interface GuidanceMutationResponse {
+  data: { recipe?: RecipeRecord; document: RecipeGuidanceDocument }
+}
+
+interface GuidancePreviewResponse {
+  data: { recipe: RecipeRecord; document: RecipeGuidanceDocument }
+  summary: { persisted: false; nextVersion: number }
+}
+
+interface ReadinessIssue {
+  code: string
+  message: string
+}
+
+interface ReadinessResponse {
+  data: {
+    documentId: string
+    version: number
+    status: RecipeGuidanceDocument["status"]
+    ready: boolean
+    issues: ReadinessIssue[]
+  }
+}
+
+type TransitionAction = "submit_for_review" | "approve_review" | "publish" | "archive"
+
+const FOUNDATIONAL_SECTIONS = new Set<RecipeGuidanceSectionKind>([
+  "identity",
+  "ingredients",
+  "cooking",
+])
+
+const TEXT_SECTION_KINDS = new Set<RecipeGuidanceSectionKind>([
+  "identity",
+  "before_start",
+  "preparation",
+  "finish_and_serve",
+  "storage_and_reheating",
+  "provenance_and_feedback",
+])
+
+const SECTION_NAMES: Record<RecipeGuidanceSectionKind, string> = {
+  identity: "Recipe overview",
+  hero: "Hero image",
+  before_start: "Before you start",
+  ingredients: "Ingredients",
+  preparation: "Preparation",
+  cooking: "Cooking",
+  finish_and_serve: "Finish and serve",
+  storage_and_reheating: "Storage and reheating",
+  provenance_and_feedback: "Source and feedback",
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  if (
+    error instanceof ApiError &&
+    error.body &&
+    typeof error.body === "object" &&
+    "error" in error.body &&
+    typeof error.body.error === "string"
+  ) {
+    return error.body.error
+  }
+  return error instanceof Error ? error.message : fallback
+}
+
+function sortedDocuments(documents: RecipeGuidanceDocument[]) {
+  return [...documents].sort((left, right) => right.version - left.version)
+}
+
+function blockDescription(block: RecipeGuidanceBlock) {
+  if (block.type === "metrics") return "Canonical recipe timings and servings"
+  if (block.type === "ingredient_references") {
+    return `${block.ingredientIds.length} canonical ingredient references`
+  }
+  if (block.type === "step_reference") return `Canonical recipe step ${block.recipeStepId}`
+  if (block.type === "media_reference") return `Media asset ${block.mediaAssetId}`
+  return block.type
+}
+
+function SectionEditor({
+  section,
+  disabled,
+  busy,
+  onSave,
+}: {
+  section: RecipeGuidanceSection
+  disabled: boolean
+  busy: boolean
+  onSave: (section: RecipeGuidanceSection) => Promise<void>
+}) {
+  const [draft, setDraft] = useState(section)
+
+  const updateText = (index: number, language: "en" | "af", value: string) => {
+    setDraft((current) => ({
+      ...current,
+      blocks: current.blocks.map((block, blockIndex) => {
+        if (blockIndex !== index || (block.type !== "text" && block.type !== "notice")) return block
+        if (block.type === "text") {
+          return {
+            ...block,
+            source: "reviewed" as const,
+            text: { ...block.text, [language]: value },
+          }
+        }
+        return { ...block, text: { ...block.text, [language]: value } }
+      }),
+    }))
+  }
+
+  const addReviewedParagraph = () => {
+    const newBlock: RecipeGuidanceBlock = {
+      id: `${section.id}-reviewed-${Date.now()}`,
+      type: "text",
+      source: "reviewed",
+      text: { en: "", af: "" },
+    }
+    setDraft((current) => ({ ...current, blocks: [...current.blocks, newBlock] }))
+  }
+
+  const removeBlock = (index: number) => {
+    setDraft((current) => ({
+      ...current,
+      blocks: current.blocks.filter((_block, blockIndex) => blockIndex !== index),
+    }))
+  }
+
+  const hasIncompleteLocalizedText = draft.blocks.some(
+    (block) =>
+      (block.type === "text" || block.type === "notice") &&
+      (!block.text.en.trim() || !block.text.af.trim())
+  )
+
+  return (
+    <section className="border-border space-y-4 rounded-xl border p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h4 className="font-semibold">{SECTION_NAMES[section.kind]}</h4>
+          <p className="text-muted-foreground text-xs">{section.kind.replaceAll("_", " ")}</p>
+        </div>
+        <label className="text-muted-foreground text-xs">
+          Applicability
+          <select
+            value={draft.applicability}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                applicability: event.target.value as RecipeGuidanceSection["applicability"],
+              }))
+            }
+            disabled={disabled || FOUNDATIONAL_SECTIONS.has(section.kind)}
+            className="border-border bg-background ml-2 rounded-md border px-2 py-1"
+          >
+            <option value="required">Required</option>
+            <option value="optional">Optional</option>
+            <option value="not_applicable">Not applicable</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="space-y-3">
+        {draft.blocks.map((block, index) =>
+          block.type === "text" || block.type === "notice" ? (
+            <div key={block.id} className="bg-muted/30 space-y-3 rounded-lg p-3">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-muted-foreground text-xs font-semibold uppercase">
+                  {block.type === "notice" ? `${block.noticeType} notice` : `${block.source} text`}
+                </p>
+                {block.type === "text" && draft.blocks.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => removeBlock(index)}
+                    disabled={disabled}
+                    className="text-destructive text-xs disabled:opacity-50"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+              <label className="text-muted-foreground block text-xs">
+                English
+                <textarea
+                  value={block.text.en}
+                  onChange={(event) => updateText(index, "en", event.target.value)}
+                  disabled={disabled}
+                  rows={3}
+                  placeholder="Add reviewed English guidance"
+                  className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+                />
+              </label>
+              <label className="text-muted-foreground block text-xs">
+                Afrikaans
+                <textarea
+                  value={block.text.af}
+                  onChange={(event) => updateText(index, "af", event.target.value)}
+                  disabled={disabled}
+                  rows={3}
+                  placeholder="Voeg nagegane Afrikaanse leiding by"
+                  className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+                />
+              </label>
+            </div>
+          ) : (
+            <div
+              key={block.id}
+              className="border-border text-muted-foreground rounded-lg border border-dashed p-3 text-xs"
+            >
+              {blockDescription(block)}
+            </div>
+          )
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {TEXT_SECTION_KINDS.has(section.kind) && (
+          <button
+            type="button"
+            onClick={addReviewedParagraph}
+            disabled={disabled}
+            className="border-border bg-background rounded-lg border px-3 py-2 text-xs disabled:opacity-50"
+          >
+            Add reviewed paragraph
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => void onSave(draft)}
+          disabled={disabled || busy || hasIncompleteLocalizedText}
+          className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-lg px-3 py-2 text-xs font-semibold disabled:opacity-50"
+        >
+          {busy ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Save className="h-3.5 w-3.5" />
+          )}
+          Save section
+        </button>
+      </div>
+    </section>
+  )
+}
+
+function MediaReviewCard({
+  asset,
+  disabled,
+  busy,
+  onReview,
+}: {
+  asset: RecipeMediaAsset
+  disabled: boolean
+  busy: boolean
+  onReview: (
+    asset: RecipeMediaAsset,
+    review:
+      | { decision: "approve"; altText: { en: string; af: string } }
+      | { decision: "reject"; rejectionReason: string }
+  ) => Promise<void>
+}) {
+  const [altEn, setAltEn] = useState(asset.altText?.en ?? "")
+  const [altAf, setAltAf] = useState(asset.altText?.af ?? "")
+  const [rejectionReason, setRejectionReason] = useState(asset.rejectionReason ?? "")
+
+  return (
+    <div className="border-border space-y-3 rounded-xl border p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="font-medium">{asset.role.replaceAll("_", " ")}</p>
+          <p className="text-muted-foreground text-xs">{asset.id}</p>
+        </div>
+        <span className="bg-muted rounded-full px-3 py-1 text-xs uppercase">
+          {asset.status.replaceAll("_", " ")}
+        </span>
+      </div>
+      {asset.status === "review_required" ? (
+        <>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="text-muted-foreground text-xs">
+              English alt text
+              <input
+                value={altEn}
+                onChange={(event) => setAltEn(event.target.value)}
+                disabled={disabled}
+                className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+              />
+            </label>
+            <label className="text-muted-foreground text-xs">
+              Afrikaans alt text
+              <input
+                value={altAf}
+                onChange={(event) => setAltAf(event.target.value)}
+                disabled={disabled}
+                className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+              />
+            </label>
+          </div>
+          <button
+            type="button"
+            onClick={() =>
+              void onReview(asset, {
+                decision: "approve",
+                altText: { en: altEn.trim(), af: altAf.trim() },
+              })
+            }
+            disabled={disabled || busy || !altEn.trim() || !altAf.trim()}
+            className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white disabled:opacity-50"
+          >
+            <Check className="h-3.5 w-3.5" />
+            Approve media
+          </button>
+          <div className="border-border border-t pt-3">
+            <label className="text-muted-foreground text-xs">
+              Rejection reason
+              <input
+                value={rejectionReason}
+                onChange={(event) => setRejectionReason(event.target.value)}
+                disabled={disabled}
+                className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() =>
+                void onReview(asset, {
+                  decision: "reject",
+                  rejectionReason: rejectionReason.trim(),
+                })
+              }
+              disabled={disabled || busy || !rejectionReason.trim()}
+              className="border-destructive/40 text-destructive mt-2 rounded-lg border px-3 py-2 text-xs font-semibold disabled:opacity-50"
+            >
+              Reject media
+            </button>
+          </div>
+        </>
+      ) : (
+        <p className="text-muted-foreground text-sm">
+          {asset.status === "approved"
+            ? "Reviewed media is ready for publication."
+            : (asset.rejectionReason ??
+              asset.unavailableReason ??
+              "No client action is available.")}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function RecipeGuidanceWorkspace({
+  recipe,
+  language,
+}: {
+  recipe: RecipeRecord
+  language: RecipeGuidanceLanguageMode
+}) {
+  const [documents, setDocuments] = useState<RecipeGuidanceDocument[]>([])
+  const [selectedVersion, setSelectedVersion] = useState<number | null>(null)
+  const [preview, setPreview] = useState<GuidancePreviewResponse["data"] | null>(null)
+  const [readiness, setReadiness] = useState<ReadinessResponse["data"] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState("")
+  const [message, setMessage] = useState("")
+  const [error, setError] = useState("")
+  const [reviewChecks, setReviewChecks] = useState({
+    bilingual: false,
+    safety: false,
+    provenance: false,
+  })
+  const [waiverAssetIds, setWaiverAssetIds] = useState<string[]>([])
+
+  const selectedDocument = useMemo(
+    () => documents.find((document) => document.version === selectedVersion) ?? null,
+    [documents, selectedVersion]
+  )
+  const displayDocument = preview?.document ?? selectedDocument
+  const displayRecipe = preview?.recipe ?? recipe
+
+  const loadDocuments = useCallback(async () => {
+    setLoading(true)
+    setError("")
+    try {
+      const response = await apiFetch<GuidanceListResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts`,
+        { label: "RecipeGuidanceVersions" }
+      )
+      const next = sortedDocuments(response.data.documents)
+      setDocuments(next)
+      setSelectedVersion((current) =>
+        current !== null && next.some((document) => document.version === current)
+          ? current
+          : (next[0]?.version ?? null)
+      )
+    } catch (loadError) {
+      setDocuments([])
+      setSelectedVersion(null)
+      setError(getErrorMessage(loadError, "Unable to load recipe guidance versions"))
+    } finally {
+      setLoading(false)
+    }
+  }, [recipe.id])
+
+  const loadReadiness = useCallback(async (document: RecipeGuidanceDocument) => {
+    try {
+      const response = await apiFetch<ReadinessResponse>(
+        `/api/recipes/${document.recipeId}/guidance-drafts/${document.version}/publication-readiness`,
+        { label: "RecipeGuidanceReadiness" }
+      )
+      setReadiness(response.data)
+    } catch (readinessError) {
+      setReadiness(null)
+      setError(getErrorMessage(readinessError, "Unable to inspect publication readiness"))
+    }
+  }, [])
+
+  useEffect(() => {
+    setPreview(null)
+    setMessage("")
+    void loadDocuments()
+  }, [loadDocuments])
+
+  useEffect(() => {
+    setReviewChecks({ bilingual: false, safety: false, provenance: false })
+    setWaiverAssetIds(selectedDocument?.reviewEvidence?.optionalMediaWaiverAssetIds ?? [])
+    if (selectedDocument) void loadReadiness(selectedDocument)
+    else setReadiness(null)
+  }, [loadReadiness, selectedDocument])
+
+  const replaceDocument = (updated: RecipeGuidanceDocument) => {
+    setDocuments((current) =>
+      sortedDocuments([
+        updated,
+        ...current.filter((document) => document.version !== updated.version),
+      ])
+    )
+    setSelectedVersion(updated.version)
+    setPreview(null)
+  }
+
+  const handleMutationError = async (mutationError: unknown, fallback: string) => {
+    setError(getErrorMessage(mutationError, fallback))
+    if (mutationError instanceof ApiError && mutationError.status === 409) {
+      await loadDocuments()
+      setMessage(
+        "The guidance changed. The latest version has been loaded; review it before retrying."
+      )
+    }
+  }
+
+  const previewDraft = async () => {
+    setBusy("preview")
+    setError("")
+    setMessage("")
+    try {
+      const response = await apiFetch<GuidancePreviewResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts/preview`,
+        { method: "POST", label: "RecipeGuidancePreview" }
+      )
+      setPreview(response.data)
+      setMessage(`Previewing version ${response.summary.nextVersion}. Nothing has been persisted.`)
+    } catch (previewError) {
+      await handleMutationError(previewError, "Unable to preview recipe guidance")
+    } finally {
+      setBusy("")
+    }
+  }
+
+  const createDraft = async () => {
+    setBusy("create")
+    setError("")
+    setMessage("")
+    try {
+      const response = await apiFetch<GuidanceMutationResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts`,
+        { method: "POST", label: "RecipeGuidanceCreate" }
+      )
+      replaceDocument(response.data.document)
+      setMessage(`Version ${response.data.document.version} was created as a draft.`)
+    } catch (createError) {
+      await handleMutationError(createError, "Unable to create recipe guidance")
+    } finally {
+      setBusy("")
+    }
+  }
+
+  const saveSection = async (section: RecipeGuidanceSection) => {
+    if (!selectedDocument) return
+    setBusy(`section-${section.id}`)
+    setError("")
+    try {
+      const response = await apiFetch<GuidanceMutationResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts/${selectedDocument.version}`,
+        {
+          method: "PATCH",
+          label: "RecipeGuidanceSection",
+          body: {
+            expectedUpdatedAt: selectedDocument.updatedAt,
+            section: {
+              kind: section.kind,
+              applicability: section.applicability,
+              blocks: section.blocks,
+            },
+          },
+        }
+      )
+      replaceDocument(response.data.document)
+      setMessage(`${SECTION_NAMES[section.kind]} was saved. Review approval was cleared.`)
+    } catch (saveError) {
+      await handleMutationError(saveError, "Unable to save the guidance section")
+    } finally {
+      setBusy("")
+    }
+  }
+
+  const reviewMedia = async (
+    asset: RecipeMediaAsset,
+    review:
+      | { decision: "approve"; altText: { en: string; af: string } }
+      | { decision: "reject"; rejectionReason: string }
+  ) => {
+    if (!selectedDocument) return
+    setBusy(`media-${asset.id}`)
+    setError("")
+    try {
+      const response = await apiFetch<GuidanceMutationResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts/${selectedDocument.version}`,
+        {
+          method: "PATCH",
+          label: "RecipeGuidanceMediaReview",
+          body: {
+            expectedUpdatedAt: selectedDocument.updatedAt,
+            mediaReview: { assetId: asset.id, ...review },
+          },
+        }
+      )
+      replaceDocument(response.data.document)
+      setMessage(`Media ${review.decision === "approve" ? "approved" : "rejected"}.`)
+    } catch (reviewError) {
+      await handleMutationError(reviewError, "Unable to record the media review")
+    } finally {
+      setBusy("")
+    }
+  }
+
+  const transition = async (action: TransitionAction) => {
+    if (!selectedDocument) return
+    setBusy(action)
+    setError("")
+    setMessage("")
+    const evidence: RecipeGuidanceReviewEvidence = {
+      bilingualContentReviewed: true,
+      allergensAndSafetyReviewed: true,
+      provenanceAndRightsReviewed: true,
+      optionalMediaWaiverAssetIds: waiverAssetIds,
+    }
+    try {
+      const response = await apiFetch<GuidanceMutationResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts/${selectedDocument.version}/transitions`,
+        {
+          method: "POST",
+          label: "RecipeGuidanceTransition",
+          body: {
+            action,
+            expectedUpdatedAt: selectedDocument.updatedAt,
+            ...(action === "approve_review" ? { evidence } : {}),
+          },
+        }
+      )
+      replaceDocument(response.data.document)
+      setMessage(
+        `${action.replaceAll("_", " ")} completed for version ${selectedDocument.version}.`
+      )
+    } catch (transitionError) {
+      await handleMutationError(transitionError, "Unable to change the guidance lifecycle")
+    } finally {
+      setBusy("")
+    }
+  }
+
+  const editable = selectedDocument?.status === "draft" || selectedDocument?.status === "in_review"
+  const reviewConfirmed = reviewChecks.bilingual && reviewChecks.safety && reviewChecks.provenance
+  const unavailableAssets =
+    selectedDocument?.mediaAssets.filter((asset) => asset.status === "unavailable") ?? []
+
+  return (
+    <section
+      className="border-primary/20 bg-primary/5 space-y-5 rounded-2xl border p-4 sm:p-5"
+      data-testid="recipe-guidance-workspace"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-primary text-xs font-semibold tracking-[0.18em] uppercase">
+            Hans review workspace
+          </p>
+          <h2 className="text-foreground mt-1 text-xl font-semibold">Recipe guidance lifecycle</h2>
+          <p className="text-muted-foreground mt-1 max-w-2xl text-sm">
+            Preview deterministic guidance, persist a version, review bilingual sections and media,
+            then publish only after every readiness blocker is cleared.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadDocuments()}
+          disabled={loading || Boolean(busy)}
+          className="border-border bg-background inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm disabled:opacity-50"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh versions
+        </button>
+      </div>
+
+      {error && (
+        <div className="border-destructive/30 bg-destructive/10 text-destructive rounded-lg border p-3 text-sm">
+          {error}
+        </div>
+      )}
+      {message && (
+        <div className="bg-muted text-muted-foreground rounded-lg p-3 text-sm">{message}</div>
+      )}
+
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="text-muted-foreground text-xs">
+          Stored version
+          <select
+            value={selectedVersion ?? ""}
+            onChange={(event) => {
+              setPreview(null)
+              setSelectedVersion(event.target.value ? Number(event.target.value) : null)
+            }}
+            disabled={loading || documents.length === 0}
+            className="border-border bg-background text-foreground mt-1 block min-w-48 rounded-lg border px-3 py-2 text-sm"
+          >
+            {documents.length === 0 && <option value="">No stored versions</option>}
+            {documents.map((document) => (
+              <option key={document.id} value={document.version}>
+                Version {document.version} · {document.status.replaceAll("_", " ")}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={() => void previewDraft()}
+          disabled={Boolean(busy)}
+          className="border-border bg-background inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm disabled:opacity-50"
+        >
+          {busy === "preview" ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
+          Preview next version
+        </button>
+        <button
+          type="button"
+          onClick={() => void createDraft()}
+          disabled={Boolean(busy)}
+          className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold disabled:opacity-50"
+        >
+          {busy === "create" ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <FilePlus2 className="h-4 w-4" />
+          )}
+          Create draft
+        </button>
+      </div>
+
+      {loading ? (
+        <p className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading guidance versions…
+        </p>
+      ) : displayDocument ? (
+        <div className="space-y-5">
+          {preview && (
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-200">
+              This is a non-persisted preview. Create the draft before editing or transitioning it.
+            </div>
+          )}
+
+          {!preview && selectedDocument && (
+            <>
+              <div className="grid gap-5 2xl:grid-cols-[minmax(0,1fr)_22rem]">
+                <div className="space-y-4">
+                  <h3 className="font-semibold">Section authoring</h3>
+                  {selectedDocument.sections.map((section) => (
+                    <SectionEditor
+                      key={`${selectedDocument.updatedAt}:${section.id}`}
+                      section={section}
+                      disabled={!editable || Boolean(busy)}
+                      busy={busy === `section-${section.id}`}
+                      onSave={saveSection}
+                    />
+                  ))}
+                </div>
+
+                <aside className="space-y-5">
+                  <section className="border-border bg-card rounded-xl border p-4">
+                    <div className="flex items-center justify-between gap-2">
+                      <h3 className="font-semibold">Publication readiness</h3>
+                      {readiness?.ready ? (
+                        <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                      ) : (
+                        <AlertTriangle className="h-5 w-5 text-amber-500" />
+                      )}
+                    </div>
+                    {readiness ? (
+                      readiness.ready ? (
+                        <p className="mt-3 text-sm text-emerald-700 dark:text-emerald-300">
+                          All deterministic publication checks pass.
+                        </p>
+                      ) : (
+                        <ul className="text-muted-foreground mt-3 space-y-2 text-xs">
+                          {readiness.issues.map((issue, index) => (
+                            <li
+                              key={`${issue.code}-${index}`}
+                              className="border-border border-l-2 pl-2"
+                            >
+                              {issue.message}
+                            </li>
+                          ))}
+                        </ul>
+                      )
+                    ) : (
+                      <p className="text-muted-foreground mt-3 text-sm">
+                        Readiness is unavailable.
+                      </p>
+                    )}
+                  </section>
+
+                  <section className="border-border bg-card space-y-3 rounded-xl border p-4">
+                    <h3 className="font-semibold">Lifecycle actions</h3>
+                    {selectedDocument.status === "draft" && (
+                      <button
+                        type="button"
+                        onClick={() => void transition("submit_for_review")}
+                        disabled={Boolean(busy)}
+                        className="bg-primary text-primary-foreground inline-flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold disabled:opacity-50"
+                      >
+                        <Send className="h-4 w-4" />
+                        Submit for review
+                      </button>
+                    )}
+                    {selectedDocument.status === "in_review" && (
+                      <>
+                        {[
+                          ["bilingual", "English and Afrikaans content reviewed"],
+                          ["safety", "Allergens and food safety reviewed"],
+                          ["provenance", "Media provenance and rights reviewed"],
+                        ].map(([key, label]) => (
+                          <label key={key} className="flex items-start gap-2 text-xs">
+                            <input
+                              type="checkbox"
+                              checked={reviewChecks[key as keyof typeof reviewChecks]}
+                              onChange={(event) =>
+                                setReviewChecks((current) => ({
+                                  ...current,
+                                  [key]: event.target.checked,
+                                }))
+                              }
+                              className="mt-0.5"
+                            />
+                            {label}
+                          </label>
+                        ))}
+                        {unavailableAssets.map((asset) => (
+                          <label key={asset.id} className="flex items-start gap-2 text-xs">
+                            <input
+                              type="checkbox"
+                              checked={waiverAssetIds.includes(asset.id)}
+                              onChange={(event) =>
+                                setWaiverAssetIds((current) =>
+                                  event.target.checked
+                                    ? [...new Set([...current, asset.id])]
+                                    : current.filter((id) => id !== asset.id)
+                                )
+                              }
+                              className="mt-0.5"
+                            />
+                            Explicitly waive unavailable optional media:{" "}
+                            {asset.role.replaceAll("_", " ")}
+                          </label>
+                        ))}
+                        <button
+                          type="button"
+                          onClick={() => void transition("approve_review")}
+                          disabled={Boolean(busy) || !reviewConfirmed}
+                          className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                        >
+                          <ClipboardCheck className="h-4 w-4" />
+                          Record review approval
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void transition("publish")}
+                          disabled={Boolean(busy) || !readiness?.ready}
+                          className="bg-primary text-primary-foreground inline-flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold disabled:opacity-50"
+                        >
+                          <CheckCircle2 className="h-4 w-4" />
+                          Publish guidance
+                        </button>
+                      </>
+                    )}
+                    {selectedDocument.status === "published" && (
+                      <button
+                        type="button"
+                        onClick={() => void transition("archive")}
+                        disabled={Boolean(busy)}
+                        className="border-border bg-background inline-flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold disabled:opacity-50"
+                      >
+                        <Archive className="h-4 w-4" />
+                        Archive version
+                      </button>
+                    )}
+                    {selectedDocument.status === "archived" && (
+                      <p className="text-muted-foreground text-sm">
+                        Archived versions are immutable.
+                      </p>
+                    )}
+                  </section>
+                </aside>
+              </div>
+
+              {selectedDocument.mediaAssets.length > 0 && (
+                <section className="space-y-3">
+                  <h3 className="font-semibold">Media review</h3>
+                  <div className="grid gap-3 lg:grid-cols-2">
+                    {selectedDocument.mediaAssets.map((asset) => (
+                      <MediaReviewCard
+                        key={`${selectedDocument.updatedAt}:${asset.id}`}
+                        asset={asset}
+                        disabled={!editable || Boolean(busy)}
+                        busy={busy === `media-${asset.id}`}
+                        onReview={reviewMedia}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
+          )}
+
+          <details className="group">
+            <summary className="text-muted-foreground cursor-pointer text-sm font-medium">
+              {preview ? "Open draft preview" : "Open rendered version"}
+            </summary>
+            <div className="mt-4">
+              <RecipeGuidanceDocumentView
+                document={displayDocument}
+                recipe={displayRecipe}
+                language={language}
+                heading={preview ? "Non-persisted preview" : "Admin preview"}
+              />
+            </div>
+          </details>
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-sm">
+          No guidance versions exist. Preview the deterministic next version before creating it.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -98,6 +98,30 @@ serving counts must be positive; other valid preparation/cooking metrics remain 
   lifecycle mutations perform no Sluice work, public-package export, migration apply, OmniPost
   action, deployment, or production-data operation.
 
+### Recipe guidance author and reader clients
+
+The shared Recipes surface consumes the lifecycle contracts without recreating their rules in the
+browser.
+
+- Hans receives an admin-only guidance workspace alongside the canonical recipe. It lists immutable
+  versions, labels deterministic previews as non-persisted, creates drafts explicitly, and sends the
+  current `updatedAt` token with every section, media-review, and lifecycle mutation.
+- A `409` response reloads the current version and requires Hans to review it before retrying. The
+  client does not merge stale edits or silently repeat a mutation.
+- Section authoring preserves canonical ingredient, step, metric, and media-reference blocks.
+  Editable bilingual text is marked `source: "reviewed"` only through an explicit save action.
+- Media approval requires English and Afrikaans alternative text. Rejection requires a reason.
+  Reviewer identity and timestamps remain server-owned.
+- Publication controls render the server's deterministic readiness issues. The client collects the
+  three required review confirmations and explicit unavailable-media waivers, but the transition
+  route remains the authority for approval and publication.
+- Irma's Recipes route requests only `GET /api/recipes/:id/guidance`. A published document renders
+  bilingual reviewed sections, canonical ingredient references as a checklist, ordered canonical
+  steps and timers, approved media, and attribution. A `404` leaves the canonical authorized recipe
+  visible; other failures are explicit and retryable.
+- The UI neither seeds guidance nor enables demo data. Browser fixtures intercept requests in local
+  verification only and do not write to a repository or external service.
+
 ## Request flow
 
 1. A resident opens Guidance from a task and captures or chooses a photo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,4 +97,5 @@ Dated session continuity notes (root cause, files changed, verification, next-ow
 | [2026-07-29-recipe-guidance-builder-api.md](handoffs/2026-07-29-recipe-guidance-builder-api.md)           | Deterministic recipe draft builder and bounded preview/read APIs                     |
 | [2026-07-29-recipe-guidance-authoring-api.md](handoffs/2026-07-29-recipe-guidance-authoring-api.md)       | Explicit recipe draft creation and optimistic reviewed-section updates               |
 | [2026-07-29-recipe-guidance-lifecycle.md](handoffs/2026-07-29-recipe-guidance-lifecycle.md)               | Review transitions, readiness evidence, publication, and immutable archival          |
+| [2026-07-31-recipe-guidance-ui.md](handoffs/2026-07-31-recipe-guidance-ui.md)                             | Hans review workspace and Irma mobile published-guidance reader                      |
 | [2026-07-28-user-selectable-themes.md](handoffs/2026-07-28-user-selectable-themes.md)                     | User-selectable workspace themes implementation, review, and merge handoff           |

--- a/docs/handoffs/2026-07-31-recipe-guidance-ui.md
+++ b/docs/handoffs/2026-07-31-recipe-guidance-ui.md
@@ -1,0 +1,89 @@
+# Recipe guidance authoring and reader UI handoff
+
+- **Date:** 2026-07-31
+- **Repository:** `C:\Users\smitj\repos\house-of-veritas`
+- **Worktree:** `C:\tmp\hov-recipe-guidance-ui`
+- **Branch:** `feat/recipe-guidance-ui`
+- **Base:** `origin/main` at `58ae371e195a1a864d8a0ab5a6e405fc62e474fa`
+- **Predecessor:** PR [#160](https://github.com/neuralliquid/house-of-veritas/pull/160)
+- **Baton task:** `ba705f21-05af-49ca-971c-48605bfd120f`
+- **Risk tier:** API/data/UI workflow; internal recipe lifecycle and audience-authorized read only
+
+## Outcome
+
+Added the text-first clients for the stable recipe-guidance lifecycle.
+
+- Hans's existing Recipes route now includes an admin review workspace.
+- The workspace previews the next deterministic version without persistence, creates drafts
+  explicitly, lists stored versions, and renders the selected version.
+- Bilingual section edits preserve server-owned section IDs and canonical reference blocks. Saved
+  text is marked human-reviewed and every mutation sends `expectedUpdatedAt`.
+- Review-required media can be approved with bilingual alt text or rejected with a reason.
+- Readiness blockers come directly from the server. Review confirmation, optional-media waivers,
+  submit, approve, publish, and archive actions use the existing lifecycle endpoints.
+- A `409` reloads the current documents and tells the user to review before retrying.
+- Irma's Recipes route requests the latest audience-authorized published guidance and renders a
+  mobile bilingual document with ingredient checkboxes, ordered canonical steps, timers, notices,
+  approved media, attribution, and published-revision status.
+- Missing published guidance leaves the canonical recipe visible. Datastore and revision failures
+  remain explicit and retryable.
+- A schema-valid published browser fixture exercises the UI without seeding demo or production data.
+
+## Changed files
+
+- `components/recipes/recipe-catalog-client.tsx`
+- `components/recipes/recipe-guidance-workspace.tsx`
+- `components/recipes/recipe-guidance-document-view.tsx`
+- `components/recipes/published-recipe-guidance.tsx`
+- `tests/components/recipe-guidance-ui.test.tsx`
+- `tests/fixtures/recipe-guidance/ui-flow.json`
+- `docs/05-project/task-guidance-architecture.md`
+- `docs/handoffs/2026-07-31-recipe-guidance-ui.md`
+- `docs/README.md`
+
+## Verification
+
+Passed locally:
+
+```text
+pnpm exec vitest run tests/components/recipe-guidance-ui.test.tsx tests/api/recipe-guidance.test.ts tests/lib/recipe-guidance.test.ts tests/lib/recipe-guidance-repository.test.ts tests/lib/recipe-guidance-builder.test.ts tests/lib/recipe-mutation-lock.test.ts
+pnpm exec tsc --noEmit
+pnpm run lint
+pnpm run build
+pnpm exec prettier --check <changed TypeScript, JSON, and Markdown files>
+git diff --check
+```
+
+- Focused result: 6 files, 85 tests passed.
+- TypeScript, full repository lint, and production build passed.
+- Build generated all 125 routes.
+- Playwright CLI used local synthetic Auth.js sessions and intercepted fixture responses:
+  - Hans desktop showed the review workspace, empty version state, preview/create actions, and an
+    explicit non-persisted preview after interaction.
+  - Irma mobile showed published bilingual guidance, ingredient checklist, canonical step, timer,
+    and published-revision marker.
+  - Both final browser sessions had zero console errors or warnings.
+- Screenshots are retained in ignored local artifacts:
+  - `output/playwright/hans-recipe-guidance-workspace.png`
+  - `output/playwright/irma-published-recipe-mobile.png`
+
+## Boundaries and next slice
+
+No deployment, production-data write, migration apply, recipe seed, demo-data enablement,
+uploaded-media intake, media planning, Sluice/provider call, image generation, public package,
+OmniPost action, or authentic production acceptance was performed.
+
+The next bounded slice is authenticated uploaded-media intake and deterministic media planning for
+recipe guidance, including rights metadata and storage provenance. Keep Sluice-backed generation
+disabled until its separate capability, governance, and fail-closed contracts are proven.
+
+## Trace envelope
+
+- **Task:** `ba705f21-05af-49ca-971c-48605bfd120f`
+- **Routing:** Veritas Surface/Studio UI, Gateway lifecycle contracts, Ledger data boundary,
+  Shield authorization, Proof tests/browser verification, Journey/Compass workflow
+- **Context retained:** stable UI/API contracts, browser fixture, architecture boundary, this
+  handoff
+- **Context discarded:** local Auth.js test cookies, intercepted runtime routes, Playwright CLI
+  session logs
+- **External effects:** Baton task creation/update only; no deployment, provider, or data effect

--- a/docs/handoffs/2026-07-31-recipe-guidance-ui.md
+++ b/docs/handoffs/2026-07-31-recipe-guidance-ui.md
@@ -28,6 +28,9 @@ Added the text-first clients for the stable recipe-guidance lifecycle.
 - Missing published guidance leaves the canonical recipe visible. Datastore and revision failures
   remain explicit and retryable.
 - A schema-valid published browser fixture exercises the UI without seeding demo or production data.
+- PR review remediation keys guidance clients by recipe so stale responses cannot cross recipe
+  selections, uses collision-safe UUIDs for new reviewed blocks, and lets Hans remove a rejected
+  optional media reference before saving the section.
 
 ## Changed files
 
@@ -46,7 +49,7 @@ Added the text-first clients for the stable recipe-guidance lifecycle.
 Passed locally:
 
 ```text
-pnpm exec vitest run tests/components/recipe-guidance-ui.test.tsx tests/api/recipe-guidance.test.ts tests/lib/recipe-guidance.test.ts tests/lib/recipe-guidance-repository.test.ts tests/lib/recipe-guidance-builder.test.ts tests/lib/recipe-mutation-lock.test.ts
+pnpm test -- tests/components/recipe-guidance-ui.test.tsx tests/lib/recipe-guidance-builder.test.ts tests/lib/recipe-guidance.test.ts tests/lib/recipe-guidance-repository.test.ts tests/lib/recipe-guidance-migration.test.ts tests/api/recipe-guidance.test.ts
 pnpm exec tsc --noEmit
 pnpm run lint
 pnpm run build
@@ -54,7 +57,8 @@ pnpm exec prettier --check <changed TypeScript, JSON, and Markdown files>
 git diff --check
 ```
 
-- Focused result: 6 files, 85 tests passed.
+- Focused result after bot-review remediation: 6 files, 81 tests passed, including interaction
+  coverage for bilingual media approval, lifecycle conflict reload, and rejected-reference removal.
 - TypeScript, full repository lint, and production build passed.
 - Build generated all 125 routes.
 - Playwright CLI used local synthetic Auth.js sessions and intercepted fixture responses:

--- a/tests/components/recipe-guidance-ui.test.tsx
+++ b/tests/components/recipe-guidance-ui.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { apiFetch } from "@/lib/api-client"
+import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
+import { parseRecipeGuidanceDocument, type RecipeGuidanceDocument } from "@/lib/recipe-guidance"
+import type { RecipeRecord } from "@/lib/recipes"
+import { PublishedRecipeGuidance } from "@/components/recipes/published-recipe-guidance"
+import { RecipeGuidanceDocumentView } from "@/components/recipes/recipe-guidance-document-view"
+import { RecipeGuidanceWorkspace } from "@/components/recipes/recipe-guidance-workspace"
+import uiFlowFixture from "@/tests/fixtures/recipe-guidance/ui-flow.json"
+
+vi.mock("@/lib/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-client")>()
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+  }
+})
+
+const recipe: RecipeRecord = {
+  id: "recipe-ui-test",
+  status: "published",
+  ownerUserId: "hans",
+  audienceUserIds: ["hans", "irma"],
+  titleEn: "Garden stew",
+  titleAf: "Tuinbredie",
+  summaryEn: "A simple seasonal stew.",
+  summaryAf: "’n Eenvoudige seisoenbredie.",
+  servings: 4,
+  prepMinutes: 10,
+  cookMinutes: 30,
+  category: "Dinner",
+  cuisine: "South African",
+  image: {
+    url: "https://example.com/stew.jpg",
+    source: "Example library",
+    license: "CC BY 4.0",
+    attributionText: "Example cook",
+    retrievedAt: "2026-07-31",
+  },
+  ingredients: [
+    {
+      id: "ingredient-carrot",
+      name: "Carrots",
+      quantity: "2",
+      unit: "whole",
+      preparationNote: "sliced",
+    },
+  ],
+  steps: [
+    {
+      id: "step-simmer",
+      order: 1,
+      instructionEn: "Simmer until tender.",
+      instructionAf: "Prut tot sag.",
+      timerMinutes: 30,
+    },
+  ],
+  createdAt: "2026-07-31T08:00:00.000Z",
+  updatedAt: "2026-07-31T08:00:00.000Z",
+}
+
+const draft = buildRecipeGuidanceDraft(recipe, {
+  version: 1,
+  createdBy: "hans",
+  now: "2026-07-31T08:05:00.000Z",
+})
+
+describe("recipe guidance UI", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset()
+  })
+
+  it("keeps the browser-flow published fixture inside the document contract", () => {
+    expect(parseRecipeGuidanceDocument(uiFlowFixture.document)).not.toBeNull()
+  })
+
+  it("renders bilingual canonical facts in the structured guidance reader", () => {
+    render(
+      <RecipeGuidanceDocumentView
+        document={draft}
+        recipe={recipe}
+        language="both"
+        heading="Preview"
+      />
+    )
+
+    expect(screen.getByRole("heading", { name: "Garden stew / Tuinbredie" })).toBeInTheDocument()
+    expect(screen.getByText("Carrots", { exact: false })).toBeInTheDocument()
+    expect(screen.getByText("Simmer until tender.")).toBeInTheDocument()
+    expect(screen.getByText("Prut tot sag.")).toBeInTheDocument()
+    expect(screen.getAllByText("30 min")).toHaveLength(2)
+  })
+
+  it("loads the latest published guidance for Irma", async () => {
+    const published = { ...draft, status: "published" } as RecipeGuidanceDocument
+    vi.mocked(apiFetch).mockResolvedValue({
+      data: { recipe, document: published },
+      summary: { version: 1 },
+    })
+
+    render(<PublishedRecipeGuidance recipeId={recipe.id} language="both" />)
+
+    expect(await screen.findByText("Irma’s kitchen view")).toBeInTheDocument()
+    expect(apiFetch).toHaveBeenCalledWith(`/api/recipes/${recipe.id}/guidance`, {
+      label: "PublishedRecipeGuidance",
+    })
+  })
+
+  it("previews and explicitly persists the next admin draft", async () => {
+    vi.mocked(apiFetch).mockImplementation(async (url, options) => {
+      if (url.endsWith("/guidance-drafts/preview")) {
+        return {
+          data: { recipe, document: draft },
+          summary: { persisted: false, nextVersion: 1 },
+        }
+      }
+      if (url.endsWith("/guidance-drafts") && options?.method === "POST") {
+        return {
+          data: { recipe, document: draft },
+          summary: { persisted: true, version: 1 },
+        }
+      }
+      if (url.endsWith("/publication-readiness")) {
+        return {
+          data: {
+            documentId: draft.id,
+            version: 1,
+            status: "draft",
+            ready: false,
+            issues: [{ code: "status", message: "Guidance must be in review before publication" }],
+          },
+        }
+      }
+      return { data: { documents: [] }, summary: { count: 0, mode: "test" } }
+    })
+
+    const user = userEvent.setup()
+    render(<RecipeGuidanceWorkspace recipe={recipe} language="both" />)
+
+    expect(
+      await screen.findByText("No guidance versions exist.", { exact: false })
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Preview next version" }))
+    expect(
+      await screen.findByText("This is a non-persisted preview.", { exact: false })
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Create draft" }))
+    await waitFor(() =>
+      expect(screen.getByRole("combobox", { name: "Stored version" })).toHaveValue("1")
+    )
+    expect(screen.getByText("Version 1 was created as a draft.")).toBeInTheDocument()
+  })
+})

--- a/tests/components/recipe-guidance-ui.test.tsx
+++ b/tests/components/recipe-guidance-ui.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { apiFetch } from "@/lib/api-client"
+import { ApiError, apiFetch } from "@/lib/api-client"
 import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
 import { parseRecipeGuidanceDocument, type RecipeGuidanceDocument } from "@/lib/recipe-guidance"
 import type { RecipeRecord } from "@/lib/recipes"
@@ -153,5 +153,168 @@ describe("recipe guidance UI", () => {
       expect(screen.getByRole("combobox", { name: "Stored version" })).toHaveValue("1")
     )
     expect(screen.getByText("Version 1 was created as a draft.")).toBeInTheDocument()
+  })
+
+  it("requires bilingual alt text before approving review-required media", async () => {
+    const approved = {
+      ...draft,
+      mediaAssets: draft.mediaAssets.map((asset) => ({
+        ...asset,
+        status: "approved" as const,
+        altText: { en: "Stew in a bowl", af: "Bredie in ’n bak" },
+        reviewedBy: "hans",
+        reviewedAt: "2026-07-31T08:06:00.000Z",
+      })),
+      updatedAt: "2026-07-31T08:06:00.000Z",
+    }
+    vi.mocked(apiFetch).mockImplementation(async (url, options) => {
+      if (url.endsWith("/publication-readiness")) {
+        return {
+          data: {
+            documentId: draft.id,
+            version: 1,
+            status: "draft",
+            ready: false,
+            issues: [{ code: "media", message: "Media review is required" }],
+          },
+        }
+      }
+      if (options?.label === "RecipeGuidanceMediaReview") {
+        return { data: { document: approved } }
+      }
+      return { data: { documents: [draft] } }
+    })
+
+    const user = userEvent.setup()
+    render(<RecipeGuidanceWorkspace recipe={recipe} language="both" />)
+
+    const approve = await screen.findByRole("button", { name: "Approve media" })
+    expect(approve).toBeDisabled()
+    await user.type(screen.getByRole("textbox", { name: "English alt text" }), "Stew in a bowl")
+    expect(approve).toBeDisabled()
+    await user.type(screen.getByRole("textbox", { name: "Afrikaans alt text" }), "Bredie in ’n bak")
+    expect(approve).toBeEnabled()
+    await user.click(approve)
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        `/api/recipes/${recipe.id}/guidance-drafts/1`,
+        expect.objectContaining({
+          body: {
+            expectedUpdatedAt: draft.updatedAt,
+            mediaReview: {
+              assetId: draft.mediaAssets[0]?.id,
+              decision: "approve",
+              altText: { en: "Stew in a bowl", af: "Bredie in ’n bak" },
+            },
+          },
+        })
+      )
+    )
+  })
+
+  it("reloads the latest document when a lifecycle transition conflicts", async () => {
+    let listCalls = 0
+    vi.mocked(apiFetch).mockImplementation(async (url, options) => {
+      if (url.endsWith("/publication-readiness")) {
+        return {
+          data: {
+            documentId: draft.id,
+            version: 1,
+            status: "draft",
+            ready: false,
+            issues: [{ code: "status", message: "Guidance must be reviewed" }],
+          },
+        }
+      }
+      if (options?.label === "RecipeGuidanceTransition") {
+        throw new ApiError("Conflict", 409, "Conflict", {
+          error: "Recipe guidance changed; refresh and retry",
+        })
+      }
+      listCalls += 1
+      return { data: { documents: [draft] } }
+    })
+
+    const user = userEvent.setup()
+    render(<RecipeGuidanceWorkspace recipe={recipe} language="both" />)
+
+    await user.click(await screen.findByRole("button", { name: "Submit for review" }))
+
+    expect(
+      await screen.findByText(
+        "The guidance changed. The latest version has been loaded; review it before retrying."
+      )
+    ).toBeInTheDocument()
+    expect(listCalls).toBe(2)
+    expect(apiFetch).toHaveBeenCalledWith(
+      `/api/recipes/${recipe.id}/guidance-drafts/1/transitions`,
+      expect.objectContaining({
+        body: { action: "submit_for_review", expectedUpdatedAt: draft.updatedAt },
+      })
+    )
+  })
+
+  it("lets Hans remove a rejected optional media reference before saving", async () => {
+    const rejected = {
+      ...draft,
+      mediaAssets: draft.mediaAssets.map((asset) => ({
+        ...asset,
+        status: "rejected" as const,
+        rejectionReason: "The image does not match the recipe",
+        reviewedBy: "hans",
+        reviewedAt: "2026-07-31T08:06:00.000Z",
+      })),
+      updatedAt: "2026-07-31T08:06:00.000Z",
+    }
+    const hero = rejected.sections.find((section) => section.kind === "hero")!
+    const saved = {
+      ...rejected,
+      sections: rejected.sections.map((section) =>
+        section.kind === "hero" ? { ...section, blocks: [] } : section
+      ),
+      updatedAt: "2026-07-31T08:07:00.000Z",
+    }
+    vi.mocked(apiFetch).mockImplementation(async (url, options) => {
+      if (url.endsWith("/publication-readiness")) {
+        return {
+          data: {
+            documentId: rejected.id,
+            version: 1,
+            status: "draft",
+            ready: false,
+            issues: [{ code: "hero", message: "Rejected media is still referenced" }],
+          },
+        }
+      }
+      if (options?.label === "RecipeGuidanceSection") {
+        return { data: { document: saved } }
+      }
+      return { data: { documents: [rejected] } }
+    })
+
+    const user = userEvent.setup()
+    render(<RecipeGuidanceWorkspace recipe={recipe} language="both" />)
+
+    const heroEditor = (await screen.findByRole("heading", { name: "Hero image" })).closest(
+      "section"
+    )
+    expect(heroEditor).not.toBeNull()
+    await user.click(
+      within(heroEditor!).getByRole("button", { name: "Remove rejected media reference" })
+    )
+    await user.click(within(heroEditor!).getByRole("button", { name: "Save section" }))
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        `/api/recipes/${recipe.id}/guidance-drafts/1`,
+        expect.objectContaining({
+          body: {
+            expectedUpdatedAt: rejected.updatedAt,
+            section: { kind: "hero", applicability: hero.applicability, blocks: [] },
+          },
+        })
+      )
+    )
   })
 })

--- a/tests/fixtures/recipe-guidance/ui-flow.json
+++ b/tests/fixtures/recipe-guidance/ui-flow.json
@@ -1,0 +1,223 @@
+{
+  "recipe": {
+    "id": "recipe-ui-flow",
+    "status": "published",
+    "ownerUserId": "hans",
+    "audienceUserIds": ["hans", "irma"],
+    "titleEn": "Garden stew",
+    "titleAf": "Tuinbredie",
+    "summaryEn": "A simple seasonal stew for a quiet evening.",
+    "summaryAf": "'n Eenvoudige seisoenbredie vir 'n rustige aand.",
+    "servings": 4,
+    "prepMinutes": 10,
+    "cookMinutes": 30,
+    "category": "Dinner",
+    "cuisine": "South African",
+    "image": {
+      "url": "https://images.unsplash.com/photo-1547592180-85f173990554",
+      "source": "Unsplash",
+      "author": "Ella Olsson",
+      "license": "Unsplash License",
+      "attributionText": "Photo by Ella Olsson on Unsplash",
+      "retrievedAt": "2026-07-31"
+    },
+    "ingredients": [
+      {
+        "id": "ingredient-carrot",
+        "name": "Carrots",
+        "quantity": "2",
+        "unit": "whole",
+        "preparationNote": "sliced"
+      },
+      {
+        "id": "ingredient-beans",
+        "name": "White beans",
+        "quantity": "1",
+        "unit": "tin",
+        "preparationNote": "drained"
+      }
+    ],
+    "steps": [
+      {
+        "id": "step-simmer",
+        "order": 1,
+        "instructionEn": "Add the vegetables and beans, then simmer until tender.",
+        "instructionAf": "Voeg die groente en bone by en prut dan tot sag.",
+        "timerMinutes": 30
+      }
+    ],
+    "createdAt": "2026-07-31T08:00:00.000Z",
+    "updatedAt": "2026-07-31T08:00:00.000Z"
+  },
+  "document": {
+    "id": "recipe-guidance-recipe-ui-flow-v1",
+    "recipeId": "recipe-ui-flow",
+    "recipeRevisionId": "recipe-ui-flow@2026-07-31T08:00:00.000Z",
+    "recipeUpdatedAt": "2026-07-31T08:00:00.000Z",
+    "recipeIngredientIds": ["ingredient-carrot", "ingredient-beans"],
+    "recipeStepIds": ["step-simmer"],
+    "version": 1,
+    "status": "published",
+    "ownerUserId": "hans",
+    "audienceUserIds": ["hans", "irma"],
+    "sections": [
+      {
+        "id": "section-identity",
+        "kind": "identity",
+        "applicability": "required",
+        "blocks": [
+          {
+            "id": "identity-title",
+            "type": "text",
+            "source": "reviewed",
+            "text": { "en": "Garden stew", "af": "Tuinbredie" }
+          },
+          {
+            "id": "identity-summary",
+            "type": "text",
+            "source": "reviewed",
+            "text": {
+              "en": "A simple seasonal stew for a quiet evening.",
+              "af": "'n Eenvoudige seisoenbredie vir 'n rustige aand."
+            }
+          },
+          {
+            "id": "identity-metrics",
+            "type": "metrics",
+            "servings": 4,
+            "prepMinutes": 10,
+            "cookMinutes": 30
+          }
+        ]
+      },
+      {
+        "id": "section-hero",
+        "kind": "hero",
+        "applicability": "not_applicable",
+        "blocks": []
+      },
+      {
+        "id": "section-before-start",
+        "kind": "before_start",
+        "applicability": "optional",
+        "blocks": [
+          {
+            "id": "before-start-text",
+            "type": "text",
+            "source": "reviewed",
+            "text": {
+              "en": "Wash the vegetables and clear a safe workspace.",
+              "af": "Was die groente en maak 'n veilige werkplek oop."
+            }
+          }
+        ]
+      },
+      {
+        "id": "section-ingredients",
+        "kind": "ingredients",
+        "applicability": "required",
+        "blocks": [
+          {
+            "id": "ingredient-references",
+            "type": "ingredient_references",
+            "recipeRevisionId": "recipe-ui-flow@2026-07-31T08:00:00.000Z",
+            "ingredientIds": ["ingredient-carrot", "ingredient-beans"]
+          }
+        ]
+      },
+      {
+        "id": "section-preparation",
+        "kind": "preparation",
+        "applicability": "optional",
+        "blocks": [
+          {
+            "id": "preparation-text",
+            "type": "text",
+            "source": "reviewed",
+            "text": {
+              "en": "Slice the carrots evenly so they cook at the same rate.",
+              "af": "Sny die wortels ewe dik sodat hulle teen dieselfde tempo gaar word."
+            }
+          }
+        ]
+      },
+      {
+        "id": "section-cooking",
+        "kind": "cooking",
+        "applicability": "required",
+        "blocks": [
+          {
+            "id": "step-reference-simmer",
+            "type": "step_reference",
+            "recipeRevisionId": "recipe-ui-flow@2026-07-31T08:00:00.000Z",
+            "recipeStepId": "step-simmer",
+            "timer": { "minimumSeconds": 1800 }
+          }
+        ]
+      },
+      {
+        "id": "section-finish",
+        "kind": "finish_and_serve",
+        "applicability": "optional",
+        "blocks": [
+          {
+            "id": "finish-text",
+            "type": "text",
+            "source": "reviewed",
+            "text": {
+              "en": "Taste, adjust seasoning, and serve warm.",
+              "af": "Proe, pas die geurmiddels aan en bedien warm."
+            }
+          }
+        ]
+      },
+      {
+        "id": "section-storage",
+        "kind": "storage_and_reheating",
+        "applicability": "optional",
+        "blocks": [
+          {
+            "id": "storage-text",
+            "type": "text",
+            "source": "reviewed",
+            "text": {
+              "en": "Cool promptly and refrigerate in a sealed container.",
+              "af": "Laat vinnig afkoel en verkoel in 'n verseëlde houer."
+            }
+          }
+        ]
+      },
+      {
+        "id": "section-provenance",
+        "kind": "provenance_and_feedback",
+        "applicability": "required",
+        "blocks": [
+          {
+            "id": "provenance-text",
+            "type": "text",
+            "source": "reviewed",
+            "text": {
+              "en": "House recipe reviewed by Hans.",
+              "af": "Huisresep deur Hans nagegaan."
+            }
+          }
+        ]
+      }
+    ],
+    "mediaAssets": [],
+    "imageBriefs": [],
+    "createdBy": "hans",
+    "createdAt": "2026-07-31T08:05:00.000Z",
+    "updatedAt": "2026-07-31T08:10:00.000Z",
+    "reviewedBy": "hans",
+    "reviewedAt": "2026-07-31T08:09:00.000Z",
+    "reviewEvidence": {
+      "bilingualContentReviewed": true,
+      "allergensAndSafetyReviewed": true,
+      "provenanceAndRightsReviewed": true,
+      "optionalMediaWaiverAssetIds": []
+    },
+    "publishedBy": "hans",
+    "publishedAt": "2026-07-31T08:10:00.000Z"
+  }
+}


### PR DESCRIPTION
## What changed
- add a Hans-only recipe guidance workspace for previewing, creating, editing, reviewing, transitioning, publishing, and archiving guidance documents
- add an Irma mobile reader for the latest audience-authorized published bilingual guidance, while preserving the canonical recipe fallback
- enforce revision-safe mutations, readiness blockers, bilingual reviewed text, explicit media decisions, and conflict reloads
- add component coverage, a schema-valid UI fixture, architecture notes, and a replayable handoff

## Why
PR #160 stabilized the recipe-guidance lifecycle APIs but intentionally left the client surface out of scope. This is the next bounded slice: a deterministic author/review workflow for Hans and a practical published reader for Irma.

## Validation
- `pnpm test -- tests/components/recipe-guidance-ui.test.tsx tests/lib/recipe-guidance-builder.test.ts tests/lib/recipe-guidance.test.ts tests/lib/recipe-guidance-repository.test.ts tests/lib/recipe-guidance-migration.test.ts tests/api/recipe-guidance.test.ts` — 78 passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm run lint` — passed
- `pnpm run build` — passed, 125 routes
- Playwright browser check: Hans desktop workspace and non-persisted preview; Irma mobile published bilingual reader, ingredient checklist, canonical step, timer, and revision marker; zero console warnings/errors

## Boundaries
No deployment, production writes, migration apply, demo-data defaults, Sluice/provider calls, public package generation, or OmniPost work.

Baton: `ba705f21-05af-49ca-971c-48605bfd120f`