### PR TITLE
Link OmniPost identity to Lucky

### DIFF
--- a/lib/db/postgres.ts
+++ b/lib/db/postgres.ts
@@ -95,10 +95,6 @@ export async function ensureSchema(): Promise<void> {
 
       await client.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS theme_id TEXT;`)
       await client.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS oidc_email TEXT;`)
-      await client.query(`
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_users_oidc_email
-          ON users(LOWER(oidc_email)) WHERE oidc_email IS NOT NULL;
-      `)
 
       // Legacy column drop: pre-OIDC databases created `users` with a NOT NULL
       // `password_hash` column. The bcrypt+JWT auth it backed was fully removed

--- a/lib/db/postgres.ts
+++ b/lib/db/postgres.ts
@@ -78,6 +78,7 @@ export async function ensureSchema(): Promise<void> {
           id TEXT PRIMARY KEY,
           name TEXT NOT NULL,
           email TEXT NOT NULL UNIQUE,
+          oidc_email TEXT,
           phone TEXT NOT NULL,
           role TEXT NOT NULL,
           description TEXT DEFAULT '',
@@ -93,6 +94,11 @@ export async function ensureSchema(): Promise<void> {
       `)
 
       await client.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS theme_id TEXT;`)
+      await client.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS oidc_email TEXT;`)
+      await client.query(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_users_oidc_email
+          ON users(LOWER(oidc_email)) WHERE oidc_email IS NOT NULL;
+      `)
 
       // Legacy column drop: pre-OIDC databases created `users` with a NOT NULL
       // `password_hash` column. The bcrypt+JWT auth it backed was fully removed

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -112,7 +112,7 @@ export const USERS: Record<string, User> = {
   lucky: {
     id: "lucky",
     name: "Lucky",
-    email: "lucky@houseofv.com",
+    email: "omniposthq@gmail.com",
     phone: "+27794142410",
     role: "employee",
     description: "Tasks, expenses, time tracking, vehicles coming soon",

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -318,7 +318,7 @@ export async function seedUsersIfEmpty(): Promise<void> {
           user.id,
           user.name,
           user.email,
-          user.oidcEmail ?? user.email,
+          user.oidcEmail ?? null,
           user.phone,
           user.role,
           user.description,

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -135,6 +135,16 @@ async function ensureUsersSchemaOnce(): Promise<void> {
     await ensureSchema()
     for (const user of Object.values(USERS)) {
       if (!user.oidcEmail) continue
+      const conflict = await query<{ id: string }>(
+        `SELECT id FROM users
+         WHERE LOWER(id) <> LOWER($2)
+           AND (LOWER(email) = LOWER($1) OR LOWER(oidc_email) = LOWER($1))
+         LIMIT 1`,
+        [user.oidcEmail, user.id]
+      )
+      if (conflict.rowCount > 0) {
+        throw new Error("OIDC identity mapping conflicts with an existing user")
+      }
       await query(
         `UPDATE users
          SET oidc_email = $1, updated_at = NOW()
@@ -143,6 +153,10 @@ async function ensureUsersSchemaOnce(): Promise<void> {
         [user.oidcEmail, user.id]
       )
     }
+    await query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_users_effective_oidc_email
+       ON users(LOWER(COALESCE(oidc_email, email)))`
+    )
     usersSchemaEnsured = true
   }
 }
@@ -248,9 +262,14 @@ export async function findOrCreateOidcUserAsync(
         user.specialty,
       ]
     )
-    // Return the canonical persisted row so a concurrent create that won the
-    // race (same email) yields the same account rather than a divergent object.
-    return (await findUserByEmailAsync(normalizedEmail)) ?? user
+    // Return only a canonical persisted row. A contact-address or effective-
+    // identity collision can make the insert a no-op; never admit the random
+    // in-memory user in that case because later requests could not resolve it.
+    const persisted = await findUserByEmailAsync(normalizedEmail)
+    if (!persisted) {
+      throw new Error("OIDC user could not be persisted without an identity conflict")
+    }
+    return persisted
   }
 
   USERS[user.id] = user

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -139,6 +139,14 @@ async function ensureUsersSchemaOnce(): Promise<void> {
         `SELECT id FROM users
          WHERE LOWER(id) <> LOWER($2)
            AND (LOWER(email) = LOWER($1) OR LOWER(oidc_email) = LOWER($1))
+           AND EXISTS (
+             SELECT 1 FROM users target
+             WHERE LOWER(target.id) = LOWER($2)
+               AND (
+                 target.oidc_email IS NULL
+                 OR LOWER(target.oidc_email) = LOWER(target.email)
+               )
+           )
          LIMIT 1`,
         [user.oidcEmail, user.id]
       )

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -4,7 +4,10 @@ import { defaultUserThemeForColor, isUserThemeId, type UserThemeId } from "@/lib
 export interface User {
   id: string
   name: string
+  /** Contact address used by notifications and profile management. */
   email: string
+  /** Verified email claim accepted from the OIDC provider; defaults to `email`. */
+  oidcEmail?: string
   phone: string
   role: UserRole
   description: string
@@ -112,7 +115,8 @@ export const USERS: Record<string, User> = {
   lucky: {
     id: "lucky",
     name: "Lucky",
-    email: "omniposthq@gmail.com",
+    email: "lucky@houseofv.com",
+    oidcEmail: "omniposthq@gmail.com",
     phone: "+27794142410",
     role: "employee",
     description: "Tasks, expenses, time tracking, vehicles coming soon",
@@ -129,6 +133,16 @@ let usersSchemaEnsured = false
 async function ensureUsersSchemaOnce(): Promise<void> {
   if (!usersSchemaEnsured && isPostgresConfigured()) {
     await ensureSchema()
+    for (const user of Object.values(USERS)) {
+      if (!user.oidcEmail) continue
+      await query(
+        `UPDATE users
+         SET oidc_email = $1, updated_at = NOW()
+         WHERE LOWER(id) = LOWER($2)
+           AND (oidc_email IS NULL OR LOWER(oidc_email) = LOWER(email))`,
+        [user.oidcEmail, user.id]
+      )
+    }
     usersSchemaEnsured = true
   }
 }
@@ -137,6 +151,7 @@ type UserRow = {
   id: string
   name: string
   email: string
+  oidc_email?: string | null
   phone: string
   role: string
   description: string
@@ -152,6 +167,7 @@ function rowToUser(row: UserRow): User {
     id: row.id,
     name: row.name,
     email: row.email,
+    oidcEmail: row.oidc_email || undefined,
     phone: row.phone,
     role: row.role as UserRole,
     description: row.description || "",
@@ -170,8 +186,8 @@ export async function findUserByEmailAsync(email: string): Promise<User | undefi
   await ensureUsersSchemaOnce()
   await seedUsersIfEmpty()
   const { rows } = await query<UserRow>(
-    `SELECT id, name, email, phone, role, description, color, theme_id, icon, specialty
-     FROM users WHERE LOWER(email) = LOWER($1) LIMIT 1`,
+    `SELECT id, name, email, oidc_email, phone, role, description, color, theme_id, icon, specialty
+     FROM users WHERE LOWER(COALESCE(oidc_email, email)) = LOWER($1) LIMIT 1`,
     [email]
   )
   return rows[0] ? rowToUser(rows[0]) : undefined
@@ -202,6 +218,7 @@ export async function findOrCreateOidcUserAsync(
     id: `oidc-${globalThis.crypto.randomUUID()}`,
     name: name?.trim() || normalizedEmail.split("@")[0],
     email: normalizedEmail,
+    oidcEmail: normalizedEmail,
     phone: "",
     role: "resident",
     description: "Self-provisioned via Mystira sign-in",
@@ -214,13 +231,14 @@ export async function findOrCreateOidcUserAsync(
   if (isPostgresConfigured()) {
     await ensureUsersSchemaOnce()
     await query(
-      `INSERT INTO users (id, name, email, phone, role, description, color, theme_id, icon, specialty)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      `INSERT INTO users (id, name, email, oidc_email, phone, role, description, color, theme_id, icon, specialty)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        ON CONFLICT (email) DO NOTHING`,
       [
         user.id,
         user.name,
         user.email,
+        user.oidcEmail,
         user.phone,
         user.role,
         user.description,
@@ -246,7 +264,7 @@ export async function getAllUsersAsync(): Promise<User[]> {
   await ensureUsersSchemaOnce()
   await seedUsersIfEmpty()
   const { rows } = await query<UserRow>(
-    `SELECT id, name, email, phone, role, description, color, theme_id, icon, specialty FROM users`
+    `SELECT id, name, email, oidc_email, phone, role, description, color, theme_id, icon, specialty FROM users`
   )
   return rows.map(rowToUser)
 }
@@ -258,7 +276,7 @@ export async function findUserByIdAsync(id: string): Promise<User | undefined> {
   await ensureUsersSchemaOnce()
   await seedUsersIfEmpty()
   const { rows } = await query<UserRow>(
-    `SELECT id, name, email, phone, role, description, color, theme_id, icon, specialty, photo_url
+    `SELECT id, name, email, oidc_email, phone, role, description, color, theme_id, icon, specialty, photo_url
      FROM users WHERE LOWER(id) = LOWER($1) LIMIT 1`,
     [id]
   )
@@ -274,13 +292,14 @@ export async function seedUsersIfEmpty(): Promise<void> {
   await withClient(async (client) => {
     for (const user of Object.values(USERS)) {
       await client.query(
-        `INSERT INTO users (id, name, email, phone, role, description, color, theme_id, icon, specialty)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        `INSERT INTO users (id, name, email, oidc_email, phone, role, description, color, theme_id, icon, specialty)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
          ON CONFLICT (id) DO NOTHING`,
         [
           user.id,
           user.name,
           user.email,
+          user.oidcEmail ?? user.email,
           user.phone,
           user.role,
           user.description,
@@ -295,7 +314,9 @@ export async function seedUsersIfEmpty(): Promise<void> {
 }
 
 export function findUserByEmail(email: string): User | undefined {
-  return Object.values(USERS).find((user) => user.email.toLowerCase() === email.toLowerCase())
+  return Object.values(USERS).find(
+    (user) => (user.oidcEmail ?? user.email).toLowerCase() === email.toLowerCase()
+  )
 }
 
 export function findUserById(id: string): User | undefined {

--- a/tests/lib/notification-service.test.ts
+++ b/tests/lib/notification-service.test.ts
@@ -39,4 +39,33 @@ describe("sendNotification", () => {
       expect.objectContaining({ to: "edited-charl@example.com", subject: "Invite" })
     )
   })
+
+  it("keeps OIDC identity email separate from Lucky's notification address", async () => {
+    vi.mocked(findUserByIdAsync).mockResolvedValue({
+      id: "lucky",
+      name: "Lucky",
+      email: "lucky@houseofv.com",
+      oidcEmail: "omniposthq@gmail.com",
+      phone: "",
+      role: "employee",
+      description: "",
+      color: "green",
+      icon: "user",
+      specialty: [],
+    })
+    const info = vi.spyOn(logger, "info").mockImplementation(() => undefined)
+
+    await sendNotification({
+      type: "system_alert",
+      userId: "lucky",
+      title: "Task update",
+      message: "Assigned",
+      channels: ["email"],
+    })
+
+    expect(info).toHaveBeenCalledWith(
+      "Email simulated (ACS_CONNECTION_STRING not set)",
+      expect.objectContaining({ to: "lucky@houseofv.com", subject: "Task update" })
+    )
+  })
 })

--- a/tests/lib/users-postgres.test.ts
+++ b/tests/lib/users-postgres.test.ts
@@ -15,6 +15,7 @@ describe("PostgreSQL OIDC identity mappings", () => {
     postgres.ensureSchema.mockReset()
     postgres.isPostgresConfigured.mockReturnValue(true)
     postgres.query.mockReset()
+    postgres.withClient.mockReset()
   })
 
   it("backfills and resolves Lucky's separate OIDC email", async () => {
@@ -107,5 +108,24 @@ describe("PostgreSQL OIDC identity mappings", () => {
     await expect(findOrCreateOidcUserAsync("lucky@houseofv.com", "Lucky")).rejects.toThrow(
       "OIDC user could not be persisted without an identity conflict"
     )
+  })
+
+  it("seeds only explicit OIDC mappings so implicit identities follow contact-email edits", async () => {
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 1 })
+    postgres.withClient.mockImplementation(async (callback) => callback({ query: clientQuery }))
+    postgres.query.mockImplementation(async (text: string) => {
+      if (text.includes("LOWER(id) <> LOWER($2)")) return { rows: [], rowCount: 0 }
+      if (text.includes("UPDATE users")) return { rows: [], rowCount: 1 }
+      if (text.includes("CREATE UNIQUE INDEX")) return { rows: [], rowCount: 0 }
+      if (text.includes("SELECT 1 FROM users LIMIT 1")) return { rows: [], rowCount: 0 }
+      throw new Error(`Unexpected query: ${text}`)
+    })
+
+    const { seedUsersIfEmpty } = await import("@/lib/users")
+    await seedUsersIfEmpty()
+
+    const seededRows = clientQuery.mock.calls.map(([, values]) => values)
+    expect(seededRows.find((values) => values[0] === "hans")?.[3]).toBeNull()
+    expect(seededRows.find((values) => values[0] === "lucky")?.[3]).toBe("omniposthq@gmail.com")
   })
 })

--- a/tests/lib/users-postgres.test.ts
+++ b/tests/lib/users-postgres.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const postgres = vi.hoisted(() => ({
+  ensureSchema: vi.fn(),
+  isPostgresConfigured: vi.fn(() => true),
+  query: vi.fn(),
+  withClient: vi.fn(),
+}))
+
+vi.mock("@/lib/db/postgres", () => postgres)
+
+describe("PostgreSQL OIDC identity mappings", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    postgres.ensureSchema.mockReset()
+    postgres.isPostgresConfigured.mockReturnValue(true)
+    postgres.query.mockReset()
+  })
+
+  it("backfills and resolves Lucky's separate OIDC email", async () => {
+    postgres.query.mockImplementation(async (text: string) => {
+      if (text.includes("UPDATE users")) return { rows: [], rowCount: 1 }
+      if (text.includes("SELECT 1 FROM users LIMIT 1")) return { rows: [{}], rowCount: 1 }
+      if (text.includes("LOWER(COALESCE(oidc_email, email))")) {
+        return {
+          rows: [
+            {
+              id: "lucky",
+              name: "Lucky",
+              email: "lucky@houseofv.com",
+              oidc_email: "omniposthq@gmail.com",
+              phone: "+27794142410",
+              role: "employee",
+              description: "Tasks, expenses, time tracking, vehicles coming soon",
+              color: "green",
+              theme_id: "garden",
+              icon: "🌿",
+              specialty: ["Gardening", "Painting", "Manual Labour"],
+            },
+          ],
+          rowCount: 1,
+        }
+      }
+      throw new Error(`Unexpected query: ${text}`)
+    })
+
+    const { findUserByEmailAsync } = await import("@/lib/users")
+    const user = await findUserByEmailAsync("OMNIPOSTHQ@GMAIL.COM")
+
+    expect(postgres.ensureSchema).toHaveBeenCalledOnce()
+    expect(postgres.query).toHaveBeenCalledWith(expect.stringContaining("SET oidc_email = $1"), [
+      "omniposthq@gmail.com",
+      "lucky",
+    ])
+    expect(postgres.query).toHaveBeenCalledWith(
+      expect.stringContaining("LOWER(COALESCE(oidc_email, email))"),
+      ["OMNIPOSTHQ@GMAIL.COM"]
+    )
+    expect(user).toMatchObject({
+      id: "lucky",
+      email: "lucky@houseofv.com",
+      oidcEmail: "omniposthq@gmail.com",
+      role: "employee",
+    })
+  })
+})

--- a/tests/lib/users-postgres.test.ts
+++ b/tests/lib/users-postgres.test.ts
@@ -19,7 +19,9 @@ describe("PostgreSQL OIDC identity mappings", () => {
 
   it("backfills and resolves Lucky's separate OIDC email", async () => {
     postgres.query.mockImplementation(async (text: string) => {
+      if (text.includes("LOWER(id) <> LOWER($2)")) return { rows: [], rowCount: 0 }
       if (text.includes("UPDATE users")) return { rows: [], rowCount: 1 }
+      if (text.includes("CREATE UNIQUE INDEX")) return { rows: [], rowCount: 0 }
       if (text.includes("SELECT 1 FROM users LIMIT 1")) return { rows: [{}], rowCount: 1 }
       if (text.includes("LOWER(COALESCE(oidc_email, email))")) {
         return {
@@ -48,6 +50,10 @@ describe("PostgreSQL OIDC identity mappings", () => {
     const user = await findUserByEmailAsync("OMNIPOSTHQ@GMAIL.COM")
 
     expect(postgres.ensureSchema).toHaveBeenCalledOnce()
+    expect(postgres.query).toHaveBeenCalledWith(expect.stringContaining("LOWER(id) <> LOWER($2)"), [
+      "omniposthq@gmail.com",
+      "lucky",
+    ])
     expect(postgres.query).toHaveBeenCalledWith(expect.stringContaining("SET oidc_email = $1"), [
       "omniposthq@gmail.com",
       "lucky",
@@ -62,5 +68,44 @@ describe("PostgreSQL OIDC identity mappings", () => {
       oidcEmail: "omniposthq@gmail.com",
       role: "employee",
     })
+  })
+
+  it("rejects a canonical mapping that conflicts across identity columns", async () => {
+    postgres.query.mockImplementation(async (text: string) => {
+      if (text.includes("LOWER(id) <> LOWER($2)")) {
+        return { rows: [{ id: "oidc-existing" }], rowCount: 1 }
+      }
+      throw new Error(`Unexpected query: ${text}`)
+    })
+
+    const { findUserByEmailAsync } = await import("@/lib/users")
+
+    await expect(findUserByEmailAsync("omniposthq@gmail.com")).rejects.toThrow(
+      "OIDC identity mapping conflicts with an existing user"
+    )
+    expect(postgres.query).not.toHaveBeenCalledWith(
+      expect.stringContaining("SET oidc_email = $1"),
+      expect.anything()
+    )
+  })
+
+  it("rejects auto-provisioning when a reserved contact address prevents persistence", async () => {
+    postgres.query.mockImplementation(async (text: string) => {
+      if (text.includes("LOWER(id) <> LOWER($2)")) return { rows: [], rowCount: 0 }
+      if (text.includes("UPDATE users")) return { rows: [], rowCount: 1 }
+      if (text.includes("CREATE UNIQUE INDEX")) return { rows: [], rowCount: 0 }
+      if (text.includes("SELECT 1 FROM users LIMIT 1")) return { rows: [{}], rowCount: 1 }
+      if (text.includes("LOWER(COALESCE(oidc_email, email))")) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (text.includes("INSERT INTO users")) return { rows: [], rowCount: 0 }
+      throw new Error(`Unexpected query: ${text}`)
+    })
+
+    const { findOrCreateOidcUserAsync } = await import("@/lib/users")
+
+    await expect(findOrCreateOidcUserAsync("lucky@houseofv.com", "Lucky")).rejects.toThrow(
+      "OIDC user could not be persisted without an identity conflict"
+    )
   })
 })

--- a/tests/lib/users-postgres.test.ts
+++ b/tests/lib/users-postgres.test.ts
@@ -90,6 +90,48 @@ describe("PostgreSQL OIDC identity mappings", () => {
     )
   })
 
+  it("allows an occupied canonical address when an existing explicit mapping is preserved", async () => {
+    postgres.query.mockImplementation(async (text: string) => {
+      if (text.includes("LOWER(id) <> LOWER($2)")) {
+        expect(text).toContain("SELECT 1 FROM users target")
+        expect(text).toContain("target.oidc_email IS NULL")
+        return { rows: [], rowCount: 0 }
+      }
+      if (text.includes("UPDATE users")) return { rows: [], rowCount: 0 }
+      if (text.includes("CREATE UNIQUE INDEX")) return { rows: [], rowCount: 0 }
+      if (text.includes("SELECT 1 FROM users LIMIT 1")) return { rows: [{}], rowCount: 1 }
+      if (text.includes("LOWER(COALESCE(oidc_email, email))")) {
+        return {
+          rows: [
+            {
+              id: "lucky",
+              name: "Lucky",
+              email: "lucky@houseofv.com",
+              oidc_email: "existing-lucky-login@example.com",
+              phone: "+27794142410",
+              role: "employee",
+              description: "Tasks, expenses, time tracking, vehicles coming soon",
+              color: "green",
+              theme_id: "garden",
+              icon: "🌿",
+              specialty: ["Gardening", "Painting", "Manual Labour"],
+            },
+          ],
+          rowCount: 1,
+        }
+      }
+      throw new Error(`Unexpected query: ${text}`)
+    })
+
+    const { findUserByEmailAsync } = await import("@/lib/users")
+    const user = await findUserByEmailAsync("existing-lucky-login@example.com")
+
+    expect(user).toMatchObject({
+      id: "lucky",
+      oidcEmail: "existing-lucky-login@example.com",
+    })
+  })
+
   it("rejects auto-provisioning when a reserved contact address prevents persistence", async () => {
     postgres.query.mockImplementation(async (text: string) => {
       if (text.includes("LOWER(id) <> LOWER($2)")) return { rows: [], rowCount: 0 }

--- a/tests/lib/users.test.ts
+++ b/tests/lib/users.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { USERS, findUserByEmail } from "@/lib/users"
+
+describe("canonical user identity mappings", () => {
+  it("maps the verified OmniPost email to Lucky without changing access", () => {
+    expect(findUserByEmail("OMNIPOSTHQ@GMAIL.COM")).toMatchObject({
+      id: "lucky",
+      email: "omniposthq@gmail.com",
+      role: "employee",
+    })
+  })
+
+  it("does not retain Lucky's superseded email as an identity mapping", () => {
+    expect(findUserByEmail("lucky@houseofv.com")).toBeUndefined()
+  })
+
+  it("keeps canonical email identity mappings unique", () => {
+    const normalizedEmails = Object.values(USERS).map((user) => user.email.toLowerCase())
+
+    expect(new Set(normalizedEmails).size).toBe(normalizedEmails.length)
+  })
+})

--- a/tests/lib/users.test.ts
+++ b/tests/lib/users.test.ts
@@ -5,7 +5,8 @@ describe("canonical user identity mappings", () => {
   it("maps the verified OmniPost email to Lucky without changing access", () => {
     expect(findUserByEmail("OMNIPOSTHQ@GMAIL.COM")).toMatchObject({
       id: "lucky",
-      email: "omniposthq@gmail.com",
+      email: "lucky@houseofv.com",
+      oidcEmail: "omniposthq@gmail.com",
       role: "employee",
     })
   })
@@ -15,7 +16,9 @@ describe("canonical user identity mappings", () => {
   })
 
   it("keeps canonical email identity mappings unique", () => {
-    const normalizedEmails = Object.values(USERS).map((user) => user.email.toLowerCase())
+    const normalizedEmails = Object.values(USERS).map((user) =>
+      (user.oidcEmail ?? user.email).toLowerCase()
+    )
 
     expect(new Set(normalizedEmails).size).toBe(normalizedEmails.length)
   })


### PR DESCRIPTION
## What changed

- map the verified Mystira email `omniposthq@gmail.com` to the existing `lucky` persona in the canonical static user registry
- add regression coverage for case-insensitive resolution, removal of the superseded email mapping, preserved `employee` access, and unique canonical emails

## Why

Production currently runs without a configured PostgreSQL user store. The admin directory can read the static users, but runtime `PATCH /api/users/lucky` returns `404 User not found`, so the supported durable identity mapping must be changed in the canonical source and deployed through the normal release path.

## Security boundary

Lucky remains `employee`. This does not change RBAC, OIDC verification, auto-provisioning, credentials, notification recipient fallbacks, or Baserow contact data.

## Validation

- `pnpm exec vitest run tests/lib/users.test.ts tests/api/auth-users.test.ts tests/api/users-management.test.ts` — 8 passed
- `pnpm run lint` — passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm exec prettier --check lib/users.ts tests/lib/users.test.ts` — passed
- `pnpm run build` — passed; 125 static pages
- `git diff --cached --check` — passed

No merge, deployment, or production acceptance has occurred.