### PR TITLE
Add recipe guidance media intake and planning

### DIFF
--- a/app/api/recipes/[id]/guidance-drafts/[version]/route.ts
+++ b/app/api/recipes/[id]/guidance-drafts/[version]/route.ts
@@ -9,11 +9,13 @@ import {
   recipeGuidanceSectionSchema,
   type RecipeGuidanceDocument,
 } from "@/lib/recipe-guidance"
+import { attachRecipeGuidanceUpload, planRecipeGuidanceMedia } from "@/lib/recipe-guidance-media"
 import {
   RecipeGuidanceConflictError,
   getRecipeGuidanceRepository,
 } from "@/lib/repositories/recipe-guidance-repository"
 import { getRecipeById } from "@/lib/repositories/recipe-repository"
+import { getUploadContentHash, getUploadMetadataById } from "@/lib/uploads"
 
 const sectionUpdateSchema = z
   .object({
@@ -41,12 +43,35 @@ const mediaReviewSchema = z.discriminatedUnion("decision", [
     .strict(),
 ])
 
+const mediaPlanSchema = z.object({ action: z.literal("create_missing") }).strict()
+
+const mediaAttachmentSchema = z
+  .object({
+    mediaAssetId: z.string().trim().min(1).max(200),
+    uploadId: z.string().trim().min(1).max(200),
+    rightsBasis: z.string().trim().min(1).max(500),
+    attributionText: z.string().trim().min(1).max(1_000),
+  })
+  .strict()
+
 const draftUpdateSchema = z.union([
   sectionUpdateSchema,
   z
     .object({
       expectedUpdatedAt: z.string().datetime({ offset: true }),
       mediaReview: mediaReviewSchema,
+    })
+    .strict(),
+  z
+    .object({
+      expectedUpdatedAt: z.string().datetime({ offset: true }),
+      mediaPlan: mediaPlanSchema,
+    })
+    .strict(),
+  z
+    .object({
+      expectedUpdatedAt: z.string().datetime({ offset: true }),
+      mediaAttachment: mediaAttachmentSchema,
     })
     .strict(),
 ])
@@ -153,7 +178,7 @@ export const PATCH = withRole("admin")(async (request, context) => {
       }
       candidate = { ...withoutReview(document), sections, updatedAt: now }
       summary = { mode, version: document.version, updatedSection: currentSection.kind }
-    } else {
+    } else if ("mediaReview" in parsed.data) {
       invalidUpdateError = "Media review conflicts with the guidance document"
       const mediaReview = parsed.data.mediaReview
       const mediaAssetIndex = document.mediaAssets.findIndex(
@@ -196,6 +221,73 @@ export const PATCH = withRole("admin")(async (request, context) => {
         version: document.version,
         reviewedMediaAsset: currentAsset.id,
         decision: mediaReview.decision,
+      }
+    } else if ("mediaPlan" in parsed.data) {
+      invalidUpdateError = "Media planning conflicts with the guidance document"
+      const plan = planRecipeGuidanceMedia(document, recipe, now)
+      if (!plan) {
+        return NextResponse.json({ error: invalidUpdateError }, { status: 400 })
+      }
+      if (plan.addedAssetIds.length === 0) {
+        if (parsed.data.expectedUpdatedAt !== document.updatedAt) {
+          return NextResponse.json(
+            { error: "Recipe guidance changed; refresh and retry" },
+            { status: 409 }
+          )
+        }
+        return NextResponse.json({
+          data: { document },
+          summary: { mode, version: document.version, plannedMediaAssets: [] },
+        })
+      }
+      candidate = plan.document
+      summary = {
+        mode,
+        version: document.version,
+        plannedMediaAssets: plan.addedAssetIds,
+      }
+    } else {
+      invalidUpdateError = "Uploaded media conflicts with the guidance document"
+      const attachment = parsed.data.mediaAttachment
+      const upload = await getUploadMetadataById(attachment.uploadId)
+      if (!upload) {
+        return NextResponse.json({ error: "Recipe guidance upload not found" }, { status: 404 })
+      }
+      if (
+        upload.resourceType !== "recipe-guidance" ||
+        upload.resourceId !== recipeId ||
+        upload.category !== "image" ||
+        !upload.mimeType.startsWith("image/")
+      ) {
+        return NextResponse.json(
+          { error: "Upload is not an image scoped to this recipe guidance" },
+          { status: 403 }
+        )
+      }
+      const contentHash = await getUploadContentHash(upload)
+      if (!contentHash) {
+        return NextResponse.json(
+          { error: "Recipe guidance upload content is unavailable" },
+          { status: 409 }
+        )
+      }
+      const attached = attachRecipeGuidanceUpload(document, {
+        mediaAssetId: attachment.mediaAssetId,
+        upload,
+        contentHash,
+        rightsBasis: attachment.rightsBasis,
+        attributionText: attachment.attributionText,
+        now,
+      })
+      if (!attached) {
+        return NextResponse.json({ error: invalidUpdateError }, { status: 400 })
+      }
+      candidate = attached
+      summary = {
+        mode,
+        version: document.version,
+        attachedUploadId: upload.id,
+        mediaAssetId: attachment.mediaAssetId,
       }
     }
 

--- a/app/api/uploads/[id]/route.ts
+++ b/app/api/uploads/[id]/route.ts
@@ -10,6 +10,9 @@ import {
   isUploadId,
   readLocalUploadMetadata,
 } from "@/lib/uploads"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
+import { createRecipeRevisionId } from "@/lib/recipe-guidance"
+import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
 
 let schemaEnsured = false
 
@@ -74,10 +77,57 @@ export const GET = withAuth(async (_request, context) => {
         return NextResponse.json({ error: "Task not found." }, { status: 404 })
       }
       if (taskAccess.status === 403) {
-        return NextResponse.json(
-          { error: "You do not have access to this task." },
-          { status: 403 }
+        return NextResponse.json({ error: "You do not have access to this task." }, { status: 403 })
+      }
+    }
+
+    if (resourceType === "recipe-guidance") {
+      if (!resourceId) {
+        return NextResponse.json({ error: "Upload recipe binding is missing." }, { status: 403 })
+      }
+      const recipe = await getRecipeById(resourceId)
+      if (!recipe) {
+        return NextResponse.json({ error: "Recipe not found." }, { status: 404 })
+      }
+      if (context.role !== "admin") {
+        const recipeAudience = new Set([recipe.ownerUserId, ...recipe.audienceUserIds])
+        if (!recipeAudience.has(context.userId)) {
+          return NextResponse.json(
+            { error: "You do not have access to this recipe upload." },
+            { status: 403 }
+          )
+        }
+
+        const { repository } = await getRecipeGuidanceRepository()
+        const document = await repository.findLatestPublished(resourceId)
+        const documentAudience = new Set(
+          document ? [document.ownerUserId, ...document.audienceUserIds] : []
         )
+        const approvedAsset = document?.mediaAssets.find(
+          (asset) =>
+            asset.status === "approved" &&
+            asset.storage?.type === "hov" &&
+            asset.storage.storageId === id
+        )
+        const isReferenced = Boolean(
+          approvedAsset &&
+          document?.sections.some((section) =>
+            section.blocks.some(
+              (block) => block.type === "media_reference" && block.mediaAssetId === approvedAsset.id
+            )
+          )
+        )
+        if (
+          !document ||
+          document.recipeRevisionId !== createRecipeRevisionId(recipe.id, recipe.updatedAt) ||
+          !documentAudience.has(context.userId) ||
+          !isReferenced
+        ) {
+          return NextResponse.json(
+            { error: "You do not have access to this recipe upload." },
+            { status: 403 }
+          )
+        }
       }
     }
 

--- a/app/api/uploads/route.ts
+++ b/app/api/uploads/route.ts
@@ -14,6 +14,7 @@ import {
   UPLOAD_DIR,
 } from "@/lib/uploads"
 import { resolveTaskAccess } from "@/lib/task-access"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
 
 const ALLOWED_TYPES: Record<string, string[]> = {
   image: ["image/jpeg", "image/png", "image/gif", "image/webp"],
@@ -46,6 +47,30 @@ async function ensureUploadDir() {
   if (!existsSync(UPLOAD_DIR)) {
     await mkdir(UPLOAD_DIR, { recursive: true })
   }
+}
+
+async function authorizeRecipeGuidanceResource(
+  resourceType: string | null,
+  resourceId: string | null,
+  role: string
+): Promise<NextResponse | null> {
+  if (resourceType !== "recipe-guidance") return null
+  if (!resourceId) {
+    return NextResponse.json(
+      { error: "resourceId is required for recipe guidance uploads." },
+      { status: 400 }
+    )
+  }
+  if (role !== "admin") {
+    return NextResponse.json(
+      { error: "Admin access is required for recipe guidance uploads." },
+      { status: 403 }
+    )
+  }
+  if (!(await getRecipeById(resourceId))) {
+    return NextResponse.json({ error: "Recipe not found." }, { status: 404 })
+  }
+  return null
 }
 
 async function persistToPostgres(metadata: {
@@ -141,6 +166,14 @@ export const GET = withAuth(async (request, context) => {
   }
 
   const isAuthorizedTaskGuidanceList = resourceType === "task-guidance" && Boolean(resourceId)
+  const recipeGuidanceError = await authorizeRecipeGuidanceResource(
+    resourceType,
+    resourceId,
+    context.role
+  )
+  if (recipeGuidanceError) return recipeGuidanceError
+  const isAuthorizedRecipeGuidanceList =
+    resourceType === "recipe-guidance" && Boolean(resourceId) && context.role === "admin"
   if (resourceType === "task-guidance") {
     if (!resourceId) {
       return NextResponse.json(
@@ -154,18 +187,17 @@ export const GET = withAuth(async (request, context) => {
       return NextResponse.json({ error: "Task not found." }, { status: 404 })
     }
     if (taskAccess.status === 403) {
-      return NextResponse.json(
-        { error: "You do not have access to this task." },
-        { status: 403 }
-      )
+      return NextResponse.json({ error: "You do not have access to this task." }, { status: 403 })
     }
   }
 
   if (isPostgresConfigured()) {
     await ensureSchemaOnce()
     let files = await getFilesFromPostgres(filters)
-    if (!isAuthorizedTaskGuidanceList) {
-      files = files.filter((file) => file.resourceType !== "task-guidance")
+    if (!isAuthorizedTaskGuidanceList && !isAuthorizedRecipeGuidanceList) {
+      files = files.filter(
+        (file) => file.resourceType !== "task-guidance" && file.resourceType !== "recipe-guidance"
+      )
     }
     return NextResponse.json({ files, total: files.length })
   }
@@ -175,8 +207,10 @@ export const GET = withAuth(async (request, context) => {
   if (category) files = files.filter((f) => f.category === category)
   if (resourceType) files = files.filter((f) => f.resourceType === resourceType)
   if (resourceId) files = files.filter((f) => f.resourceId === resourceId)
-  if (!isAuthorizedTaskGuidanceList) {
-    files = files.filter((file) => file.resourceType !== "task-guidance")
+  if (!isAuthorizedTaskGuidanceList && !isAuthorizedRecipeGuidanceList) {
+    files = files.filter(
+      (file) => file.resourceType !== "task-guidance" && file.resourceType !== "recipe-guidance"
+    )
   }
 
   return NextResponse.json({
@@ -193,6 +227,20 @@ export const POST = withAuth(async (request, context) => {
     const resourceType = (formData.get("resourceType") as string | null)?.trim() || null
     const resourceId = (formData.get("resourceId") as string | null)?.trim() || null
     const uploader = context.userId
+
+    const recipeGuidanceError = await authorizeRecipeGuidanceResource(
+      resourceType,
+      resourceId,
+      context.role
+    )
+    if (recipeGuidanceError) return recipeGuidanceError
+
+    if (resourceType === "recipe-guidance" && category !== "image") {
+      return NextResponse.json(
+        { error: "Recipe guidance uploads must use the image category." },
+        { status: 400 }
+      )
+    }
 
     if (!file) {
       return NextResponse.json({ error: "No file provided" }, { status: 400 })
@@ -228,10 +276,7 @@ export const POST = withAuth(async (request, context) => {
         return NextResponse.json({ error: "Task not found." }, { status: 404 })
       }
       if (taskAccess.status === 403) {
-        return NextResponse.json(
-          { error: "You do not have access to this task." },
-          { status: 403 }
-        )
+        return NextResponse.json({ error: "You do not have access to this task." }, { status: 403 })
       }
     }
 
@@ -282,6 +327,14 @@ export const DELETE = withAuth(async (request, context) => {
   }
 
   const file = await getUploadMetadataById(fileId)
+  if (file?.resourceType === "recipe-guidance") {
+    const recipeGuidanceError = await authorizeRecipeGuidanceResource(
+      file.resourceType,
+      file.resourceId ?? null,
+      context.role
+    )
+    if (recipeGuidanceError) return recipeGuidanceError
+  }
   if (file?.resourceType === "task-guidance") {
     if (!file.resourceId) {
       return NextResponse.json({ error: "Upload task binding is missing." }, { status: 403 })
@@ -292,10 +345,7 @@ export const DELETE = withAuth(async (request, context) => {
       return NextResponse.json({ error: "Task not found." }, { status: 404 })
     }
     if (taskAccess.status === 403) {
-      return NextResponse.json(
-        { error: "You do not have access to this task." },
-        { status: 403 }
-      )
+      return NextResponse.json({ error: "You do not have access to this task." }, { status: 403 })
     }
   }
 

--- a/components/recipes/recipe-guidance-media-intake.tsx
+++ b/components/recipes/recipe-guidance-media-intake.tsx
@@ -1,0 +1,301 @@
+"use client"
+
+import { ApiError, apiFetch } from "@/lib/api-client"
+import type { RecipeGuidanceDocument } from "@/lib/recipe-guidance"
+import { ImagePlus, Loader2, RefreshCw, Upload } from "lucide-react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+interface UploadRecord {
+  id: string
+  originalName: string
+  mimeType: string
+  size: number
+  uploadedBy: string
+  uploadedAt: string
+  url: string
+}
+
+interface UploadListResponse {
+  files: UploadRecord[]
+  total: number
+}
+
+interface UploadResponse {
+  file: UploadRecord
+}
+
+function errorText(error: unknown, fallback: string) {
+  if (
+    error instanceof ApiError &&
+    error.body &&
+    typeof error.body === "object" &&
+    "error" in error.body &&
+    typeof error.body.error === "string"
+  ) {
+    return error.body.error
+  }
+  return error instanceof Error ? error.message : fallback
+}
+
+export function RecipeGuidanceMediaIntake({
+  recipeId,
+  document,
+  disabled,
+  busy,
+  onPlan,
+  onAttach,
+}: {
+  recipeId: string
+  document: RecipeGuidanceDocument
+  disabled: boolean
+  busy: boolean
+  onPlan: () => Promise<void>
+  onAttach: (input: {
+    mediaAssetId: string
+    uploadId: string
+    rightsBasis: string
+    attributionText: string
+  }) => Promise<void>
+}) {
+  const [uploads, setUploads] = useState<UploadRecord[]>([])
+  const [selectedUploadId, setSelectedUploadId] = useState("")
+  const [selectedAssetId, setSelectedAssetId] = useState("")
+  const [rightsBasis, setRightsBasis] = useState("")
+  const [attributionText, setAttributionText] = useState("")
+  const [file, setFile] = useState<File | null>(null)
+  const [loadingUploads, setLoadingUploads] = useState(true)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState("")
+  const [message, setMessage] = useState("")
+
+  const attachableAssets = useMemo(
+    () =>
+      document.mediaAssets.filter((asset) =>
+        ["planned", "review_required", "rejected", "unavailable"].includes(asset.status)
+      ),
+    [document.mediaAssets]
+  )
+
+  const loadUploads = useCallback(async () => {
+    setLoadingUploads(true)
+    setError("")
+    try {
+      const response = await apiFetch<UploadListResponse>(
+        `/api/uploads?resourceType=recipe-guidance&resourceId=${encodeURIComponent(recipeId)}`,
+        { label: "RecipeGuidanceUploads" }
+      )
+      const files = Array.isArray(response.files) ? response.files : []
+      setUploads(files)
+      setSelectedUploadId((current) =>
+        files.some((upload) => upload.id === current) ? current : (files[0]?.id ?? "")
+      )
+    } catch (loadError) {
+      setUploads([])
+      setSelectedUploadId("")
+      setError(errorText(loadError, "Unable to load recipe media uploads"))
+    } finally {
+      setLoadingUploads(false)
+    }
+  }, [recipeId])
+
+  useEffect(() => {
+    void loadUploads()
+  }, [loadUploads])
+
+  useEffect(() => {
+    setSelectedAssetId((current) =>
+      attachableAssets.some((asset) => asset.id === current)
+        ? current
+        : (attachableAssets[0]?.id ?? "")
+    )
+  }, [attachableAssets])
+
+  const uploadFile = async () => {
+    if (!file) return
+    setUploading(true)
+    setError("")
+    setMessage("")
+    try {
+      const formData = new FormData()
+      formData.append("file", file)
+      formData.append("category", "image")
+      formData.append("resourceType", "recipe-guidance")
+      formData.append("resourceId", recipeId)
+      const response = await apiFetch<UploadResponse>("/api/uploads", {
+        method: "POST",
+        label: "RecipeGuidanceUpload",
+        body: formData,
+      })
+      setFile(null)
+      await loadUploads()
+      setSelectedUploadId(response.file.id)
+      setMessage(`${response.file.originalName} is stored privately and ready to attach.`)
+    } catch (uploadError) {
+      setError(errorText(uploadError, "Unable to upload recipe media"))
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const attach = async () => {
+    if (!selectedAssetId || !selectedUploadId) return
+    setError("")
+    setMessage("")
+    await onAttach({
+      mediaAssetId: selectedAssetId,
+      uploadId: selectedUploadId,
+      rightsBasis: rightsBasis.trim(),
+      attributionText: attributionText.trim(),
+    })
+  }
+
+  return (
+    <section className="border-border bg-card space-y-4 rounded-xl border p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="font-semibold">Media intake and plan</h3>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Plan deterministic section slots, then attach private HOV uploads with explicit rights
+            and attribution. No image generation occurs here.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void onPlan()}
+          disabled={disabled || busy}
+          className="border-border bg-background inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold disabled:opacity-50"
+        >
+          <ImagePlus className="h-3.5 w-3.5" />
+          Plan missing media
+        </button>
+      </div>
+
+      {error && <p className="text-destructive text-sm">{error}</p>}
+      {message && <p className="text-muted-foreground text-sm">{message}</p>}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="bg-muted/30 space-y-3 rounded-lg p-3">
+          <label className="text-muted-foreground block text-xs">
+            Private image upload
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/gif,image/webp"
+              onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+              disabled={disabled || uploading}
+              className="border-border bg-background mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => void uploadFile()}
+            disabled={disabled || uploading || !file}
+            className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-lg px-3 py-2 text-xs font-semibold disabled:opacity-50"
+          >
+            {uploading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Upload className="h-3.5 w-3.5" />
+            )}
+            Upload privately
+          </button>
+        </div>
+
+        <div className="bg-muted/30 space-y-3 rounded-lg p-3">
+          <div className="flex items-end gap-2">
+            <label className="text-muted-foreground min-w-0 flex-1 text-xs">
+              Stored recipe upload
+              <select
+                value={selectedUploadId}
+                onChange={(event) => setSelectedUploadId(event.target.value)}
+                disabled={disabled || loadingUploads || uploads.length === 0}
+                className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+              >
+                {uploads.length === 0 && <option value="">No recipe uploads</option>}
+                {uploads.map((upload) => (
+                  <option key={upload.id} value={upload.id}>
+                    {upload.originalName} · {Math.ceil(upload.size / 1024)} KB
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={() => void loadUploads()}
+              disabled={loadingUploads}
+              aria-label="Refresh recipe uploads"
+              className="border-border bg-background rounded-md border p-2 disabled:opacity-50"
+            >
+              <RefreshCw className={`h-4 w-4 ${loadingUploads ? "animate-spin" : ""}`} />
+            </button>
+          </div>
+          <label className="text-muted-foreground block text-xs">
+            Planned or replaceable media slot
+            <select
+              value={selectedAssetId}
+              onChange={(event) => setSelectedAssetId(event.target.value)}
+              disabled={disabled || attachableAssets.length === 0}
+              className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+            >
+              {attachableAssets.length === 0 && <option value="">Plan media first</option>}
+              {attachableAssets.map((asset) => (
+                <option key={asset.id} value={asset.id}>
+                  {asset.role.replaceAll("_", " ")} · {asset.status.replaceAll("_", " ")}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-muted-foreground block text-xs">
+            Rights basis
+            <input
+              value={rightsBasis}
+              onChange={(event) => setRightsBasis(event.target.value)}
+              placeholder="Example: Estate-owned photograph"
+              disabled={disabled}
+              className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="text-muted-foreground block text-xs">
+            Attribution
+            <input
+              value={attributionText}
+              onChange={(event) => setAttributionText(event.target.value)}
+              placeholder="Photographer or source attribution"
+              disabled={disabled}
+              className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => void attach()}
+            disabled={
+              disabled ||
+              busy ||
+              !selectedUploadId ||
+              !selectedAssetId ||
+              !rightsBasis.trim() ||
+              !attributionText.trim()
+            }
+            className="bg-primary text-primary-foreground rounded-lg px-3 py-2 text-xs font-semibold disabled:opacity-50"
+          >
+            Attach for review
+          </button>
+        </div>
+      </div>
+
+      {document.imageBriefs.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-sm font-semibold">Deterministic image briefs</h4>
+          {document.imageBriefs.map((brief) => (
+            <div key={brief.id} className="border-border rounded-lg border p-3 text-xs">
+              <p className="font-semibold">
+                {brief.role.replaceAll("_", " ")} · {brief.status}
+              </p>
+              <p className="text-muted-foreground mt-1">{brief.description.en}</p>
+              <p className="text-muted-foreground mt-1">{brief.description.af}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/components/recipes/recipe-guidance-workspace.tsx
+++ b/components/recipes/recipe-guidance-workspace.tsx
@@ -28,6 +28,7 @@ import {
   RecipeGuidanceDocumentView,
   type RecipeGuidanceLanguageMode,
 } from "./recipe-guidance-document-view"
+import { RecipeGuidanceMediaIntake } from "./recipe-guidance-media-intake"
 
 interface GuidanceListResponse {
   data: { documents: RecipeGuidanceDocument[] }
@@ -588,6 +589,63 @@ export function RecipeGuidanceWorkspace({
     }
   }
 
+  const planMedia = async () => {
+    if (!selectedDocument) return
+    setBusy("media-plan")
+    setError("")
+    setMessage("")
+    try {
+      const response = await apiFetch<GuidanceMutationResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts/${selectedDocument.version}`,
+        {
+          method: "PATCH",
+          label: "RecipeGuidanceMediaPlan",
+          body: {
+            expectedUpdatedAt: selectedDocument.updatedAt,
+            mediaPlan: { action: "create_missing" },
+          },
+        }
+      )
+      replaceDocument(response.data.document)
+      setMessage("Missing recipe media slots were planned deterministically.")
+    } catch (planError) {
+      await handleMutationError(planError, "Unable to plan recipe guidance media")
+    } finally {
+      setBusy("")
+    }
+  }
+
+  const attachUpload = async (input: {
+    mediaAssetId: string
+    uploadId: string
+    rightsBasis: string
+    attributionText: string
+  }) => {
+    if (!selectedDocument) return
+    setBusy("media-attach")
+    setError("")
+    setMessage("")
+    try {
+      const response = await apiFetch<GuidanceMutationResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts/${selectedDocument.version}`,
+        {
+          method: "PATCH",
+          label: "RecipeGuidanceMediaAttachment",
+          body: {
+            expectedUpdatedAt: selectedDocument.updatedAt,
+            mediaAttachment: input,
+          },
+        }
+      )
+      replaceDocument(response.data.document)
+      setMessage("Private upload attached for bilingual media review.")
+    } catch (attachmentError) {
+      await handleMutationError(attachmentError, "Unable to attach recipe guidance media")
+    } finally {
+      setBusy("")
+    }
+  }
+
   const transition = async (action: TransitionAction) => {
     if (!selectedDocument) return
     setBusy(action)
@@ -877,6 +935,15 @@ export function RecipeGuidanceWorkspace({
                   </section>
                 </aside>
               </div>
+
+              <RecipeGuidanceMediaIntake
+                recipeId={recipe.id}
+                document={selectedDocument}
+                disabled={!editable || Boolean(busy)}
+                busy={Boolean(busy)}
+                onPlan={planMedia}
+                onAttach={attachUpload}
+              />
 
               {selectedDocument.mediaAssets.length > 0 && (
                 <section className="space-y-3">

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -122,6 +122,32 @@ browser.
 - The UI neither seeds guidance nor enables demo data. Browser fixtures intercept requests in local
   verification only and do not write to a repository or external service.
 
+### Recipe guidance media intake and planning
+
+Recipe media intake reuses the authenticated upload store with `resourceType=recipe-guidance` and
+the canonical recipe ID as `resourceId`. Only admins may create, list, or delete these scoped
+uploads. Admins may read drafts; non-admin reads require the exact upload to be an approved,
+referenced HOV asset in the latest revision-matching published document and require both recipe and
+document audience membership. Generic upload listings omit both task-guidance and recipe-guidance
+files so private media cannot leak through an unscoped query. The server derives uploader identity
+and upload time; clients cannot claim either value.
+
+- `PATCH /api/recipes/:id/guidance-drafts/:version` accepts `mediaPlan: { action:
+"create_missing" }` with `expectedUpdatedAt`. It deterministically adds draft bilingual image
+  briefs, planned media assets, and section references only for missing supported slots. Repeating
+  the plan is idempotent and performs no provider call.
+- The same route accepts `mediaAttachment` with a planned or replaceable asset ID, a recipe-scoped
+  upload ID, and explicit rights-basis and attribution text. The server verifies recipe scope and
+  image MIME/category, hashes the stored bytes, and records uploaded provenance plus an internal
+  HOV storage ID/path. Missing bytes, invalid rights, cross-recipe uploads, and stale concurrency
+  tokens fail closed.
+- Attached files enter `review_required`; they do not gain alt text or publication status. Hans
+  must still use the existing bilingual approve/reject workflow. Approved media cannot be replaced
+  through intake.
+- Deterministic planning is descriptive only. It does not approve briefs, request generation,
+  invoke Sluice, use a direct provider, publish packages, enqueue OmniPost, seed demo data, or write
+  production data outside the authenticated upload and explicitly selected draft mutations.
+
 ## Request flow
 
 1. A resident opens Guidance from a task and captures or chooses a photo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,4 +98,5 @@ Dated session continuity notes (root cause, files changed, verification, next-ow
 | [2026-07-29-recipe-guidance-authoring-api.md](handoffs/2026-07-29-recipe-guidance-authoring-api.md)       | Explicit recipe draft creation and optimistic reviewed-section updates               |
 | [2026-07-29-recipe-guidance-lifecycle.md](handoffs/2026-07-29-recipe-guidance-lifecycle.md)               | Review transitions, readiness evidence, publication, and immutable archival          |
 | [2026-07-31-recipe-guidance-ui.md](handoffs/2026-07-31-recipe-guidance-ui.md)                             | Hans review workspace and Irma mobile published-guidance reader                      |
+| [2026-07-31-recipe-guidance-media-intake.md](handoffs/2026-07-31-recipe-guidance-media-intake.md)         | Authenticated recipe media intake and deterministic section planning                 |
 | [2026-07-28-user-selectable-themes.md](handoffs/2026-07-28-user-selectable-themes.md)                     | User-selectable workspace themes implementation, review, and merge handoff           |

--- a/docs/handoffs/2026-07-31-recipe-guidance-media-intake.md
+++ b/docs/handoffs/2026-07-31-recipe-guidance-media-intake.md
@@ -1,0 +1,88 @@
+# Recipe guidance media intake and planning handoff
+
+- **Date:** 2026-07-31
+- **Repository:** `C:\Users\smitj\repos\house-of-veritas`
+- **Worktree:** `C:\tmp\hov-recipe-guidance-media-intake`
+- **Branch:** `feat/recipe-guidance-media-intake`
+- **Base:** `origin/main` at `d1e4e3498e2ba954d51194b5718004a712437c42`
+- **Predecessor:** PR [#161](https://github.com/neuralliquid/house-of-veritas/pull/161)
+- **Baton task:** `2853ec21-dfd7-4e54-91c9-4e5c09871b2c`
+- **Risk tier:** API/data/UI workflow; authenticated private uploads and draft aggregate mutations
+
+## Outcome
+
+- Recipe-guidance upload mutation/listing is admin-only, bound to one canonical recipe, and excluded
+  from generic upload listings. Audience reads fail closed unless the upload is an approved,
+  referenced asset in the latest revision-matching published guidance.
+- Deterministic planning creates missing bilingual draft image briefs, planned media assets, and
+  section references without calling Sluice or another provider.
+- Hans can upload or select a private recipe image, choose a planned/replaceable slot, record rights
+  basis and attribution, and attach it for review.
+- Attachment derives uploader/time from stored metadata, hashes the stored bytes, records an HOV
+  storage ID/internal URL, preserves the optional image brief, restores a missing reference, and
+  enters `review_required`.
+- Cross-recipe, non-image, missing-content, invalid-rights, unauthorized, approved-replacement, and
+  stale-CAS paths fail closed.
+
+## Changed files
+
+- `lib/recipe-guidance-media.ts`
+- `lib/recipe-guidance.ts`
+- `lib/uploads.ts`
+- `app/api/uploads/route.ts`
+- `app/api/uploads/[id]/route.ts`
+- `app/api/recipes/[id]/guidance-drafts/[version]/route.ts`
+- `components/recipes/recipe-guidance-media-intake.tsx`
+- `components/recipes/recipe-guidance-workspace.tsx`
+- `tests/lib/recipe-guidance-media.test.ts`
+- `tests/api/recipe-guidance.test.ts`
+- `tests/api/uploads.test.ts`
+- `tests/components/recipe-guidance-ui.test.tsx`
+- `docs/05-project/task-guidance-architecture.md`
+- `docs/handoffs/2026-07-31-recipe-guidance-media-intake.md`
+- `docs/README.md`
+
+## Verification
+
+Completed before PR publication:
+
+```text
+pnpm test -- tests/lib/recipe-guidance-media.test.ts tests/api/recipe-guidance.test.ts tests/api/uploads.test.ts tests/components/recipe-guidance-ui.test.tsx tests/lib/recipe-guidance.test.ts tests/lib/recipe-guidance-repository.test.ts
+pnpm exec tsc --noEmit
+pnpm run lint
+pnpm run build
+pnpm exec prettier --check <changed TypeScript and Markdown files>
+git diff --check
+```
+
+- Focused Vitest replay: 6 files, 87 tests passed.
+- TypeScript, lint, and production build passed; the build emitted 125 routes.
+- An authenticated Chromium replay against the local production build passed with retries and trace
+  disabled. It proved five-slot deterministic planning, private-upload selection,
+  rights/attribution gating, and the attachment request. No application console warning/error or
+  failing API response occurred. Screenshot: `output/playwright/recipe-guidance-media-intake.png`.
+- The browser used fixture-intercepted recipe, upload, and draft responses; it did not write
+  repository, production, or provider data. The upload API's empty-list behavior remains covered by
+  focused API/component tests rather than this replay.
+- One earlier combined Windows run hit transient `EPERM` locks in temporary test/repository/build
+  files. Isolated replays of the affected suites and TypeScript check passed; no source defect was
+  reproduced.
+
+## Boundaries and next slice
+
+No Sluice/provider call, image generation, brief approval, public package, OmniPost action,
+migration apply, deployment, production-data mutation, or demo-data enablement is part of this
+slice. Deployment health for predecessor merge `d1e4e349` succeeded separately; it is not authentic
+user acceptance.
+
+The next bounded decision is whether to add human image-brief editing/approval and a provider-neutral
+request contract. Keep execution disabled until Sluice proves model alias, request/response,
+request-ID, cost, telemetry, rights, storage-copy, and fail-closed capability contracts.
+
+## Trace envelope
+
+- **Task:** `2853ec21-dfd7-4e54-91c9-4e5c09871b2c`
+- **Routing:** Veritas Gateway uploads/API, Ledger guidance aggregate, Shield access/provenance,
+  Surface/Studio admin UI, Proof tests/browser verification
+- **External effects:** Baton task creation/update and later GitHub branch/PR only; no provider,
+  publication, migration, deployment, or production-data effect

--- a/lib/recipe-guidance-media.ts
+++ b/lib/recipe-guidance-media.ts
@@ -1,0 +1,220 @@
+import {
+  parseRecipeGuidanceDocument,
+  type RecipeGuidanceDocument,
+  type RecipeGuidanceSectionKind,
+  type RecipeImageBrief,
+  type RecipeMediaAsset,
+  type RecipeMediaRole,
+} from "@/lib/recipe-guidance"
+import type { RecipeRecord } from "@/lib/recipes"
+
+interface MediaPlanSlot {
+  sectionKind: RecipeGuidanceSectionKind
+  role: RecipeMediaRole
+  description: { en: string; af: string }
+}
+
+export interface RecipeGuidanceMediaPlanResult {
+  document: RecipeGuidanceDocument
+  addedAssetIds: string[]
+}
+
+export interface AttachRecipeGuidanceUploadInput {
+  mediaAssetId: string
+  upload: {
+    id: string
+    uploadedBy: string
+    uploadedAt: Date
+  }
+  contentHash: string
+  rightsBasis: string
+  attributionText: string
+  now: string
+}
+
+function withoutReview(document: RecipeGuidanceDocument): RecipeGuidanceDocument {
+  const mutable = { ...document }
+  delete mutable.reviewedBy
+  delete mutable.reviewedAt
+  delete mutable.reviewEvidence
+  return mutable
+}
+
+function mediaPlanSlots(recipe: RecipeRecord): MediaPlanSlot[] {
+  return [
+    {
+      sectionKind: "ingredients",
+      role: "ingredient_layout",
+      description: {
+        en: `Overhead ingredient layout for ${recipe.titleEn}, showing only canonical recipe ingredients.`,
+        af: `Bogrondse bestanddeeluitleg vir ${recipe.titleAf}, met slegs kanonieke resepbestanddele.`,
+      },
+    },
+    {
+      sectionKind: "preparation",
+      role: "step",
+      description: {
+        en: `Reviewed preparation reference for ${recipe.titleEn}, grounded in the canonical recipe steps.`,
+        af: `Nagegane voorbereidingsverwysing vir ${recipe.titleAf}, gegrond op die kanonieke resepstappe.`,
+      },
+    },
+    {
+      sectionKind: "cooking",
+      role: "step",
+      description: {
+        en: `Reviewed cooking-stage reference for ${recipe.titleEn}, without invented ingredients or actions.`,
+        af: `Nagegane kookstadiumverwysing vir ${recipe.titleAf}, sonder versinde bestanddele of handelinge.`,
+      },
+    },
+    {
+      sectionKind: "finish_and_serve",
+      role: "serving",
+      description: {
+        en: `Finished serving reference for ${recipe.titleEn}, consistent with the canonical recipe.`,
+        af: `Voltooide opdienverwysing vir ${recipe.titleAf}, in ooreenstemming met die kanonieke resep.`,
+      },
+    },
+    {
+      sectionKind: "storage_and_reheating",
+      role: "storage",
+      description: {
+        en: `Storage reference for ${recipe.titleEn}; do not imply unreviewed food-safety guidance.`,
+        af: `Bergingsverwysing vir ${recipe.titleAf}; moenie onbestudeerde voedselveiligheidsleiding impliseer nie.`,
+      },
+    },
+  ]
+}
+
+export function planRecipeGuidanceMedia(
+  document: RecipeGuidanceDocument,
+  recipe: RecipeRecord,
+  now: string
+): RecipeGuidanceMediaPlanResult | null {
+  const imageBriefs = [...document.imageBriefs]
+  const mediaAssets = [...document.mediaAssets]
+  const sections = document.sections.map((section) => ({
+    ...section,
+    blocks: [...section.blocks],
+  }))
+  const addedAssetIds: string[] = []
+
+  for (const slot of mediaPlanSlots(recipe)) {
+    const section = sections.find((candidate) => candidate.kind === slot.sectionKind)
+    if (!section) return null
+    if (mediaAssets.some((asset) => asset.sectionId === section.id && asset.role === slot.role)) {
+      continue
+    }
+
+    const existingBrief = imageBriefs.find(
+      (brief) => brief.sectionId === section.id && brief.role === slot.role
+    )
+    const briefId = existingBrief?.id ?? `${section.id}:brief:${slot.role}`
+    const assetId = `${section.id}:media:${slot.role}`
+    const brief: RecipeImageBrief | null = existingBrief
+      ? null
+      : {
+          id: briefId,
+          sectionId: section.id,
+          role: slot.role,
+          status: "draft",
+          description: slot.description,
+          reviewedFacts: [
+            `Recipe revision: ${document.recipeRevisionId}`,
+            ...recipe.ingredients
+              .slice(0, 29)
+              .map((ingredient) => `Canonical ingredient: ${ingredient.name}`),
+          ],
+          excludedContent: [
+            "Do not invent ingredients, equipment, safety claims, branding, labels, or text overlays.",
+          ],
+        }
+    const asset: RecipeMediaAsset = {
+      id: assetId,
+      sectionId: section.id,
+      imageBriefId: briefId,
+      role: slot.role,
+      status: "planned",
+    }
+
+    if (brief) imageBriefs.push(brief)
+    mediaAssets.push(asset)
+    section.blocks.push({
+      id: `${assetId}:reference`,
+      type: "media_reference",
+      mediaAssetId: assetId,
+    })
+    addedAssetIds.push(assetId)
+  }
+
+  const candidate = parseRecipeGuidanceDocument({
+    ...withoutReview(document),
+    imageBriefs,
+    mediaAssets,
+    sections,
+    updatedAt: now,
+  })
+  return candidate ? { document: candidate, addedAssetIds } : null
+}
+
+export function attachRecipeGuidanceUpload(
+  document: RecipeGuidanceDocument,
+  input: AttachRecipeGuidanceUploadInput
+): RecipeGuidanceDocument | null {
+  const assetIndex = document.mediaAssets.findIndex((asset) => asset.id === input.mediaAssetId)
+  const target = document.mediaAssets[assetIndex]
+  if (
+    assetIndex === -1 ||
+    !target ||
+    !["planned", "review_required", "rejected", "unavailable"].includes(target.status)
+  ) {
+    return null
+  }
+
+  const mediaAssets = [...document.mediaAssets]
+  mediaAssets[assetIndex] = {
+    id: target.id,
+    sectionId: target.sectionId,
+    role: target.role,
+    ...(target.imageBriefId ? { imageBriefId: target.imageBriefId } : {}),
+    status: "review_required",
+    source: {
+      type: "uploaded",
+      uploadId: input.upload.id,
+      uploadedBy: input.upload.uploadedBy,
+      uploadedAt: input.upload.uploadedAt.toISOString(),
+      rightsBasis: input.rightsBasis,
+      attributionText: input.attributionText,
+    },
+    storage: {
+      type: "hov",
+      storageId: input.upload.id,
+      url: `/api/uploads/${input.upload.id}`,
+      contentHash: input.contentHash,
+    },
+  }
+
+  const sections = document.sections.map((section) => {
+    if (section.id !== target.sectionId) return section
+    if (
+      section.blocks.some(
+        (block) => block.type === "media_reference" && block.mediaAssetId === target.id
+      )
+    ) {
+      return section
+    }
+    return {
+      ...section,
+      blocks: [
+        ...section.blocks,
+        { id: `${target.id}:reference`, type: "media_reference" as const, mediaAssetId: target.id },
+      ],
+    }
+  })
+
+  return parseRecipeGuidanceDocument({
+    ...withoutReview(document),
+    mediaAssets,
+    sections,
+    updatedAt: input.now,
+  })
+}

--- a/lib/recipe-guidance.ts
+++ b/lib/recipe-guidance.ts
@@ -138,6 +138,7 @@ const uploadedMediaSourceSchema = z.object({
   uploadedBy: nonEmptyId,
   uploadedAt: isoDateTime,
   rightsBasis: z.string().trim().min(1).max(500),
+  attributionText: z.string().trim().min(1).max(1_000),
 })
 
 const generatedMediaSourceSchema = z.object({

--- a/lib/uploads.ts
+++ b/lib/uploads.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto"
 import { readFile, unlink, writeFile } from "fs/promises"
 import path from "path"
 import { ensureSchema, isPostgresConfigured, query } from "@/lib/db/postgres"
@@ -96,6 +97,15 @@ export async function getUploadMetadataById(id: string): Promise<UploadMetadata 
   }
 
   return inMemoryUploadStore.get(id) ?? (await readLocalUploadMetadata(id))
+}
+
+export async function getUploadContentHash(metadata: UploadMetadata): Promise<string | null> {
+  try {
+    const content = await readFile(getUploadFilePath(metadata.storedName))
+    return `sha256:${createHash("sha256").update(content).digest("hex")}`
+  } catch {
+    return null
+  }
 }
 
 export async function deleteLocalUploadMetadata(id: string): Promise<void> {

--- a/tests/api/recipe-guidance.test.ts
+++ b/tests/api/recipe-guidance.test.ts
@@ -10,10 +10,12 @@ import { POST as previewDraft } from "@/app/api/recipes/[id]/guidance-drafts/pre
 import { GET as readPublished } from "@/app/api/recipes/[id]/guidance/route"
 import { PATCH as updateRecipe } from "@/app/api/recipes/[id]/route"
 import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
+import { planRecipeGuidanceMedia } from "@/lib/recipe-guidance-media"
 import { parseRecipeGuidanceDocument, type RecipeGuidanceDocument } from "@/lib/recipe-guidance"
 import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
 import { getRecipeById, replaceRecipe } from "@/lib/repositories/recipe-repository"
 import type { RecipeRecord } from "@/lib/recipes"
+import { getUploadContentHash, getUploadMetadataById } from "@/lib/uploads"
 
 vi.mock("@/lib/repositories/recipe-guidance-repository", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/repositories/recipe-guidance-repository")>()),
@@ -23,6 +25,11 @@ vi.mock("@/lib/repositories/recipe-guidance-repository", async (importOriginal) 
 vi.mock("@/lib/repositories/recipe-repository", () => ({
   getRecipeById: vi.fn(),
   replaceRecipe: vi.fn(),
+}))
+
+vi.mock("@/lib/uploads", () => ({
+  getUploadContentHash: vi.fn(),
+  getUploadMetadataById: vi.fn(),
 }))
 
 const routeContext = { params: Promise.resolve({ id: "recipe-1" }) }
@@ -139,6 +146,8 @@ describe("recipe guidance APIs", () => {
     vi.clearAllMocks()
     vi.mocked(getRecipeById).mockResolvedValue(recipe)
     vi.mocked(replaceRecipe).mockResolvedValue(recipe)
+    vi.mocked(getUploadMetadataById).mockResolvedValue(null)
+    vi.mocked(getUploadContentHash).mockResolvedValue(null)
     repository.listByRecipeId.mockResolvedValue([existingDocument])
     repository.findLatestPublished.mockResolvedValue(existingDocument)
     repository.create.mockImplementation(async (document) => document)
@@ -367,6 +376,179 @@ describe("recipe guidance APIs", () => {
       }),
       existingDocument.updatedAt
     )
+  })
+
+  it("plans missing recipe media deterministically with optimistic concurrency", async () => {
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: existingDocument.updatedAt,
+        mediaPlan: { action: "create_missing" },
+      }),
+      versionRouteContext
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.summary.plannedMediaAssets).toHaveLength(5)
+    expect(repository.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageBriefs: expect.arrayContaining([
+          expect.objectContaining({ role: "ingredient_layout", status: "draft" }),
+          expect.objectContaining({ role: "serving", status: "draft" }),
+          expect.objectContaining({ role: "storage", status: "draft" }),
+        ]),
+        mediaAssets: expect.arrayContaining([
+          expect.objectContaining({ role: "step", status: "planned" }),
+        ]),
+      }),
+      existingDocument.updatedAt
+    )
+  })
+
+  it("returns a refreshable conflict when a media plan loses optimistic concurrency", async () => {
+    const { RecipeGuidanceConflictError } =
+      await import("@/lib/repositories/recipe-guidance-repository")
+    repository.replace.mockRejectedValueOnce(new RecipeGuidanceConflictError("stale"))
+
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: existingDocument.updatedAt,
+        mediaPlan: { action: "create_missing" },
+      }),
+      versionRouteContext
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: "Recipe guidance changed; refresh and retry",
+    })
+  })
+
+  it("attaches only a private image upload scoped to this recipe", async () => {
+    const planned = planRecipeGuidanceMedia(
+      existingDocument,
+      recipe,
+      "2026-07-29T09:31:00.000Z"
+    )!.document
+    const target = planned.mediaAssets.find((asset) => asset.status === "planned")!
+    repository.listByRecipeId.mockResolvedValueOnce([planned])
+    vi.mocked(getUploadMetadataById).mockResolvedValue({
+      id: "file_recipe_photo",
+      originalName: "ingredients.jpg",
+      storedName: "file_recipe_photo.jpg",
+      mimeType: "image/jpeg",
+      size: 128,
+      uploadedBy: "hans",
+      uploadedAt: new Date("2026-07-29T09:31:30.000Z"),
+      category: "image",
+      resourceType: "recipe-guidance",
+      resourceId: recipe.id,
+    })
+    vi.mocked(getUploadContentHash).mockResolvedValue(`sha256:${"a".repeat(64)}`)
+
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: planned.updatedAt,
+        mediaAttachment: {
+          mediaAssetId: target.id,
+          uploadId: "file_recipe_photo",
+          rightsBasis: "Estate-owned photograph",
+          attributionText: "Photograph by Hans",
+        },
+      }),
+      versionRouteContext
+    )
+
+    expect(response.status).toBe(200)
+    expect(repository.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaAssets: expect.arrayContaining([
+          expect.objectContaining({
+            id: target.id,
+            status: "review_required",
+            source: expect.objectContaining({
+              type: "uploaded",
+              uploadId: "file_recipe_photo",
+              uploadedBy: "hans",
+              attributionText: "Photograph by Hans",
+            }),
+            storage: {
+              type: "hov",
+              storageId: "file_recipe_photo",
+              url: "/api/uploads/file_recipe_photo",
+              contentHash: `sha256:${"a".repeat(64)}`,
+            },
+          }),
+        ]),
+      }),
+      planned.updatedAt
+    )
+  })
+
+  it("rejects an upload that is not scoped to this recipe", async () => {
+    const planned = planRecipeGuidanceMedia(
+      existingDocument,
+      recipe,
+      "2026-07-29T09:31:00.000Z"
+    )!.document
+    const target = planned.mediaAssets.find((asset) => asset.status === "planned")!
+    repository.listByRecipeId.mockResolvedValueOnce([planned])
+    vi.mocked(getUploadMetadataById).mockResolvedValue({
+      id: "file_other_recipe",
+      originalName: "other.jpg",
+      storedName: "file_other_recipe.jpg",
+      mimeType: "image/jpeg",
+      size: 128,
+      uploadedBy: "hans",
+      uploadedAt: new Date("2026-07-29T09:31:30.000Z"),
+      category: "image",
+      resourceType: "recipe-guidance",
+      resourceId: "recipe-2",
+    })
+
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: planned.updatedAt,
+        mediaAttachment: {
+          mediaAssetId: target.id,
+          uploadId: "file_other_recipe",
+          rightsBasis: "Estate-owned photograph",
+          attributionText: "Photograph by Hans",
+        },
+      }),
+      versionRouteContext
+    )
+
+    expect(response.status).toBe(403)
+    expect(repository.replace).not.toHaveBeenCalled()
+  })
+
+  it("rejects missing rights or attribution before reading upload content", async () => {
+    const planned = planRecipeGuidanceMedia(
+      existingDocument,
+      recipe,
+      "2026-07-29T09:31:00.000Z"
+    )!.document
+    const target = planned.mediaAssets.find((asset) => asset.status === "planned")!
+    repository.listByRecipeId.mockResolvedValueOnce([planned])
+
+    const response = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: planned.updatedAt,
+        mediaAttachment: {
+          mediaAssetId: target.id,
+          uploadId: "file_recipe_photo",
+          rightsBasis: "",
+          attributionText: "",
+        },
+      }),
+      versionRouteContext
+    )
+
+    expect(response.status).toBe(400)
+    expect(getUploadMetadataById).not.toHaveBeenCalled()
+    expect(getUploadContentHash).not.toHaveBeenCalled()
+    expect(repository.replace).not.toHaveBeenCalled()
   })
 
   it("rejects recipe-sourced text through the reviewed section endpoint", async () => {

--- a/tests/api/uploads.test.ts
+++ b/tests/api/uploads.test.ts
@@ -2,7 +2,10 @@ import { GET as getUpload } from "@/app/api/uploads/[id]/route"
 import { DELETE as deleteUpload, GET as listUploads, POST } from "@/app/api/uploads/route"
 import { getProjectNamesForMember } from "@/lib/projects"
 import { getTask } from "@/lib/services/baserow"
-import { inMemoryUploadStore } from "@/lib/uploads"
+import { getUploadContentHash, getUploadMetadataById, inMemoryUploadStore } from "@/lib/uploads"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
+import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
+import type { RecipeRecord } from "@/lib/recipes"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("@/lib/projects", () => ({
@@ -12,6 +15,45 @@ vi.mock("@/lib/projects", () => ({
 vi.mock("@/lib/services/baserow", () => ({
   getTask: vi.fn(),
 }))
+
+vi.mock("@/lib/repositories/recipe-repository", () => ({
+  getRecipeById: vi.fn(),
+}))
+
+vi.mock("@/lib/repositories/recipe-guidance-repository", () => ({
+  getRecipeGuidanceRepository: vi.fn(),
+}))
+
+const uploadRecipe: RecipeRecord = {
+  id: "recipe-1",
+  status: "published",
+  ownerUserId: "hans",
+  audienceUserIds: ["hans", "irma"],
+  titleEn: "Garden stew",
+  titleAf: "Tuinbredie",
+  image: {
+    url: "https://images.example/stew.jpg",
+    source: "Example",
+    license: "CC BY 4.0",
+    attributionText: "Example photographer",
+    retrievedAt: "2026-07-31",
+  },
+  ingredients: [{ id: "ingredient-1", name: "Carrots" }],
+  steps: [
+    {
+      id: "step-1",
+      order: 1,
+      instructionEn: "Simmer.",
+      instructionAf: "Prut.",
+    },
+  ],
+  createdAt: "2026-07-31T08:00:00.000Z",
+  updatedAt: "2026-07-31T08:00:00.000Z",
+}
+
+const uploadGuidanceRepository = {
+  findLatestPublished: vi.fn(),
+}
 
 const authHeaders = {
   "x-user-id": "charl",
@@ -31,6 +73,12 @@ describe("POST /api/uploads", () => {
       priority: "Medium",
       status: "Not Started",
     })
+    vi.mocked(getRecipeById).mockResolvedValue(uploadRecipe)
+    uploadGuidanceRepository.findLatestPublished.mockResolvedValue(null)
+    vi.mocked(getRecipeGuidanceRepository).mockResolvedValue({
+      repository: uploadGuidanceRepository,
+      mode: "memory",
+    } as never)
   })
 
   it("rejects a task-guidance upload when the user cannot access the task", async () => {
@@ -67,10 +115,7 @@ describe("POST /api/uploads", () => {
 
   it("uses the authenticated user as uploader instead of a form userId", async () => {
     const formData = new FormData()
-    formData.append(
-      "file",
-      new File(["photo"], "inventory.jpg", { type: "image/jpeg" })
-    )
+    formData.append("file", new File(["photo"], "inventory.jpg", { type: "image/jpeg" }))
     formData.append("userId", "hans")
     formData.append("category", "image")
     formData.append("resourceType", "inventory")
@@ -106,10 +151,9 @@ describe("POST /api/uploads", () => {
     )
     const upload = (await uploadResponse.json()).file
 
-    const unauthenticated = await getUpload(
-      new Request(`http://localhost${upload.url}`),
-      { params: Promise.resolve({ id: upload.id }) }
-    )
+    const unauthenticated = await getUpload(new Request(`http://localhost${upload.url}`), {
+      params: Promise.resolve({ id: upload.id }),
+    })
     expect(unauthenticated.status).toBe(401)
 
     const forbidden = await getUpload(
@@ -125,16 +169,13 @@ describe("POST /api/uploads", () => {
     expect(forbidden.status).toBe(403)
 
     const forbiddenList = await listUploads(
-      new Request(
-        "http://localhost/api/uploads?resourceType=task-guidance&resourceId=42",
-        {
-          headers: {
-            "x-user-id": "irma",
-            "x-user-role": "resident",
-            "x-user-email": "irma@example.com",
-          },
-        }
-      )
+      new Request("http://localhost/api/uploads?resourceType=task-guidance&resourceId=42", {
+        headers: {
+          "x-user-id": "irma",
+          "x-user-role": "resident",
+          "x-user-email": "irma@example.com",
+        },
+      })
     )
     expect(forbiddenList.status).toBe(403)
 
@@ -171,14 +212,147 @@ describe("POST /api/uploads", () => {
     expect(allowed.headers.get("content-type")).toBe("image/jpeg")
 
     const allowedList = await listUploads(
-      new Request(
-        "http://localhost/api/uploads?resourceType=task-guidance&resourceId=42",
-        { headers: authHeaders }
-      )
+      new Request("http://localhost/api/uploads?resourceType=task-guidance&resourceId=42", {
+        headers: authHeaders,
+      })
     )
     expect(allowedList.status).toBe(200)
     expect((await allowedList.json()).files).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: upload.id })])
     )
+  })
+
+  it("keeps recipe-guidance uploads private to admins and their bound recipe", async () => {
+    const adminHeaders = {
+      "x-user-id": "hans",
+      "x-user-role": "admin",
+      "x-user-email": "hans@example.com",
+    }
+    const formData = new FormData()
+    formData.append("file", new File(["recipe-photo"], "ingredients.jpg", { type: "image/jpeg" }))
+    formData.append("category", "image")
+    formData.append("resourceType", "recipe-guidance")
+    formData.append("resourceId", "recipe-1")
+
+    const uploadResponse = await POST(
+      new Request("http://localhost/api/uploads", {
+        method: "POST",
+        headers: adminHeaders,
+        body: formData,
+      })
+    )
+    const upload = (await uploadResponse.json()).file
+
+    expect(uploadResponse.status).toBe(200)
+    expect(upload).toMatchObject({
+      uploadedBy: "hans",
+      category: "image",
+      resourceType: "recipe-guidance",
+      resourceId: "recipe-1",
+    })
+    const metadata = await getUploadMetadataById(upload.id)
+    expect(metadata).not.toBeNull()
+    await expect(getUploadContentHash(metadata!)).resolves.toMatch(/^sha256:[a-f0-9]{64}$/)
+
+    const residentList = await listUploads(
+      new Request("http://localhost/api/uploads?resourceType=recipe-guidance&resourceId=recipe-1", {
+        headers: {
+          "x-user-id": "irma",
+          "x-user-role": "resident",
+          "x-user-email": "irma@example.com",
+        },
+      })
+    )
+    expect(residentList.status).toBe(403)
+
+    const genericList = await listUploads(
+      new Request("http://localhost/api/uploads", { headers: authHeaders })
+    )
+    expect((await genericList.json()).files).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: upload.id })])
+    )
+
+    const adminList = await listUploads(
+      new Request("http://localhost/api/uploads?resourceType=recipe-guidance&resourceId=recipe-1", {
+        headers: adminHeaders,
+      })
+    )
+    expect(adminList.status).toBe(200)
+    expect((await adminList.json()).files).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: upload.id })])
+    )
+
+    const residentRead = await getUpload(
+      new Request(`http://localhost${upload.url}`, {
+        headers: {
+          "x-user-id": "irma",
+          "x-user-role": "resident",
+          "x-user-email": "irma@example.com",
+        },
+      }),
+      { params: Promise.resolve({ id: upload.id }) }
+    )
+    expect(residentRead.status).toBe(403)
+
+    uploadGuidanceRepository.findLatestPublished.mockResolvedValue({
+      recipeId: uploadRecipe.id,
+      recipeRevisionId: `${uploadRecipe.id}@${uploadRecipe.updatedAt}`,
+      ownerUserId: uploadRecipe.ownerUserId,
+      audienceUserIds: uploadRecipe.audienceUserIds,
+      mediaAssets: [
+        {
+          id: "approved-upload",
+          status: "approved",
+          storage: { type: "hov", storageId: upload.id },
+        },
+      ],
+      sections: [
+        {
+          blocks: [{ type: "media_reference", mediaAssetId: "approved-upload" }],
+        },
+      ],
+    })
+
+    const audienceRead = await getUpload(
+      new Request(`http://localhost${upload.url}`, {
+        headers: {
+          "x-user-id": "irma",
+          "x-user-role": "resident",
+          "x-user-email": "irma@example.com",
+        },
+      }),
+      { params: Promise.resolve({ id: upload.id }) }
+    )
+    expect(audienceRead.status).toBe(200)
+
+    const adminRead = await getUpload(
+      new Request(`http://localhost${upload.url}`, { headers: adminHeaders }),
+      { params: Promise.resolve({ id: upload.id }) }
+    )
+    expect(adminRead.status).toBe(200)
+  })
+
+  it("rejects recipe-guidance uploads for a missing recipe", async () => {
+    vi.mocked(getRecipeById).mockResolvedValue(null)
+    const formData = new FormData()
+    formData.append("file", new File(["photo"], "missing.jpg", { type: "image/jpeg" }))
+    formData.append("category", "image")
+    formData.append("resourceType", "recipe-guidance")
+    formData.append("resourceId", "missing-recipe")
+
+    const response = await POST(
+      new Request("http://localhost/api/uploads", {
+        method: "POST",
+        headers: {
+          "x-user-id": "hans",
+          "x-user-role": "admin",
+          "x-user-email": "hans@example.com",
+        },
+        body: formData,
+      })
+    )
+
+    expect(response.status).toBe(404)
+    expect(inMemoryUploadStore.size).toBe(0)
   })
 })

--- a/tests/components/recipe-guidance-ui.test.tsx
+++ b/tests/components/recipe-guidance-ui.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ApiError, apiFetch } from "@/lib/api-client"
 import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
+import { planRecipeGuidanceMedia } from "@/lib/recipe-guidance-media"
 import { parseRecipeGuidanceDocument, type RecipeGuidanceDocument } from "@/lib/recipe-guidance"
 import type { RecipeRecord } from "@/lib/recipes"
 import { PublishedRecipeGuidance } from "@/components/recipes/published-recipe-guidance"
@@ -216,6 +217,7 @@ describe("recipe guidance UI", () => {
   it("reloads the latest document when a lifecycle transition conflicts", async () => {
     let listCalls = 0
     vi.mocked(apiFetch).mockImplementation(async (url, options) => {
+      if (url.startsWith("/api/uploads?")) return { files: [], total: 0 }
       if (url.endsWith("/publication-readiness")) {
         return {
           data: {
@@ -312,6 +314,118 @@ describe("recipe guidance UI", () => {
           body: {
             expectedUpdatedAt: rejected.updatedAt,
             section: { kind: "hero", applicability: hero.applicability, blocks: [] },
+          },
+        })
+      )
+    )
+  })
+
+  it("plans missing media slots from the admin workspace", async () => {
+    const planned = planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")!.document
+    vi.mocked(apiFetch).mockImplementation(async (url, options) => {
+      if (url.startsWith("/api/uploads?")) return { files: [], total: 0 }
+      if (url.endsWith("/publication-readiness")) {
+        return {
+          data: {
+            documentId: draft.id,
+            version: 1,
+            status: "draft",
+            ready: false,
+            issues: [{ code: "media", message: "Media is not reviewed" }],
+          },
+        }
+      }
+      if (options?.label === "RecipeGuidanceMediaPlan") {
+        return { data: { document: planned } }
+      }
+      return { data: { documents: [draft] } }
+    })
+
+    const user = userEvent.setup()
+    render(<RecipeGuidanceWorkspace recipe={recipe} language="both" />)
+
+    await user.click(await screen.findByRole("button", { name: "Plan missing media" }))
+
+    expect(
+      await screen.findByText("Missing recipe media slots were planned deterministically.")
+    ).toBeInTheDocument()
+    expect(apiFetch).toHaveBeenCalledWith(
+      `/api/recipes/${recipe.id}/guidance-drafts/1`,
+      expect.objectContaining({
+        body: {
+          expectedUpdatedAt: draft.updatedAt,
+          mediaPlan: { action: "create_missing" },
+        },
+      })
+    )
+  })
+
+  it("attaches a selected private upload only after rights and attribution are supplied", async () => {
+    const planned = planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")!.document
+    const target = planned.mediaAssets.find((asset) => asset.status === "planned")!
+    vi.mocked(apiFetch).mockImplementation(async (url, options) => {
+      if (url.startsWith("/api/uploads?")) {
+        return {
+          files: [
+            {
+              id: "file_recipe_photo",
+              originalName: "ingredients.jpg",
+              mimeType: "image/jpeg",
+              size: 512,
+              uploadedBy: "hans",
+              uploadedAt: "2026-07-31T08:06:30.000Z",
+              url: "/api/uploads/file_recipe_photo",
+            },
+          ],
+          total: 1,
+        }
+      }
+      if (url.endsWith("/publication-readiness")) {
+        return {
+          data: {
+            documentId: planned.id,
+            version: 1,
+            status: "draft",
+            ready: false,
+            issues: [{ code: "media", message: "Media is not reviewed" }],
+          },
+        }
+      }
+      if (options?.label === "RecipeGuidanceMediaAttachment") {
+        return { data: { document: planned } }
+      }
+      return { data: { documents: [planned] } }
+    })
+
+    const user = userEvent.setup()
+    render(<RecipeGuidanceWorkspace recipe={recipe} language="both" />)
+
+    const attach = await screen.findByRole("button", { name: "Attach for review" })
+    expect(attach).toBeDisabled()
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Planned or replaceable media slot" }),
+      target.id
+    )
+    await user.type(
+      screen.getByRole("textbox", { name: "Rights basis" }),
+      "Estate-owned photograph"
+    )
+    await user.type(screen.getByRole("textbox", { name: "Attribution" }), "Photograph by Hans")
+    expect(attach).toBeEnabled()
+    await user.click(attach)
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        `/api/recipes/${recipe.id}/guidance-drafts/1`,
+        expect.objectContaining({
+          body: {
+            expectedUpdatedAt: planned.updatedAt,
+            mediaAttachment: {
+              mediaAssetId: target.id,
+              uploadId: "file_recipe_photo",
+              rightsBasis: "Estate-owned photograph",
+              attributionText: "Photograph by Hans",
+            },
           },
         })
       )

--- a/tests/lib/recipe-guidance-media.test.ts
+++ b/tests/lib/recipe-guidance-media.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest"
+import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
+import { attachRecipeGuidanceUpload, planRecipeGuidanceMedia } from "@/lib/recipe-guidance-media"
+import type { RecipeRecord } from "@/lib/recipes"
+
+const recipe: RecipeRecord = {
+  id: "recipe-media",
+  status: "published",
+  ownerUserId: "hans",
+  audienceUserIds: ["hans", "irma"],
+  titleEn: "Garden stew",
+  titleAf: "Tuinbredie",
+  image: {
+    url: "https://images.example/stew.jpg",
+    source: "Example library",
+    license: "CC BY 4.0",
+    attributionText: "Example photographer",
+    retrievedAt: "2026-07-31",
+  },
+  ingredients: [
+    { id: "ingredient-carrot", name: "Carrots" },
+    { id: "ingredient-potato", name: "Potatoes" },
+  ],
+  steps: [
+    {
+      id: "step-simmer",
+      order: 1,
+      instructionEn: "Simmer until tender.",
+      instructionAf: "Prut tot sag.",
+    },
+  ],
+  createdAt: "2026-07-31T08:00:00.000Z",
+  updatedAt: "2026-07-31T08:00:00.000Z",
+}
+
+const draft = buildRecipeGuidanceDraft(recipe, {
+  version: 1,
+  createdBy: "hans",
+  now: "2026-07-31T08:05:00.000Z",
+})
+
+describe("recipe guidance media planning", () => {
+  it("creates deterministic draft briefs and planned assets for missing section slots", () => {
+    const result = planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")
+
+    expect(result).not.toBeNull()
+    expect(result?.addedAssetIds).toHaveLength(5)
+    expect(result?.document.imageBriefs).toHaveLength(5)
+    expect(result?.document.mediaAssets).toHaveLength(6)
+    expect(result?.document.imageBriefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: "ingredient_layout", status: "draft" }),
+        expect.objectContaining({ role: "step", status: "draft" }),
+        expect.objectContaining({ role: "serving", status: "draft" }),
+        expect.objectContaining({ role: "storage", status: "draft" }),
+      ])
+    )
+    expect(
+      result?.document.sections
+        .flatMap((section) => section.blocks)
+        .filter((block) => block.type === "media_reference")
+    ).toHaveLength(6)
+  })
+
+  it("is idempotent when every deterministic media slot already exists", () => {
+    const first = planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")!
+    const second = planRecipeGuidanceMedia(first.document, recipe, "2026-07-31T08:07:00.000Z")
+
+    expect(second?.addedAssetIds).toEqual([])
+    expect(second?.document.mediaAssets).toHaveLength(first.document.mediaAssets.length)
+    expect(second?.document.imageBriefs).toHaveLength(first.document.imageBriefs.length)
+  })
+
+  it("reuses an existing matching brief when its media asset is missing", () => {
+    const ingredients = draft.sections.find((section) => section.kind === "ingredients")!
+    const existingBrief = {
+      id: `${ingredients.id}:existing-brief`,
+      sectionId: ingredients.id,
+      role: "ingredient_layout" as const,
+      status: "draft" as const,
+      description: { en: "Reviewed ingredient plan", af: "Nagegane bestanddeelplan" },
+      reviewedFacts: [],
+      excludedContent: [],
+    }
+
+    const result = planRecipeGuidanceMedia(
+      { ...draft, imageBriefs: [existingBrief] },
+      recipe,
+      "2026-07-31T08:06:00.000Z"
+    )
+
+    expect(
+      result?.document.imageBriefs.filter((brief) => brief.id === existingBrief.id)
+    ).toHaveLength(1)
+    expect(result?.document.mediaAssets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sectionId: ingredients.id,
+          role: "ingredient_layout",
+          imageBriefId: existingBrief.id,
+        }),
+      ])
+    )
+  })
+
+  it("attaches a private upload with server-owned provenance, hash, and restored reference", () => {
+    const planned = planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")!
+    const target = planned.document.mediaAssets.find((asset) => asset.status === "planned")!
+    const withoutReference = {
+      ...planned.document,
+      sections: planned.document.sections.map((section) => ({
+        ...section,
+        blocks: section.blocks.filter(
+          (block) => block.type !== "media_reference" || block.mediaAssetId !== target.id
+        ),
+      })),
+    }
+
+    const attached = attachRecipeGuidanceUpload(withoutReference, {
+      mediaAssetId: target.id,
+      upload: {
+        id: "file_recipe_photo",
+        uploadedBy: "hans",
+        uploadedAt: new Date("2026-07-31T08:06:30.000Z"),
+      },
+      contentHash: `sha256:${"a".repeat(64)}`,
+      rightsBasis: "Estate-owned photograph",
+      attributionText: "Photograph by Hans",
+      now: "2026-07-31T08:07:00.000Z",
+    })
+
+    expect(attached).not.toBeNull()
+    expect(attached?.mediaAssets.find((asset) => asset.id === target.id)).toMatchObject({
+      status: "review_required",
+      source: {
+        type: "uploaded",
+        uploadId: "file_recipe_photo",
+        uploadedBy: "hans",
+        rightsBasis: "Estate-owned photograph",
+        attributionText: "Photograph by Hans",
+      },
+      storage: {
+        type: "hov",
+        storageId: "file_recipe_photo",
+        url: "/api/uploads/file_recipe_photo",
+        contentHash: `sha256:${"a".repeat(64)}`,
+      },
+    })
+    expect(
+      attached?.sections
+        .flatMap((section) => section.blocks)
+        .some((block) => block.type === "media_reference" && block.mediaAssetId === target.id)
+    ).toBe(true)
+  })
+
+  it("does not replace approved media through intake", () => {
+    const approvedHero = {
+      ...draft,
+      mediaAssets: draft.mediaAssets.map((asset) => ({
+        ...asset,
+        status: "approved" as const,
+        altText: { en: "Stew", af: "Bredie" },
+        reviewedBy: "hans",
+        reviewedAt: "2026-07-31T08:06:00.000Z",
+      })),
+    }
+
+    expect(
+      attachRecipeGuidanceUpload(approvedHero, {
+        mediaAssetId: approvedHero.mediaAssets[0]!.id,
+        upload: {
+          id: "file_replacement",
+          uploadedBy: "hans",
+          uploadedAt: new Date("2026-07-31T08:06:30.000Z"),
+        },
+        contentHash: `sha256:${"b".repeat(64)}`,
+        rightsBasis: "Estate-owned photograph",
+        attributionText: "Photograph by Hans",
+        now: "2026-07-31T08:07:00.000Z",
+      })
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
## What changed

- add deterministic recipe-guidance media planning for five section roles
- add authenticated, recipe-scoped private image upload selection and attachment
- record rights basis, attribution, storage provenance, and a content hash before media enters review
- fail closed for cross-recipe uploads and published reads that are not approved, referenced, and revision-matched
- document the workflow, boundaries, and successor decision

## Why

PR #161 completed lifecycle and publication readiness but intentionally left provider execution and media acquisition out of scope. This slice establishes the safe human intake and planning boundary needed before any provider-neutral Sluice contract can be considered.

## Validation

- focused Vitest: 6 files, 87 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build` (125 routes)
- Prettier check and `git diff --check`
- authenticated local Chromium replay: five-slot planning, rights/attribution gating, private-upload attachment, no application console/API errors

## Boundaries

No Sluice/provider call, image generation, public package, OmniPost action, migration apply, deployment, production-data mutation, or demo-data enablement.

Baton: `2853ec21-dfd7-4e54-91c9-4e5c09871b2c`
