### PR TITLE
Add recipe image brief review contracts

### DIFF
--- a/app/api/recipes/[id]/guidance-drafts/[version]/generation-requests/route.ts
+++ b/app/api/recipes/[id]/guidance-drafts/[version]/generation-requests/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { withRole } from "@/lib/auth/rbac"
+import { logger } from "@/lib/logger"
+import { buildRecipeGuidanceGenerationRequest } from "@/lib/recipe-guidance-generation"
+import { createRecipeRevisionId } from "@/lib/recipe-guidance"
+import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
+import { getRecipeById } from "@/lib/repositories/recipe-repository"
+
+const requestSchema = z
+  .object({
+    expectedUpdatedAt: z.string().datetime({ offset: true }),
+    imageBriefId: z.string().trim().min(1).max(200),
+  })
+  .strict()
+
+function parseVersion(value: string | undefined): number | null {
+  if (!value || !/^[1-9]\d*$/.test(value)) return null
+  const version = Number(value)
+  return Number.isSafeInteger(version) ? version : null
+}
+
+export const POST = withRole("admin")(async (request, context) => {
+  try {
+    const params = await context.params
+    const recipeId = params?.id
+    const version = parseVersion(params?.version)
+    if (!recipeId || version === null) {
+      return NextResponse.json(
+        { error: "Recipe and guidance version are required" },
+        { status: 400 }
+      )
+    }
+
+    let input: unknown
+    try {
+      input = await request.json()
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return NextResponse.json({ error: "Malformed JSON in request body" }, { status: 400 })
+      }
+      throw error
+    }
+    const parsed = requestSchema.safeParse(input)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid generation request contract input" },
+        { status: 400 }
+      )
+    }
+
+    const recipe = await getRecipeById(recipeId)
+    if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 })
+    const { repository, mode } = await getRecipeGuidanceRepository()
+    const document = (await repository.listByRecipeId(recipeId)).find(
+      (candidate) => candidate.version === version
+    )
+    if (!document) {
+      return NextResponse.json({ error: "Recipe guidance draft not found" }, { status: 404 })
+    }
+    if (document.status !== "draft" && document.status !== "in_review") {
+      return NextResponse.json(
+        { error: "Generation requests can only be prepared from draft or in-review guidance" },
+        { status: 409 }
+      )
+    }
+    if (parsed.data.expectedUpdatedAt !== document.updatedAt) {
+      return NextResponse.json(
+        { error: "Recipe guidance changed; refresh and retry" },
+        { status: 409 }
+      )
+    }
+    if (document.recipeRevisionId !== createRecipeRevisionId(recipe.id, recipe.updatedAt)) {
+      return NextResponse.json(
+        { error: "Recipe changed; create a new guidance draft" },
+        { status: 409 }
+      )
+    }
+
+    const contract = buildRecipeGuidanceGenerationRequest(
+      document,
+      parsed.data.imageBriefId,
+      context.userId,
+      new Date().toISOString()
+    )
+    if (!contract) {
+      return NextResponse.json(
+        { error: "An approved brief with a planned media slot is required" },
+        { status: 409 }
+      )
+    }
+
+    return NextResponse.json({
+      data: { request: contract },
+      summary: {
+        mode,
+        version: document.version,
+        executionAllowed: false,
+        persisted: false,
+      },
+    })
+  } catch (error) {
+    logger.error("Failed to prepare recipe guidance generation request", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: "Recipe guidance datastore is unavailable" }, { status: 503 })
+  }
+})

--- a/app/api/recipes/[id]/guidance-drafts/[version]/route.ts
+++ b/app/api/recipes/[id]/guidance-drafts/[version]/route.ts
@@ -9,7 +9,11 @@ import {
   recipeGuidanceSectionSchema,
   type RecipeGuidanceDocument,
 } from "@/lib/recipe-guidance"
-import { attachRecipeGuidanceUpload, planRecipeGuidanceMedia } from "@/lib/recipe-guidance-media"
+import {
+  attachRecipeGuidanceUpload,
+  planRecipeGuidanceMedia,
+  reviewRecipeImageBrief,
+} from "@/lib/recipe-guidance-media"
 import {
   RecipeGuidanceConflictError,
   getRecipeGuidanceRepository,
@@ -54,6 +58,31 @@ const mediaAttachmentSchema = z
   })
   .strict()
 
+const imageBriefReviewSchema = z.discriminatedUnion("action", [
+  z
+    .object({
+      action: z.literal("edit"),
+      briefId: z.string().trim().min(1).max(200),
+      description: localizedTextSchema,
+      reviewedFacts: z.array(z.string().trim().min(1).max(500)).max(30),
+      excludedContent: z.array(z.string().trim().min(1).max(500)).max(30),
+    })
+    .strict(),
+  z
+    .object({
+      action: z.literal("approve"),
+      briefId: z.string().trim().min(1).max(200),
+    })
+    .strict(),
+  z
+    .object({
+      action: z.literal("reject"),
+      briefId: z.string().trim().min(1).max(200),
+      rejectionReason: z.string().trim().min(1).max(1_000),
+    })
+    .strict(),
+])
+
 const draftUpdateSchema = z.union([
   sectionUpdateSchema,
   z
@@ -72,6 +101,12 @@ const draftUpdateSchema = z.union([
     .object({
       expectedUpdatedAt: z.string().datetime({ offset: true }),
       mediaAttachment: mediaAttachmentSchema,
+    })
+    .strict(),
+  z
+    .object({
+      expectedUpdatedAt: z.string().datetime({ offset: true }),
+      imageBriefReview: imageBriefReviewSchema,
     })
     .strict(),
 ])
@@ -245,6 +280,23 @@ export const PATCH = withRole("admin")(async (request, context) => {
         mode,
         version: document.version,
         plannedMediaAssets: plan.addedAssetIds,
+      }
+    } else if ("imageBriefReview" in parsed.data) {
+      invalidUpdateError = "Image brief review conflicts with the guidance document"
+      const reviewed = reviewRecipeImageBrief(document, {
+        update: parsed.data.imageBriefReview,
+        reviewerUserId: context.userId,
+        now,
+      })
+      if (!reviewed) {
+        return NextResponse.json({ error: invalidUpdateError }, { status: 409 })
+      }
+      candidate = reviewed
+      summary = {
+        mode,
+        version: document.version,
+        reviewedImageBrief: parsed.data.imageBriefReview.briefId,
+        action: parsed.data.imageBriefReview.action,
       }
     } else {
       invalidUpdateError = "Uploaded media conflicts with the guidance document"

--- a/components/recipes/recipe-guidance-media-intake.tsx
+++ b/components/recipes/recipe-guidance-media-intake.tsx
@@ -48,11 +48,13 @@ function lines(value: string) {
 function ImageBriefEditor({
   brief,
   disabled,
+  canPrepareRequest,
   onReview,
   onPrepareRequest,
 }: {
   brief: RecipeImageBrief
   disabled: boolean
+  canPrepareRequest: boolean
   onReview: (input: RecipeImageBriefUpdate) => Promise<void>
   onPrepareRequest: (briefId: string) => Promise<void>
 }) {
@@ -61,6 +63,25 @@ function ImageBriefEditor({
   const [reviewedFacts, setReviewedFacts] = useState(brief.reviewedFacts.join("\n"))
   const [excludedContent, setExcludedContent] = useState(brief.excludedContent.join("\n"))
   const [rejectionReason, setRejectionReason] = useState(brief.rejectionReason ?? "")
+  const persistedReviewedFacts = brief.reviewedFacts.join("\n")
+  const persistedExcludedContent = brief.excludedContent.join("\n")
+  const persistedKey = JSON.stringify([
+    brief.description.en,
+    brief.description.af,
+    persistedReviewedFacts,
+    persistedExcludedContent,
+    brief.rejectionReason ?? "",
+  ])
+  const [lastPersistedKey, setLastPersistedKey] = useState(persistedKey)
+
+  if (lastPersistedKey !== persistedKey) {
+    setLastPersistedKey(persistedKey)
+    setDescriptionEn(brief.description.en)
+    setDescriptionAf(brief.description.af)
+    setReviewedFacts(persistedReviewedFacts)
+    setExcludedContent(persistedExcludedContent)
+    setRejectionReason(brief.rejectionReason ?? "")
+  }
   const editable = (brief.status === "draft" || brief.status === "rejected") && !disabled
   const complete = Boolean(descriptionEn.trim() && descriptionAf.trim())
   const reviewReady =
@@ -68,8 +89,8 @@ function ImageBriefEditor({
   const hasUnsavedChanges =
     descriptionEn !== brief.description.en ||
     descriptionAf !== brief.description.af ||
-    reviewedFacts !== brief.reviewedFacts.join("\n") ||
-    excludedContent !== brief.excludedContent.join("\n")
+    reviewedFacts !== persistedReviewedFacts ||
+    excludedContent !== persistedExcludedContent
 
   return (
     <article className="border-border space-y-3 rounded-lg border p-3 text-xs">
@@ -179,7 +200,7 @@ function ImageBriefEditor({
             </button>
           </>
         )}
-        {brief.status === "approved" && (
+        {brief.status === "approved" && canPrepareRequest && (
           <button
             type="button"
             disabled={disabled}
@@ -448,9 +469,12 @@ export function RecipeGuidanceMediaIntake({
           <h4 className="text-sm font-semibold">Deterministic image briefs</h4>
           {document.imageBriefs.map((brief) => (
             <ImageBriefEditor
-              key={`${document.updatedAt}:${brief.id}`}
+              key={brief.id}
               brief={brief}
               disabled={disabled || busy}
+              canPrepareRequest={document.mediaAssets.some(
+                (asset) => asset.imageBriefId === brief.id && asset.status === "planned"
+              )}
               onReview={onReviewBrief}
               onPrepareRequest={onPrepareRequest}
             />

--- a/components/recipes/recipe-guidance-media-intake.tsx
+++ b/components/recipes/recipe-guidance-media-intake.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { ApiError, apiFetch } from "@/lib/api-client"
-import type { RecipeGuidanceDocument } from "@/lib/recipe-guidance"
+import type { RecipeGuidanceDocument, RecipeImageBrief } from "@/lib/recipe-guidance"
+import type { RecipeImageBriefUpdate } from "@/lib/recipe-guidance-media"
 import { ImagePlus, Loader2, RefreshCw, Upload } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
@@ -37,6 +38,162 @@ function errorText(error: unknown, fallback: string) {
   return error instanceof Error ? error.message : fallback
 }
 
+function lines(value: string) {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function ImageBriefEditor({
+  brief,
+  disabled,
+  onReview,
+  onPrepareRequest,
+}: {
+  brief: RecipeImageBrief
+  disabled: boolean
+  onReview: (input: RecipeImageBriefUpdate) => Promise<void>
+  onPrepareRequest: (briefId: string) => Promise<void>
+}) {
+  const [descriptionEn, setDescriptionEn] = useState(brief.description.en)
+  const [descriptionAf, setDescriptionAf] = useState(brief.description.af)
+  const [reviewedFacts, setReviewedFacts] = useState(brief.reviewedFacts.join("\n"))
+  const [excludedContent, setExcludedContent] = useState(brief.excludedContent.join("\n"))
+  const [rejectionReason, setRejectionReason] = useState(brief.rejectionReason ?? "")
+  const editable = (brief.status === "draft" || brief.status === "rejected") && !disabled
+  const complete = Boolean(descriptionEn.trim() && descriptionAf.trim())
+  const reviewReady =
+    complete && lines(reviewedFacts).length > 0 && lines(excludedContent).length > 0
+  const hasUnsavedChanges =
+    descriptionEn !== brief.description.en ||
+    descriptionAf !== brief.description.af ||
+    reviewedFacts !== brief.reviewedFacts.join("\n") ||
+    excludedContent !== brief.excludedContent.join("\n")
+
+  return (
+    <article className="border-border space-y-3 rounded-lg border p-3 text-xs">
+      <div>
+        <p className="font-semibold">
+          {brief.role.replaceAll("_", " ")} · {brief.status}
+        </p>
+        {brief.rejectionReason && (
+          <p className="text-destructive mt-1">Rejected: {brief.rejectionReason}</p>
+        )}
+      </div>
+      <label className="text-muted-foreground block">
+        English brief
+        <textarea
+          value={descriptionEn}
+          onChange={(event) => setDescriptionEn(event.target.value)}
+          disabled={!editable}
+          rows={3}
+          className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2"
+        />
+      </label>
+      <label className="text-muted-foreground block">
+        Afrikaans brief
+        <textarea
+          value={descriptionAf}
+          onChange={(event) => setDescriptionAf(event.target.value)}
+          disabled={!editable}
+          rows={3}
+          className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2"
+        />
+      </label>
+      <div className="grid gap-3 lg:grid-cols-2">
+        <label className="text-muted-foreground block">
+          Reviewed facts (one per line)
+          <textarea
+            value={reviewedFacts}
+            onChange={(event) => setReviewedFacts(event.target.value)}
+            disabled={!editable}
+            rows={4}
+            className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2"
+          />
+        </label>
+        <label className="text-muted-foreground block">
+          Excluded content (one per line)
+          <textarea
+            value={excludedContent}
+            onChange={(event) => setExcludedContent(event.target.value)}
+            disabled={!editable}
+            rows={4}
+            className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2"
+          />
+        </label>
+      </div>
+      {brief.status === "draft" && (
+        <label className="text-muted-foreground block">
+          Rejection reason
+          <input
+            value={rejectionReason}
+            onChange={(event) => setRejectionReason(event.target.value)}
+            disabled={disabled}
+            className="border-border bg-background text-foreground mt-1 block w-full rounded-md border px-3 py-2"
+          />
+        </label>
+      )}
+      <div className="flex flex-wrap gap-2">
+        {editable && (
+          <button
+            type="button"
+            disabled={!complete}
+            onClick={() =>
+              void onReview({
+                action: "edit",
+                briefId: brief.id,
+                description: { en: descriptionEn.trim(), af: descriptionAf.trim() },
+                reviewedFacts: lines(reviewedFacts),
+                excludedContent: lines(excludedContent),
+              })
+            }
+            className="border-border bg-background rounded-md border px-3 py-2 font-semibold disabled:opacity-50"
+          >
+            Save brief draft
+          </button>
+        )}
+        {brief.status === "draft" && (
+          <>
+            <button
+              type="button"
+              disabled={disabled || !reviewReady || hasUnsavedChanges}
+              onClick={() => void onReview({ action: "approve", briefId: brief.id })}
+              className="bg-primary text-primary-foreground rounded-md px-3 py-2 font-semibold disabled:opacity-50"
+            >
+              Approve brief
+            </button>
+            <button
+              type="button"
+              disabled={disabled || !rejectionReason.trim() || hasUnsavedChanges}
+              onClick={() =>
+                void onReview({
+                  action: "reject",
+                  briefId: brief.id,
+                  rejectionReason: rejectionReason.trim(),
+                })
+              }
+              className="border-destructive/40 text-destructive rounded-md border px-3 py-2 font-semibold disabled:opacity-50"
+            >
+              Reject brief
+            </button>
+          </>
+        )}
+        {brief.status === "approved" && (
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => void onPrepareRequest(brief.id)}
+            className="border-border bg-background rounded-md border px-3 py-2 font-semibold disabled:opacity-50"
+          >
+            Prepare disabled request contract
+          </button>
+        )}
+      </div>
+    </article>
+  )
+}
+
 export function RecipeGuidanceMediaIntake({
   recipeId,
   document,
@@ -44,6 +201,8 @@ export function RecipeGuidanceMediaIntake({
   busy,
   onPlan,
   onAttach,
+  onReviewBrief,
+  onPrepareRequest,
 }: {
   recipeId: string
   document: RecipeGuidanceDocument
@@ -56,6 +215,8 @@ export function RecipeGuidanceMediaIntake({
     rightsBasis: string
     attributionText: string
   }) => Promise<void>
+  onReviewBrief: (input: RecipeImageBriefUpdate) => Promise<void>
+  onPrepareRequest: (briefId: string) => Promise<void>
 }) {
   const [uploads, setUploads] = useState<UploadRecord[]>([])
   const [selectedUploadId, setSelectedUploadId] = useState("")
@@ -286,13 +447,13 @@ export function RecipeGuidanceMediaIntake({
         <div className="space-y-2">
           <h4 className="text-sm font-semibold">Deterministic image briefs</h4>
           {document.imageBriefs.map((brief) => (
-            <div key={brief.id} className="border-border rounded-lg border p-3 text-xs">
-              <p className="font-semibold">
-                {brief.role.replaceAll("_", " ")} · {brief.status}
-              </p>
-              <p className="text-muted-foreground mt-1">{brief.description.en}</p>
-              <p className="text-muted-foreground mt-1">{brief.description.af}</p>
-            </div>
+            <ImageBriefEditor
+              key={`${document.updatedAt}:${brief.id}`}
+              brief={brief}
+              disabled={disabled || busy}
+              onReview={onReviewBrief}
+              onPrepareRequest={onPrepareRequest}
+            />
           ))}
         </div>
       )}

--- a/components/recipes/recipe-guidance-workspace.tsx
+++ b/components/recipes/recipe-guidance-workspace.tsx
@@ -9,6 +9,7 @@ import {
   type RecipeGuidanceSectionKind,
   type RecipeMediaAsset,
 } from "@/lib/recipe-guidance"
+import type { RecipeImageBriefUpdate } from "@/lib/recipe-guidance-media"
 import type { RecipeRecord } from "@/lib/recipes"
 import {
   AlertTriangle,
@@ -41,6 +42,11 @@ interface GuidanceMutationResponse {
 interface GuidancePreviewResponse {
   data: { recipe: RecipeRecord; document: RecipeGuidanceDocument }
   summary: { persisted: false; nextVersion: number }
+}
+
+interface GenerationRequestResponse {
+  data: { request: { requestId: string; execution: { allowed: false; reason: string } } }
+  summary: { executionAllowed: false; persisted: false }
 }
 
 interface ReadinessIssue {
@@ -646,6 +652,56 @@ export function RecipeGuidanceWorkspace({
     }
   }
 
+  const reviewImageBrief = async (input: RecipeImageBriefUpdate) => {
+    if (!selectedDocument) return
+    setBusy(`brief-${input.briefId}`)
+    setError("")
+    setMessage("")
+    try {
+      const response = await apiFetch<GuidanceMutationResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts/${selectedDocument.version}`,
+        {
+          method: "PATCH",
+          label: "RecipeGuidanceImageBriefReview",
+          body: {
+            expectedUpdatedAt: selectedDocument.updatedAt,
+            imageBriefReview: input,
+          },
+        }
+      )
+      replaceDocument(response.data.document)
+      setMessage(`Image brief ${input.action} recorded. Document review approval was cleared.`)
+    } catch (reviewError) {
+      await handleMutationError(reviewError, "Unable to update the image brief")
+    } finally {
+      setBusy("")
+    }
+  }
+
+  const prepareGenerationRequest = async (imageBriefId: string) => {
+    if (!selectedDocument) return
+    setBusy(`brief-request-${imageBriefId}`)
+    setError("")
+    setMessage("")
+    try {
+      const response = await apiFetch<GenerationRequestResponse>(
+        `/api/recipes/${recipe.id}/guidance-drafts/${selectedDocument.version}/generation-requests`,
+        {
+          method: "POST",
+          label: "RecipeGuidanceGenerationRequest",
+          body: { expectedUpdatedAt: selectedDocument.updatedAt, imageBriefId },
+        }
+      )
+      setMessage(
+        `Validated request ${response.data.request.requestId}. Execution remains disabled and nothing was persisted.`
+      )
+    } catch (requestError) {
+      await handleMutationError(requestError, "Unable to prepare the generation request")
+    } finally {
+      setBusy("")
+    }
+  }
+
   const transition = async (action: TransitionAction) => {
     if (!selectedDocument) return
     setBusy(action)
@@ -943,6 +999,8 @@ export function RecipeGuidanceWorkspace({
                 busy={Boolean(busy)}
                 onPlan={planMedia}
                 onAttach={attachUpload}
+                onReviewBrief={reviewImageBrief}
+                onPrepareRequest={prepareGenerationRequest}
               />
 
               {selectedDocument.mediaAssets.length > 0 && (

--- a/docs/05-project/task-guidance-architecture.md
+++ b/docs/05-project/task-guidance-architecture.md
@@ -148,6 +148,28 @@ and upload time; clients cannot claim either value.
   invoke Sluice, use a direct provider, publish packages, enqueue OmniPost, seed demo data, or write
   production data outside the authenticated upload and explicitly selected draft mutations.
 
+### Recipe image-brief review and disabled generation requests
+
+Hans may edit deterministic bilingual image briefs and their reviewed-fact and excluded-content
+lists while a guidance document is `draft` or `in_review`. Every mutation carries `expectedUpdatedAt`.
+The server preserves the brief's section/role identity, derives the reviewer ID and timestamp, clears
+document-level review evidence, and rejects edits to immutable or already-approved briefs. Approval
+is explicit; rejection requires a reason and returns the brief to a human-editable state without
+silently approving later edits.
+
+`POST /api/recipes/:id/guidance-drafts/:version/generation-requests` creates a validated,
+non-persisted snapshot only for an approved brief attached to a still-planned media slot. The
+contract binds the immutable recipe revision, guidance version, media slot, approved bilingual
+brief, reviewed facts, exclusions, requesting admin, HOV-copy output requirement, and a stable
+request ID. It always returns `execution.allowed=false`, with no provider or model alias, and lists
+the Sluice capabilities that remain unproven: model alias, request/response shape, request-ID
+propagation, cost reporting, telemetry, rights enforcement, and HOV storage copy.
+
+Request construction never changes the media status to `requested`, stores a job, calls Sluice,
+falls back to a provider, or exposes an execution endpoint. Provider execution remains fail-closed
+until those capabilities are evidenced and a separately authorized slice introduces the execution
+boundary.
+
 ## Request flow
 
 1. A resident opens Guidance from a task and captures or chooses a photo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,4 +99,5 @@ Dated session continuity notes (root cause, files changed, verification, next-ow
 | [2026-07-29-recipe-guidance-lifecycle.md](handoffs/2026-07-29-recipe-guidance-lifecycle.md)               | Review transitions, readiness evidence, publication, and immutable archival          |
 | [2026-07-31-recipe-guidance-ui.md](handoffs/2026-07-31-recipe-guidance-ui.md)                             | Hans review workspace and Irma mobile published-guidance reader                      |
 | [2026-07-31-recipe-guidance-media-intake.md](handoffs/2026-07-31-recipe-guidance-media-intake.md)         | Authenticated recipe media intake and deterministic section planning                 |
+| [2026-07-31-recipe-guidance-brief-approval.md](handoffs/2026-07-31-recipe-guidance-brief-approval.md)     | Human image-brief review and disabled provider-neutral request contract              |
 | [2026-07-28-user-selectable-themes.md](handoffs/2026-07-28-user-selectable-themes.md)                     | User-selectable workspace themes implementation, review, and merge handoff           |

--- a/docs/handoffs/2026-07-31-recipe-guidance-brief-approval.md
+++ b/docs/handoffs/2026-07-31-recipe-guidance-brief-approval.md
@@ -65,6 +65,20 @@ git diff --check
   clean replay ran this worktree's build on isolated port 3100; the pre-existing process was not
   stopped or changed.
 
+## Review remediation
+
+- PR #163 review feedback was addressed by keeping brief-editor identity stable, synchronizing
+  only fields whose persisted brief values changed, and preserving unsaved edits in other briefs.
+- The generation-request action is now shown only when the approved brief still has a matching
+  `planned` media asset, so an uploaded `review_required` slot cannot offer an action guaranteed to
+  return 409.
+- Approved image briefs now fail schema parsing unless both grounded reviewed facts and explicit
+  exclusions are present, matching the mutation and generation-request gates.
+- Review-remediation verification: 4 focused files with 51 tests passed, TypeScript passed, lint
+  passed, and the production build generated 125 static pages. The first sandboxed build retry hit
+  a Windows access denial on the generated `.next/trace-build`; removing that exact generated file
+  and rerunning outside the sandbox passed.
+
 ## Boundaries and next slice
 
 No Sluice/provider call, image generation, request persistence, media-status transition, direct

--- a/docs/handoffs/2026-07-31-recipe-guidance-brief-approval.md
+++ b/docs/handoffs/2026-07-31-recipe-guidance-brief-approval.md
@@ -1,0 +1,84 @@
+# Recipe guidance image-brief approval handoff
+
+- **Date:** 2026-07-31
+- **Repository:** `C:\Users\smitj\repos\house-of-veritas`
+- **Worktree:** `C:\tmp\hov-recipe-guidance-brief-approval`
+- **Branch:** `feat/recipe-guidance-brief-approval`
+- **Base:** `origin/main` at `33f1fa2c42362ba5183202057c5f15a01bd31c98`
+- **Predecessor:** PR [#162](https://github.com/neuralliquid/house-of-veritas/pull/162)
+- **Baton task:** `06df7efb-d396-4cfa-81f0-1a5b193f0759`
+- **Risk tier:** API/data/UI workflow; admin review and deliberately disabled provider boundary
+
+## Outcome
+
+- Hans can edit deterministic bilingual image briefs and reviewed-fact/exclusion lists, then
+  explicitly approve or reject a brief. Rejection requires a reason; reviewer identity and time are
+  server-derived.
+- Brief mutations use the existing draft CAS token, clear document-level review evidence, preserve
+  stable section/role identity, and fail closed for stale, immutable, or already-approved updates.
+- An admin-only endpoint constructs a provider-neutral request snapshot from an approved brief and
+  planned media slot. It binds the exact recipe revision and guidance version but neither persists a
+  request nor changes media status.
+- Every returned request has provider/model unset and `execution.allowed=false`. Missing Sluice
+  model-alias, request/response, request-ID, cost, telemetry, rights, and HOV-copy capabilities are
+  explicit in the contract.
+
+## Changed files
+
+- `lib/recipe-guidance.ts`
+- `lib/recipe-guidance-media.ts`
+- `lib/recipe-guidance-generation.ts`
+- `app/api/recipes/[id]/guidance-drafts/[version]/route.ts`
+- `app/api/recipes/[id]/guidance-drafts/[version]/generation-requests/route.ts`
+- `components/recipes/recipe-guidance-media-intake.tsx`
+- `components/recipes/recipe-guidance-workspace.tsx`
+- `tests/lib/recipe-guidance-media.test.ts`
+- `tests/lib/recipe-guidance-generation.test.ts`
+- `tests/api/recipe-guidance.test.ts`
+- `tests/components/recipe-guidance-ui.test.tsx`
+- `docs/05-project/task-guidance-architecture.md`
+- `docs/handoffs/2026-07-31-recipe-guidance-brief-approval.md`
+- `docs/README.md`
+
+## Verification
+
+```text
+pnpm test -- tests/lib/recipe-guidance-generation.test.ts tests/lib/recipe-guidance-media.test.ts tests/lib/recipe-guidance.test.ts tests/api/recipe-guidance.test.ts tests/components/recipe-guidance-ui.test.tsx
+pnpm exec tsc --noEmit
+pnpm run lint
+pnpm run build
+pnpm exec prettier --check <changed TypeScript and Markdown files>
+git diff --check
+```
+
+- Focused Vitest: 5 files, 78 tests passed.
+- TypeScript passed.
+- Lint and production build passed; the build generated 125 static pages and emitted the new
+  generation-request route.
+- A visible local Chromium replay used a synthetic E2E-only Hans session with fixture-intercepted
+  recipe, guidance, upload, scope, brief-review, and generation-request APIs. It proved draft brief
+  rendering, explicit approval, the approved read-only state, disabled request construction, and
+  the message `Execution remains disabled and nothing was persisted.` Final console evidence had
+  zero errors and zero warnings. Screenshot:
+  `output/playwright/recipe-guidance-brief-approval.png` (ignored local artifact).
+- The first browser attempt hit a pre-existing user-owned app on port 3000 and was discarded. The
+  clean replay ran this worktree's build on isolated port 3100; the pre-existing process was not
+  stopped or changed.
+
+## Boundaries and next slice
+
+No Sluice/provider call, image generation, request persistence, media-status transition, direct
+provider fallback, public package, OmniPost action, migration apply, deployment, production-data
+mutation, auth/secret change, or demo-data enablement is part of this slice.
+
+The next decision requires live Sluice evidence for model alias, request/response schema,
+request-ID propagation, cost and telemetry fields, rights enforcement, HOV storage-copy behavior,
+timeouts, and failure semantics. Do not add an execution route until those contracts are proven and
+the external effect is separately authorized.
+
+## Trace envelope
+
+- **Task:** `06df7efb-d396-4cfa-81f0-1a5b193f0759`
+- **Routing:** Veritas Gateway, Ledger, Shield, Surface/Studio, Proof
+- **External effects:** Baton coordination and GitHub branch/PR only; no provider, deployment,
+  publication, migration, or production-data effect

--- a/lib/recipe-guidance-generation.ts
+++ b/lib/recipe-guidance-generation.ts
@@ -1,0 +1,141 @@
+import { z } from "zod"
+import {
+  localizedTextSchema,
+  RECIPE_MEDIA_ROLES,
+  type RecipeGuidanceDocument,
+  type RecipeImageBrief,
+} from "@/lib/recipe-guidance"
+
+export const RECIPE_GENERATION_REQUIRED_CAPABILITIES = [
+  "model_alias",
+  "request_response_contract",
+  "request_id_propagation",
+  "cost_reporting",
+  "telemetry",
+  "rights_enforcement",
+  "hov_storage_copy",
+] as const
+
+const generationCapabilitySchema = z.enum(RECIPE_GENERATION_REQUIRED_CAPABILITIES)
+
+export const recipeGuidanceGenerationRequestSchema = z
+  .object({
+    contractVersion: z.literal("recipe-image-generation.v1"),
+    requestId: z.string().trim().min(1).max(1_000),
+    requestedBy: z.string().trim().min(1).max(200),
+    requestedAt: z.string().datetime({ offset: true }),
+    recipe: z
+      .object({
+        id: z.string().trim().min(1).max(200),
+        revisionId: z.string().trim().min(1).max(500),
+      })
+      .strict(),
+    guidance: z
+      .object({
+        documentId: z.string().trim().min(1).max(200),
+        version: z.number().int().positive(),
+      })
+      .strict(),
+    target: z
+      .object({
+        mediaAssetId: z.string().trim().min(1).max(200),
+        imageBriefId: z.string().trim().min(1).max(200),
+        sectionId: z.string().trim().min(1).max(200),
+        role: z.enum(RECIPE_MEDIA_ROLES),
+      })
+      .strict(),
+    brief: z
+      .object({
+        description: localizedTextSchema,
+        reviewedFacts: z.array(z.string().trim().min(1).max(500)).max(30),
+        excludedContent: z.array(z.string().trim().min(1).max(500)).max(30),
+        approvedBy: z.string().trim().min(1).max(200),
+        approvedAt: z.string().datetime({ offset: true }),
+      })
+      .strict(),
+    output: z
+      .object({
+        kind: z.literal("image"),
+        storage: z.literal("hov_managed_copy_required"),
+        publicUrlAllowed: z.literal(false),
+      })
+      .strict(),
+    execution: z
+      .object({
+        allowed: z.literal(false),
+        provider: z.null(),
+        modelAlias: z.null(),
+        reason: z.literal("Provider execution is disabled until Sluice capabilities are proven"),
+        missingCapabilities: z.array(generationCapabilitySchema).min(1),
+      })
+      .strict(),
+  })
+  .strict()
+
+export type RecipeGuidanceGenerationRequest = z.infer<typeof recipeGuidanceGenerationRequestSchema>
+
+function approvedBriefSnapshot(brief: RecipeImageBrief) {
+  if (
+    brief.status !== "approved" ||
+    !brief.approvedBy ||
+    !brief.approvedAt ||
+    brief.reviewedFacts.length === 0 ||
+    brief.excludedContent.length === 0
+  ) {
+    return null
+  }
+  return {
+    description: brief.description,
+    reviewedFacts: brief.reviewedFacts,
+    excludedContent: brief.excludedContent,
+    approvedBy: brief.approvedBy,
+    approvedAt: brief.approvedAt,
+  }
+}
+
+export function buildRecipeGuidanceGenerationRequest(
+  document: RecipeGuidanceDocument,
+  imageBriefId: string,
+  requestedBy: string,
+  requestedAt: string
+): RecipeGuidanceGenerationRequest | null {
+  if (!["draft", "in_review"].includes(document.status)) return null
+  const brief = document.imageBriefs.find((candidate) => candidate.id === imageBriefId)
+  if (!brief) return null
+  const briefSnapshot = approvedBriefSnapshot(brief)
+  if (!briefSnapshot) return null
+  const asset = document.mediaAssets.find(
+    (candidate) => candidate.imageBriefId === brief.id && candidate.status === "planned"
+  )
+  if (!asset) return null
+
+  const candidate = {
+    contractVersion: "recipe-image-generation.v1" as const,
+    requestId: `${document.id}:v${document.version}:${brief.id}:${brief.approvedAt}`,
+    requestedBy,
+    requestedAt,
+    recipe: { id: document.recipeId, revisionId: document.recipeRevisionId },
+    guidance: { documentId: document.id, version: document.version },
+    target: {
+      mediaAssetId: asset.id,
+      imageBriefId: brief.id,
+      sectionId: brief.sectionId,
+      role: brief.role,
+    },
+    brief: briefSnapshot,
+    output: {
+      kind: "image" as const,
+      storage: "hov_managed_copy_required" as const,
+      publicUrlAllowed: false as const,
+    },
+    execution: {
+      allowed: false as const,
+      provider: null,
+      modelAlias: null,
+      reason: "Provider execution is disabled until Sluice capabilities are proven" as const,
+      missingCapabilities: [...RECIPE_GENERATION_REQUIRED_CAPABILITIES],
+    },
+  }
+  const parsed = recipeGuidanceGenerationRequestSchema.safeParse(candidate)
+  return parsed.success ? parsed.data : null
+}

--- a/lib/recipe-guidance-media.ts
+++ b/lib/recipe-guidance-media.ts
@@ -32,6 +32,23 @@ export interface AttachRecipeGuidanceUploadInput {
   now: string
 }
 
+export type RecipeImageBriefUpdate =
+  | {
+      action: "edit"
+      briefId: string
+      description: { en: string; af: string }
+      reviewedFacts: string[]
+      excludedContent: string[]
+    }
+  | { action: "approve"; briefId: string }
+  | { action: "reject"; briefId: string; rejectionReason: string }
+
+export interface ReviewRecipeImageBriefInput {
+  update: RecipeImageBriefUpdate
+  reviewerUserId: string
+  now: string
+}
+
 function withoutReview(document: RecipeGuidanceDocument): RecipeGuidanceDocument {
   const mutable = { ...document }
   delete mutable.reviewedBy
@@ -215,6 +232,60 @@ export function attachRecipeGuidanceUpload(
     ...withoutReview(document),
     mediaAssets,
     sections,
+    updatedAt: input.now,
+  })
+}
+
+export function reviewRecipeImageBrief(
+  document: RecipeGuidanceDocument,
+  input: ReviewRecipeImageBriefInput
+): RecipeGuidanceDocument | null {
+  const briefIndex = document.imageBriefs.findIndex((brief) => brief.id === input.update.briefId)
+  const current = document.imageBriefs[briefIndex]
+  if (briefIndex === -1 || !current) return null
+
+  let replacement: RecipeImageBrief
+  if (input.update.action === "edit") {
+    if (current.status !== "draft" && current.status !== "rejected") return null
+    replacement = {
+      id: current.id,
+      sectionId: current.sectionId,
+      role: current.role,
+      status: "draft",
+      description: input.update.description,
+      reviewedFacts: input.update.reviewedFacts,
+      excludedContent: input.update.excludedContent,
+    }
+  } else if (input.update.action === "approve") {
+    if (
+      current.status !== "draft" ||
+      current.reviewedFacts.length === 0 ||
+      current.excludedContent.length === 0
+    ) {
+      return null
+    }
+    replacement = {
+      ...current,
+      status: "approved",
+      approvedBy: input.reviewerUserId,
+      approvedAt: input.now,
+    }
+  } else {
+    if (current.status !== "draft") return null
+    replacement = {
+      ...current,
+      status: "rejected",
+      rejectedBy: input.reviewerUserId,
+      rejectedAt: input.now,
+      rejectionReason: input.update.rejectionReason,
+    }
+  }
+
+  const imageBriefs = [...document.imageBriefs]
+  imageBriefs[briefIndex] = replacement
+  return parseRecipeGuidanceDocument({
+    ...withoutReview(document),
+    imageBriefs,
     updatedAt: input.now,
   })
 }

--- a/lib/recipe-guidance.ts
+++ b/lib/recipe-guidance.ts
@@ -329,6 +329,20 @@ export const recipeImageBriefSchema = z
           })
         }
       }
+      if (brief.reviewedFacts.length === 0) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["reviewedFacts"],
+          message: "approved image briefs require reviewed facts",
+        })
+      }
+      if (brief.excludedContent.length === 0) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["excludedContent"],
+          message: "approved image briefs require explicit exclusions",
+        })
+      }
     }
     if (brief.status === "rejected") {
       for (const field of ["rejectedBy", "rejectedAt", "rejectionReason"] as const) {

--- a/lib/recipe-guidance.ts
+++ b/lib/recipe-guidance.ts
@@ -33,7 +33,7 @@ export const RECIPE_MEDIA_STATUSES = [
   "unavailable",
 ] as const
 
-export const RECIPE_IMAGE_BRIEF_STATUSES = ["draft", "approved", "retired"] as const
+export const RECIPE_IMAGE_BRIEF_STATUSES = ["draft", "approved", "rejected", "retired"] as const
 
 export type RecipeGuidanceSectionKind = (typeof RECIPE_GUIDANCE_SECTION_KINDS)[number]
 export type RecipeGuidanceStatus = (typeof RECIPE_GUIDANCE_STATUSES)[number]
@@ -314,6 +314,9 @@ export const recipeImageBriefSchema = z
     excludedContent: z.array(z.string().trim().min(1).max(500)).max(30).default([]),
     approvedBy: nonEmptyId.optional(),
     approvedAt: isoDateTime.optional(),
+    rejectedBy: nonEmptyId.optional(),
+    rejectedAt: isoDateTime.optional(),
+    rejectionReason: z.string().trim().min(1).max(1_000).optional(),
   })
   .superRefine((brief, context) => {
     if (brief.status === "approved") {
@@ -326,6 +329,34 @@ export const recipeImageBriefSchema = z
           })
         }
       }
+    }
+    if (brief.status === "rejected") {
+      for (const field of ["rejectedBy", "rejectedAt", "rejectionReason"] as const) {
+        if (!brief[field]) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [field],
+            message: `${field} is required for a rejected image brief`,
+          })
+        }
+      }
+    }
+    if (brief.status !== "approved" && (brief.approvedBy || brief.approvedAt)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["approvedBy"],
+        message: "approval evidence is only valid for an approved image brief",
+      })
+    }
+    if (
+      brief.status !== "rejected" &&
+      (brief.rejectedBy || brief.rejectedAt || brief.rejectionReason)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["rejectedBy"],
+        message: "rejection evidence is only valid for a rejected image brief",
+      })
     }
   })
 

--- a/tests/api/recipe-guidance.test.ts
+++ b/tests/api/recipe-guidance.test.ts
@@ -4,13 +4,14 @@ import {
   POST as createDraft,
 } from "@/app/api/recipes/[id]/guidance-drafts/route"
 import { PATCH as updateDraftSection } from "@/app/api/recipes/[id]/guidance-drafts/[version]/route"
+import { POST as prepareGenerationRequest } from "@/app/api/recipes/[id]/guidance-drafts/[version]/generation-requests/route"
 import { GET as inspectPublicationReadiness } from "@/app/api/recipes/[id]/guidance-drafts/[version]/publication-readiness/route"
 import { POST as transitionDraft } from "@/app/api/recipes/[id]/guidance-drafts/[version]/transitions/route"
 import { POST as previewDraft } from "@/app/api/recipes/[id]/guidance-drafts/preview/route"
 import { GET as readPublished } from "@/app/api/recipes/[id]/guidance/route"
 import { PATCH as updateRecipe } from "@/app/api/recipes/[id]/route"
 import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
-import { planRecipeGuidanceMedia } from "@/lib/recipe-guidance-media"
+import { planRecipeGuidanceMedia, reviewRecipeImageBrief } from "@/lib/recipe-guidance-media"
 import { parseRecipeGuidanceDocument, type RecipeGuidanceDocument } from "@/lib/recipe-guidance"
 import { getRecipeGuidanceRepository } from "@/lib/repositories/recipe-guidance-repository"
 import { getRecipeById, replaceRecipe } from "@/lib/repositories/recipe-repository"
@@ -422,6 +423,147 @@ describe("recipe guidance APIs", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Recipe guidance changed; refresh and retry",
     })
+  })
+
+  it("records human image-brief edits and approval with optimistic concurrency", async () => {
+    const planned = planRecipeGuidanceMedia(
+      existingDocument,
+      recipe,
+      "2026-07-31T09:31:00.000Z"
+    )!.document
+    const brief = planned.imageBriefs[0]!
+    repository.listByRecipeId.mockResolvedValueOnce([planned])
+
+    const editResponse = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: planned.updatedAt,
+        imageBriefReview: {
+          action: "edit",
+          briefId: brief.id,
+          description: { en: "Reviewed brief", af: "Nagegane opdrag" },
+          reviewedFacts: ["Canonical ingredient: Rice"],
+          excludedContent: ["No text overlays"],
+        },
+      }),
+      versionRouteContext
+    )
+    expect(editResponse.status).toBe(200)
+    const edited = repository.replace.mock.calls[0][0] as RecipeGuidanceDocument
+    expect(edited.imageBriefs.find((candidate) => candidate.id === brief.id)).toMatchObject({
+      status: "draft",
+      description: { en: "Reviewed brief", af: "Nagegane opdrag" },
+    })
+
+    repository.listByRecipeId.mockResolvedValueOnce([edited])
+    const approveResponse = await updateDraftSection(
+      jsonRequestFor("/api/recipes/recipe-1/guidance-drafts/2", "hans", "admin", "PATCH", {
+        expectedUpdatedAt: edited.updatedAt,
+        imageBriefReview: { action: "approve", briefId: brief.id },
+      }),
+      versionRouteContext
+    )
+    expect(approveResponse.status).toBe(200)
+    expect(repository.replace.mock.calls[1][0]).toMatchObject({
+      imageBriefs: expect.arrayContaining([
+        expect.objectContaining({
+          id: brief.id,
+          status: "approved",
+          approvedBy: "hans",
+          approvedAt: expect.any(String),
+        }),
+      ]),
+    })
+  })
+
+  it("prepares but never executes or persists an approved brief request contract", async () => {
+    const planned = planRecipeGuidanceMedia(
+      existingDocument,
+      recipe,
+      "2026-07-31T09:31:00.000Z"
+    )!.document
+    const brief = planned.imageBriefs[0]!
+    const approved = reviewRecipeImageBrief(planned, {
+      update: { action: "approve", briefId: brief.id },
+      reviewerUserId: "hans",
+      now: "2026-07-31T09:32:00.000Z",
+    })!
+    repository.listByRecipeId.mockResolvedValueOnce([approved])
+
+    const response = await prepareGenerationRequest(
+      jsonRequestFor(
+        "/api/recipes/recipe-1/guidance-drafts/2/generation-requests",
+        "hans",
+        "admin",
+        "POST",
+        { expectedUpdatedAt: approved.updatedAt, imageBriefId: brief.id }
+      ),
+      versionRouteContext
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      data: {
+        request: {
+          requestedBy: "hans",
+          target: { imageBriefId: brief.id },
+          execution: { allowed: false, provider: null, modelAlias: null },
+        },
+      },
+      summary: { mode: "memory", executionAllowed: false, persisted: false },
+    })
+    expect(repository.replace).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when preparing a request from stale or unapproved guidance", async () => {
+    const planned = planRecipeGuidanceMedia(
+      existingDocument,
+      recipe,
+      "2026-07-31T09:31:00.000Z"
+    )!.document
+    const brief = planned.imageBriefs[0]!
+    repository.listByRecipeId.mockResolvedValueOnce([planned])
+    const staleResponse = await prepareGenerationRequest(
+      jsonRequestFor(
+        "/api/recipes/recipe-1/guidance-drafts/2/generation-requests",
+        "hans",
+        "admin",
+        "POST",
+        { expectedUpdatedAt: existingDocument.updatedAt, imageBriefId: brief.id }
+      ),
+      versionRouteContext
+    )
+    expect(staleResponse.status).toBe(409)
+
+    repository.listByRecipeId.mockResolvedValueOnce([planned])
+    const draftResponse = await prepareGenerationRequest(
+      jsonRequestFor(
+        "/api/recipes/recipe-1/guidance-drafts/2/generation-requests",
+        "hans",
+        "admin",
+        "POST",
+        { expectedUpdatedAt: planned.updatedAt, imageBriefId: brief.id }
+      ),
+      versionRouteContext
+    )
+    expect(draftResponse.status).toBe(409)
+    expect(repository.replace).not.toHaveBeenCalled()
+  })
+
+  it("denies generation request contracts to non-admin users", async () => {
+    const response = await prepareGenerationRequest(
+      jsonRequestFor(
+        "/api/recipes/recipe-1/guidance-drafts/2/generation-requests",
+        "irma",
+        "resident",
+        "POST",
+        { expectedUpdatedAt: existingDocument.updatedAt, imageBriefId: "brief-1" }
+      ),
+      versionRouteContext
+    )
+
+    expect(response.status).toBe(403)
+    expect(repository.listByRecipeId).not.toHaveBeenCalled()
   })
 
   it("attaches only a private image upload scoped to this recipe", async () => {

--- a/tests/components/recipe-guidance-ui.test.tsx
+++ b/tests/components/recipe-guidance-ui.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ApiError, apiFetch } from "@/lib/api-client"
 import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
-import { planRecipeGuidanceMedia } from "@/lib/recipe-guidance-media"
+import { planRecipeGuidanceMedia, reviewRecipeImageBrief } from "@/lib/recipe-guidance-media"
 import { parseRecipeGuidanceDocument, type RecipeGuidanceDocument } from "@/lib/recipe-guidance"
 import type { RecipeRecord } from "@/lib/recipes"
 import { PublishedRecipeGuidance } from "@/components/recipes/published-recipe-guidance"
@@ -429,6 +429,65 @@ describe("recipe guidance UI", () => {
           },
         })
       )
+    )
+  })
+
+  it("approves a human-reviewed image brief and previews a disabled request contract", async () => {
+    const planned = planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")!.document
+    const brief = planned.imageBriefs[0]!
+    const approved = reviewRecipeImageBrief(planned, {
+      update: { action: "approve", briefId: brief.id },
+      reviewerUserId: "hans",
+      now: "2026-07-31T08:07:00.000Z",
+    })!
+    vi.mocked(apiFetch).mockImplementation(async (url, options) => {
+      if (url.startsWith("/api/uploads?")) return { files: [], total: 0 }
+      if (url.endsWith("/publication-readiness")) {
+        return {
+          data: {
+            documentId: planned.id,
+            version: 1,
+            status: "draft",
+            ready: false,
+            issues: [{ code: "media", message: "Media is not reviewed" }],
+          },
+        }
+      }
+      if (options?.label === "RecipeGuidanceImageBriefReview") {
+        return { data: { document: approved } }
+      }
+      if (options?.label === "RecipeGuidanceGenerationRequest") {
+        return {
+          data: {
+            request: {
+              requestId: "request-disabled-1",
+              execution: { allowed: false, reason: "Provider execution is disabled" },
+            },
+          },
+          summary: { executionAllowed: false, persisted: false },
+        }
+      }
+      return { data: { documents: [planned] } }
+    })
+
+    const user = userEvent.setup()
+    render(<RecipeGuidanceWorkspace recipe={recipe} language="both" />)
+    await user.click((await screen.findAllByRole("button", { name: "Approve brief" }))[0]!)
+    await user.click(
+      await screen.findByRole("button", { name: "Prepare disabled request contract" })
+    )
+
+    expect(
+      await screen.findByText(
+        "Validated request request-disabled-1. Execution remains disabled and nothing was persisted."
+      )
+    ).toBeInTheDocument()
+    expect(apiFetch).toHaveBeenCalledWith(
+      `/api/recipes/${recipe.id}/guidance-drafts/1/generation-requests`,
+      expect.objectContaining({
+        method: "POST",
+        body: { expectedUpdatedAt: approved.updatedAt, imageBriefId: brief.id },
+      })
     )
   })
 })

--- a/tests/components/recipe-guidance-ui.test.tsx
+++ b/tests/components/recipe-guidance-ui.test.tsx
@@ -3,11 +3,16 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ApiError, apiFetch } from "@/lib/api-client"
 import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
-import { planRecipeGuidanceMedia, reviewRecipeImageBrief } from "@/lib/recipe-guidance-media"
+import {
+  attachRecipeGuidanceUpload,
+  planRecipeGuidanceMedia,
+  reviewRecipeImageBrief,
+} from "@/lib/recipe-guidance-media"
 import { parseRecipeGuidanceDocument, type RecipeGuidanceDocument } from "@/lib/recipe-guidance"
 import type { RecipeRecord } from "@/lib/recipes"
 import { PublishedRecipeGuidance } from "@/components/recipes/published-recipe-guidance"
 import { RecipeGuidanceDocumentView } from "@/components/recipes/recipe-guidance-document-view"
+import { RecipeGuidanceMediaIntake } from "@/components/recipes/recipe-guidance-media-intake"
 import { RecipeGuidanceWorkspace } from "@/components/recipes/recipe-guidance-workspace"
 import uiFlowFixture from "@/tests/fixtures/recipe-guidance/ui-flow.json"
 
@@ -489,5 +494,97 @@ describe("recipe guidance UI", () => {
         body: { expectedUpdatedAt: approved.updatedAt, imageBriefId: brief.id },
       })
     )
+  })
+
+  it("preserves unsaved edits in other briefs when one brief changes", async () => {
+    const planned = planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")!.document
+    vi.mocked(apiFetch).mockResolvedValue({ files: [], total: 0 })
+    const props = {
+      recipeId: recipe.id,
+      disabled: false,
+      busy: false,
+      onPlan: vi.fn(async () => {}),
+      onAttach: vi.fn(async () => {}),
+      onReviewBrief: vi.fn(async () => {}),
+      onPrepareRequest: vi.fn(async () => {}),
+    }
+    const user = userEvent.setup()
+    const { rerender } = render(<RecipeGuidanceMediaIntake {...props} document={planned} />)
+    const englishBriefs = await screen.findAllByRole("textbox", { name: "English brief" })
+
+    await user.clear(englishBriefs[1]!)
+    await user.type(englishBriefs[1]!, "Unsaved preparation composition")
+
+    rerender(
+      <RecipeGuidanceMediaIntake
+        {...props}
+        document={{
+          ...planned,
+          updatedAt: "2026-07-31T08:07:00.000Z",
+          imageBriefs: planned.imageBriefs.map((brief, index) =>
+            index === 0
+              ? {
+                  ...brief,
+                  description: { ...brief.description, en: "Saved ingredient composition" },
+                }
+              : brief
+          ),
+        }}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("textbox", { name: "English brief" })[0]).toHaveValue(
+        "Saved ingredient composition"
+      )
+    )
+    expect(screen.getAllByRole("textbox", { name: "English brief" })[1]).toHaveValue(
+      "Unsaved preparation composition"
+    )
+  })
+
+  it("hides generation requests after an approved brief's media slot receives an upload", async () => {
+    const planned = planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")!.document
+    const brief = planned.imageBriefs[0]!
+    const approved = reviewRecipeImageBrief(planned, {
+      update: { action: "approve", briefId: brief.id },
+      reviewerUserId: "hans",
+      now: "2026-07-31T08:07:00.000Z",
+    })!
+    const asset = approved.mediaAssets.find((candidate) => candidate.imageBriefId === brief.id)!
+    const attached = attachRecipeGuidanceUpload(approved, {
+      mediaAssetId: asset.id,
+      upload: {
+        id: "file-approved-brief",
+        uploadedBy: "hans",
+        uploadedAt: new Date("2026-07-31T08:08:00.000Z"),
+      },
+      contentHash: `sha256:${"a".repeat(64)}`,
+      rightsBasis: "Estate-owned photograph",
+      attributionText: "Photograph by Hans",
+      now: "2026-07-31T08:08:00.000Z",
+    })!
+    vi.mocked(apiFetch).mockResolvedValue({ files: [], total: 0 })
+
+    render(
+      <RecipeGuidanceMediaIntake
+        recipeId={recipe.id}
+        document={attached}
+        disabled={false}
+        busy={false}
+        onPlan={vi.fn(async () => {})}
+        onAttach={vi.fn(async () => {})}
+        onReviewBrief={vi.fn(async () => {})}
+        onPrepareRequest={vi.fn(async () => {})}
+      />
+    )
+
+    expect(asset.status).toBe("planned")
+    expect(attached.mediaAssets.find((candidate) => candidate.id === asset.id)?.status).toBe(
+      "review_required"
+    )
+    expect(
+      screen.queryByRole("button", { name: "Prepare disabled request contract" })
+    ).not.toBeInTheDocument()
   })
 })

--- a/tests/lib/recipe-guidance-generation.test.ts
+++ b/tests/lib/recipe-guidance-generation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
+import {
+  buildRecipeGuidanceGenerationRequest,
+  RECIPE_GENERATION_REQUIRED_CAPABILITIES,
+  recipeGuidanceGenerationRequestSchema,
+} from "@/lib/recipe-guidance-generation"
+import { planRecipeGuidanceMedia, reviewRecipeImageBrief } from "@/lib/recipe-guidance-media"
+import type { RecipeRecord } from "@/lib/recipes"
+
+const recipe: RecipeRecord = {
+  id: "recipe-generation",
+  status: "published",
+  ownerUserId: "hans",
+  audienceUserIds: ["hans", "irma"],
+  titleEn: "Garden stew",
+  titleAf: "Tuinbredie",
+  image: {
+    url: "https://example.com/stew.jpg",
+    source: "Example library",
+    license: "CC BY 4.0",
+    attributionText: "Example cook",
+    retrievedAt: "2026-07-31",
+  },
+  ingredients: [{ id: "ingredient-1", name: "Carrots" }],
+  steps: [
+    {
+      id: "step-1",
+      order: 1,
+      instructionEn: "Simmer until tender.",
+      instructionAf: "Prut tot sag.",
+    },
+  ],
+  createdAt: "2026-07-31T08:00:00.000Z",
+  updatedAt: "2026-07-31T08:00:00.000Z",
+}
+
+function plannedDocument() {
+  const draft = buildRecipeGuidanceDraft(recipe, {
+    version: 1,
+    createdBy: "hans",
+    now: "2026-07-31T08:05:00.000Z",
+  })
+  return planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")!.document
+}
+
+describe("recipe guidance generation request", () => {
+  it("builds a provider-neutral request only from an approved brief", () => {
+    const planned = plannedDocument()
+    const brief = planned.imageBriefs[0]!
+    const approved = reviewRecipeImageBrief(planned, {
+      update: { action: "approve", briefId: brief.id },
+      reviewerUserId: "hans",
+      now: "2026-07-31T08:07:00.000Z",
+    })!
+
+    const request = buildRecipeGuidanceGenerationRequest(
+      approved,
+      brief.id,
+      "hans",
+      "2026-07-31T08:08:00.000Z"
+    )
+
+    expect(recipeGuidanceGenerationRequestSchema.safeParse(request).success).toBe(true)
+    expect(request).toMatchObject({
+      contractVersion: "recipe-image-generation.v1",
+      requestedBy: "hans",
+      target: { imageBriefId: brief.id, mediaAssetId: expect.any(String) },
+      output: { storage: "hov_managed_copy_required", publicUrlAllowed: false },
+      execution: { allowed: false, provider: null, modelAlias: null },
+    })
+    expect(request?.execution.missingCapabilities).toEqual(RECIPE_GENERATION_REQUIRED_CAPABILITIES)
+  })
+
+  it("fails closed for a draft brief or a non-planned media asset", () => {
+    const planned = plannedDocument()
+    const brief = planned.imageBriefs[0]!
+    expect(
+      buildRecipeGuidanceGenerationRequest(planned, brief.id, "hans", "2026-07-31T08:08:00.000Z")
+    ).toBeNull()
+
+    const approved = reviewRecipeImageBrief(planned, {
+      update: { action: "approve", briefId: brief.id },
+      reviewerUserId: "hans",
+      now: "2026-07-31T08:07:00.000Z",
+    })!
+    const withReviewMedia = {
+      ...approved,
+      mediaAssets: approved.mediaAssets.map((asset) =>
+        asset.imageBriefId === brief.id ? { ...asset, status: "review_required" as const } : asset
+      ),
+    }
+    expect(
+      buildRecipeGuidanceGenerationRequest(
+        withReviewMedia,
+        brief.id,
+        "hans",
+        "2026-07-31T08:08:00.000Z"
+      )
+    ).toBeNull()
+  })
+})

--- a/tests/lib/recipe-guidance-media.test.ts
+++ b/tests/lib/recipe-guidance-media.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 import { buildRecipeGuidanceDraft } from "@/lib/recipe-guidance-builder"
-import { attachRecipeGuidanceUpload, planRecipeGuidanceMedia } from "@/lib/recipe-guidance-media"
+import {
+  attachRecipeGuidanceUpload,
+  planRecipeGuidanceMedia,
+  reviewRecipeImageBrief,
+} from "@/lib/recipe-guidance-media"
 import type { RecipeRecord } from "@/lib/recipes"
 
 const recipe: RecipeRecord = {
@@ -179,5 +183,73 @@ describe("recipe guidance media planning", () => {
         now: "2026-07-31T08:07:00.000Z",
       })
     ).toBeNull()
+  })
+
+  it("edits, approves, and rejects image briefs with server-owned review evidence", () => {
+    const planned = planRecipeGuidanceMedia(draft, recipe, "2026-07-31T08:06:00.000Z")!.document
+    const brief = planned.imageBriefs[0]!
+    const edited = reviewRecipeImageBrief(planned, {
+      update: {
+        action: "edit",
+        briefId: brief.id,
+        description: { en: "Reviewed English brief", af: "Nagegane Afrikaanse opdrag" },
+        reviewedFacts: ["Canonical ingredient: carrots"],
+        excludedContent: ["No text overlays"],
+      },
+      reviewerUserId: "ignored-for-edit",
+      now: "2026-07-31T08:07:00.000Z",
+    })!
+    expect(edited.imageBriefs[0]).toMatchObject({
+      status: "draft",
+      description: { en: "Reviewed English brief", af: "Nagegane Afrikaanse opdrag" },
+    })
+
+    const approved = reviewRecipeImageBrief(edited, {
+      update: { action: "approve", briefId: brief.id },
+      reviewerUserId: "hans",
+      now: "2026-07-31T08:08:00.000Z",
+    })!
+    expect(approved.imageBriefs[0]).toMatchObject({
+      status: "approved",
+      approvedBy: "hans",
+      approvedAt: "2026-07-31T08:08:00.000Z",
+    })
+    expect(
+      reviewRecipeImageBrief(approved, {
+        update: { action: "approve", briefId: brief.id },
+        reviewerUserId: "hans",
+        now: "2026-07-31T08:09:00.000Z",
+      })
+    ).toBeNull()
+
+    const ungrounded = reviewRecipeImageBrief(planned, {
+      update: {
+        action: "edit",
+        briefId: brief.id,
+        description: brief.description,
+        reviewedFacts: [],
+        excludedContent: [],
+      },
+      reviewerUserId: "hans",
+      now: "2026-07-31T08:07:00.000Z",
+    })!
+    expect(
+      reviewRecipeImageBrief(ungrounded, {
+        update: { action: "approve", briefId: brief.id },
+        reviewerUserId: "hans",
+        now: "2026-07-31T08:08:00.000Z",
+      })
+    ).toBeNull()
+
+    const rejected = reviewRecipeImageBrief(edited, {
+      update: { action: "reject", briefId: brief.id, rejectionReason: "Unsafe composition" },
+      reviewerUserId: "hans",
+      now: "2026-07-31T08:08:00.000Z",
+    })!
+    expect(rejected.imageBriefs[0]).toMatchObject({
+      status: "rejected",
+      rejectedBy: "hans",
+      rejectionReason: "Unsafe composition",
+    })
   })
 })

--- a/tests/lib/recipe-guidance.test.ts
+++ b/tests/lib/recipe-guidance.test.ts
@@ -132,6 +132,43 @@ describe("recipe guidance contracts", () => {
     expect(result.success).toBe(true)
   })
 
+  it("rejects approved image briefs without grounded facts and exclusions", () => {
+    const approvedBrief = {
+      id: "brief-1",
+      sectionId: "section:cooking",
+      role: "step",
+      status: "approved",
+      description: {
+        en: "Show the reviewed visual state after browning.",
+        af: "Wys die hersiene visuele toestand na verbruining.",
+      },
+      approvedBy: "hans",
+      approvedAt: now,
+    } as const
+
+    expect(
+      recipeImageBriefSchema.safeParse({
+        ...approvedBrief,
+        reviewedFacts: [],
+        excludedContent: ["No text overlays"],
+      }).success
+    ).toBe(false)
+    expect(
+      recipeImageBriefSchema.safeParse({
+        ...approvedBrief,
+        reviewedFacts: ["Canonical ingredient: rice"],
+        excludedContent: [],
+      }).success
+    ).toBe(false)
+    expect(
+      recipeImageBriefSchema.safeParse({
+        ...approvedBrief,
+        reviewedFacts: ["Canonical ingredient: rice"],
+        excludedContent: ["No text overlays"],
+      }).success
+    ).toBe(true)
+  })
+
   it("requires bilingual alt text and review metadata before approval", () => {
     const result = recipeMediaAssetSchema.safeParse({
       id: "asset-1",
@@ -375,6 +412,8 @@ describe("recipe guidance contracts", () => {
       role: "hero",
       status: "approved",
       description: { en: "Finished dish.", af: "Voltooide gereg." },
+      reviewedFacts: ["Canonical serving state"],
+      excludedContent: ["No text overlays"],
       approvedBy: "hans",
       approvedAt: now,
     }


### PR DESCRIPTION
## Summary
- add CAS-protected human editing plus explicit approval/rejection for bilingual recipe image briefs
- add an admin-only provider-neutral request contract that always returns execution disabled and never persists or changes media state
- expose the workflow in Hans Recipes with grounded-fact/exclusion gates, focused tests, architecture notes, and a durable handoff

## Verification
- `pnpm test -- tests/lib/recipe-guidance-generation.test.ts tests/lib/recipe-guidance-media.test.ts tests/lib/recipe-guidance.test.ts tests/api/recipe-guidance.test.ts tests/components/recipe-guidance-ui.test.tsx` (5 files, 78 tests)
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build` (125 static pages; new route emitted)
- focused Prettier check
- `git diff --cached --check`
- visible local Chromium replay with synthetic E2E-only Hans session and fixture-intercepted APIs; zero final console errors/warnings

## Boundaries
No Sluice/provider call, image generation, request persistence, media-status transition, direct-provider fallback, public package, OmniPost action, migration apply, deployment, production-data mutation, auth/secret change, or demo-data enablement.

## Baton
`06df7efb-d396-4cfa-81f0-1a5b193f0759`