### PR TITLE
feat(auth): host Identity authorization on HOV domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,12 @@
 # secrets in this file.
 # Dev issuer: https://mys-dev-id-webapi.azurewebsites.net
 # MYSTIRA_OIDC_ISSUER=https://mys-dev-id-webapi.azurewebsites.net
-# Browser-facing Identity authorization host. Production uses the isolated HOV
+# Browser-facing Identity authorization endpoint. Production uses the isolated HOV
 # login subdomain; discovery, JWKS, and token exchange still use the issuer above.
 # MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT=https://login.hov.neuralliquid.ai/connect/authorize
+# Browser-facing logout endpoint must use the same host so Identity receives and
+# clears its host-only session cookie.
+# MYSTIRA_OIDC_END_SESSION_ENDPOINT=https://login.hov.neuralliquid.ai/connect/endsession
 # MYSTIRA_OIDC_CLIENT_ID=neuralliquid-hov-web
 # MYSTIRA_OIDC_CLIENT_SECRET=
 

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@
 # secrets in this file.
 # Dev issuer: https://mys-dev-id-webapi.azurewebsites.net
 # MYSTIRA_OIDC_ISSUER=https://mys-dev-id-webapi.azurewebsites.net
+# Browser-facing Identity authorization host. Production uses the isolated HOV
+# login subdomain; discovery, JWKS, and token exchange still use the issuer above.
+# MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT=https://login.hov.neuralliquid.ai/connect/authorize
 # MYSTIRA_OIDC_CLIENT_ID=neuralliquid-hov-web
 # MYSTIRA_OIDC_CLIENT_SECRET=
 

--- a/app/api/auth/federated-logout/route.ts
+++ b/app/api/auth/federated-logout/route.ts
@@ -3,7 +3,7 @@ import { getToken } from "next-auth/jwt"
 import { logger } from "@/lib/logger"
 import { buildEndSessionUrl, resolveEndSessionEndpoint } from "@/lib/auth/federated-logout"
 
-const issuer = process.env.MYSTIRA_OIDC_ISSUER ?? "http://localhost:5262"
+const issuer = process.env.MYSTIRA_OIDC_ISSUER?.trim() || "http://localhost:5262"
 
 /**
  * Returns the Mystira RP-initiated-logout URL for the current session so the

--- a/app/api/auth/federated-logout/route.ts
+++ b/app/api/auth/federated-logout/route.ts
@@ -38,7 +38,10 @@ export async function GET(request: NextRequest) {
     const postLogoutRedirectUri =
       process.env.MYSTIRA_OIDC_POST_LOGOUT_REDIRECT_URI ?? new URL(base).origin
 
-    const endSessionEndpoint = await resolveEndSessionEndpoint(issuer)
+    const endSessionEndpoint = await resolveEndSessionEndpoint(
+      issuer,
+      process.env.MYSTIRA_OIDC_END_SESSION_ENDPOINT?.trim()
+    )
     const url = buildEndSessionUrl({ endSessionEndpoint, idToken, postLogoutRedirectUri })
     return NextResponse.json({ url })
   } catch (err) {

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -5,11 +5,46 @@ import type { UserRole } from "@/lib/users"
 // the OIDC handshake will fail loudly at first sign-in if these are missing
 // or wrong — we don't throw at module-load so `next build` page-data
 // collection doesn't fail when envs aren't injected at build time.
-const mystiraIssuer = process.env.MYSTIRA_OIDC_ISSUER ?? "http://localhost:5262"
+const defaultMystiraIssuer = "http://localhost:5262"
+const mystiraIssuer = process.env.MYSTIRA_OIDC_ISSUER?.trim() || defaultMystiraIssuer
 const configuredMystiraAuthorizationEndpoint =
   process.env.MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT?.trim()
-const mystiraAuthorizationEndpoint =
-  configuredMystiraAuthorizationEndpoint || new URL("/connect/authorize", mystiraIssuer).toString()
+
+function resolveMystiraAuthorizationEndpoint(
+  configured: string | undefined,
+  issuer: string
+): string {
+  if (configured) {
+    try {
+      const endpoint = new URL(configured)
+      if (
+        endpoint.protocol === "https:" &&
+        endpoint.username === "" &&
+        endpoint.password === "" &&
+        endpoint.pathname === "/connect/authorize" &&
+        endpoint.search === "" &&
+        endpoint.hash === ""
+      ) {
+        return endpoint.toString()
+      }
+    } catch {
+      // Fall through to the canonical issuer endpoint.
+    }
+  }
+
+  try {
+    return new URL("/connect/authorize", issuer).toString()
+  } catch {
+    // Preserve module-load safety for a malformed issuer. The issuer itself is
+    // left unchanged so discovery still fails loudly when sign-in is attempted.
+    return `${defaultMystiraIssuer}/connect/authorize`
+  }
+}
+
+const mystiraAuthorizationEndpoint = resolveMystiraAuthorizationEndpoint(
+  configuredMystiraAuthorizationEndpoint,
+  mystiraIssuer
+)
 const mystiraClientId = process.env.MYSTIRA_OIDC_CLIENT_ID ?? "neuralliquid-hov-web"
 const mystiraClientSecret =
   process.env.MYSTIRA_OIDC_CLIENT_SECRET ?? "hov-dev-secret-change-in-staging"

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -6,6 +6,10 @@ import type { UserRole } from "@/lib/users"
 // or wrong — we don't throw at module-load so `next build` page-data
 // collection doesn't fail when envs aren't injected at build time.
 const mystiraIssuer = process.env.MYSTIRA_OIDC_ISSUER ?? "http://localhost:5262"
+const configuredMystiraAuthorizationEndpoint =
+  process.env.MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT?.trim()
+const mystiraAuthorizationEndpoint =
+  configuredMystiraAuthorizationEndpoint || new URL("/connect/authorize", mystiraIssuer).toString()
 const mystiraClientId = process.env.MYSTIRA_OIDC_CLIENT_ID ?? "neuralliquid-hov-web"
 const mystiraClientSecret =
   process.env.MYSTIRA_OIDC_CLIENT_SECRET ?? "hov-dev-secret-change-in-staging"
@@ -19,7 +23,14 @@ export default {
       issuer: mystiraIssuer,
       clientId: mystiraClientId,
       clientSecret: mystiraClientSecret,
-      authorization: { params: { scope: "openid profile email offline_access" } },
+      // The browser-facing authorization endpoint may use an HOV-owned custom
+      // hostname while discovery, JWKS, token exchange, and token issuer remain
+      // anchored to Mystira Identity. Keeping these settings separate preserves
+      // the RP/OP trust boundary without exposing a Mystira-branded browser hop.
+      authorization: {
+        url: mystiraAuthorizationEndpoint,
+        params: { scope: "openid profile email offline_access" },
+      },
       checks: ["pkce", "state"],
     },
   ],

--- a/docs/handoffs/2026-08-02-hov-native-auth-domain.md
+++ b/docs/handoffs/2026-08-02-hov-native-auth-domain.md
@@ -15,10 +15,12 @@ Deployment order:
 
 1. Apply the `neuralliquid-org` DNS change for the `login.hov` CNAME and
    `asuid.login.hov` TXT record.
-2. Apply the `mystira-workspace` Identity hostname, managed certificate, and SNI
-   bindings; verify HTTPS and the authorization route on the new hostname.
-3. Deploy this HOV change.
-4. Complete a legitimate HOV magic-link sign-in and verify the callback returns
+2. Run and apply Mystira's separate `terraform-entra-external-id` dev workflow
+   so Microsoft can return to the new Identity hostname.
+3. Apply the `mystira-workspace` Identity hostname, managed certificate, and SNI
+   bindings; verify HTTPS, authorization, and end-session routes on the hostname.
+4. Deploy this HOV change.
+5. Complete a legitimate HOV magic-link sign-in and verify the callback returns
    to HOV with an authenticated session.
 
 CI, health probes, and Terraform plans do not constitute authenticated user

--- a/docs/handoffs/2026-08-02-hov-native-auth-domain.md
+++ b/docs/handoffs/2026-08-02-hov-native-auth-domain.md
@@ -1,0 +1,25 @@
+# HOV native authentication domain
+
+Status: prepared, not deployed
+
+House of Veritas now supports a separate browser-facing OIDC authorization
+endpoint. Production is configured for
+`https://login.hov.neuralliquid.ai/connect/authorize` while the issuer,
+discovery, JWKS, and token endpoint remain canonical Mystira Identity.
+
+This hostname is intentionally separate from `hov.neuralliquid.ai`. Binding
+Identity directly to the isolated login hostname keeps Identity's host-only
+session cookie away from the HOV relying-party application.
+
+Deployment order:
+
+1. Apply the `neuralliquid-org` DNS change for the `login.hov` CNAME and
+   `asuid.login.hov` TXT record.
+2. Apply the `mystira-workspace` Identity hostname, managed certificate, and SNI
+   bindings; verify HTTPS and the authorization route on the new hostname.
+3. Deploy this HOV change.
+4. Complete a legitimate HOV magic-link sign-in and verify the callback returns
+   to HOV with an authenticated session.
+
+CI, health probes, and Terraform plans do not constitute authenticated user
+acceptance. Do not deploy step 3 before the certificate in step 2 is issued.

--- a/lib/auth/federated-logout.ts
+++ b/lib/auth/federated-logout.ts
@@ -16,7 +16,29 @@ function trimTrailingSlash(url: string): string {
  * omits it (Mystira runs OpenIddict). Never throws — sign-out must degrade
  * gracefully rather than fail on a discovery hiccup.
  */
-export async function resolveEndSessionEndpoint(issuer: string): Promise<string> {
+export async function resolveEndSessionEndpoint(
+  issuer: string,
+  configuredEndpoint?: string
+): Promise<string> {
+  if (configuredEndpoint) {
+    try {
+      const endpoint = new URL(configuredEndpoint)
+      if (
+        endpoint.protocol === "https:" &&
+        endpoint.username === "" &&
+        endpoint.password === "" &&
+        endpoint.pathname === "/connect/endsession" &&
+        endpoint.search === "" &&
+        endpoint.hash === ""
+      ) {
+        return endpoint.toString()
+      }
+    } catch {
+      // Ignore unsafe overrides and fall back to canonical discovery.
+    }
+    logger.warn("Ignoring invalid configured OIDC end-session endpoint")
+  }
+
   const cached = endSessionEndpointCache.get(issuer)
   if (cached) return cached
 

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -275,6 +275,7 @@ module "webapp" {
   jwt_secret                                       = random_password.jwt_secret.result
   mystira_oidc_issuer                              = var.mystira_oidc_issuer
   mystira_oidc_authorization_endpoint              = var.mystira_oidc_authorization_endpoint
+  mystira_oidc_end_session_endpoint                = var.mystira_oidc_end_session_endpoint
   mystira_oidc_client_id                           = var.mystira_oidc_client_id
   mystira_oidc_client_secret                       = var.mystira_oidc_client_secret
   mystira_oidc_client_secret_key_vault_secret_name = var.mystira_oidc_client_secret_key_vault_secret_name

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -274,6 +274,7 @@ module "webapp" {
   key_vault_uri                                    = module.security.key_vault_uri
   jwt_secret                                       = random_password.jwt_secret.result
   mystira_oidc_issuer                              = var.mystira_oidc_issuer
+  mystira_oidc_authorization_endpoint              = var.mystira_oidc_authorization_endpoint
   mystira_oidc_client_id                           = var.mystira_oidc_client_id
   mystira_oidc_client_secret                       = var.mystira_oidc_client_secret
   mystira_oidc_client_secret_key_vault_secret_name = var.mystira_oidc_client_secret_key_vault_secret_name

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -555,6 +555,17 @@ variable "mystira_oidc_issuer" {
   default     = "https://identity.mystira.app"
 }
 
+variable "mystira_oidc_authorization_endpoint" {
+  description = "Browser-facing Mystira authorization endpoint on the isolated HOV login hostname"
+  type        = string
+  default     = "https://login.hov.neuralliquid.ai/connect/authorize"
+
+  validation {
+    condition     = can(regex("^https://[^/]+/connect/authorize$", var.mystira_oidc_authorization_endpoint))
+    error_message = "mystira_oidc_authorization_endpoint must be an HTTPS /connect/authorize URL."
+  }
+}
+
 variable "mystira_oidc_client_id" {
   description = "Mystira OIDC client ID for the House of Veritas relying party"
   type        = string

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -561,8 +561,19 @@ variable "mystira_oidc_authorization_endpoint" {
   default     = "https://login.hov.neuralliquid.ai/connect/authorize"
 
   validation {
-    condition     = can(regex("^https://[^/]+/connect/authorize$", var.mystira_oidc_authorization_endpoint))
+    condition     = can(regex("^https://[a-z0-9.-]+(:[0-9]+)?/connect/authorize$", var.mystira_oidc_authorization_endpoint))
     error_message = "mystira_oidc_authorization_endpoint must be an HTTPS /connect/authorize URL."
+  }
+}
+
+variable "mystira_oidc_end_session_endpoint" {
+  description = "Browser-facing Mystira end-session endpoint on the isolated HOV login hostname"
+  type        = string
+  default     = "https://login.hov.neuralliquid.ai/connect/endsession"
+
+  validation {
+    condition     = can(regex("^https://[a-z0-9.-]+(:[0-9]+)?/connect/endsession$", var.mystira_oidc_end_session_endpoint))
+    error_message = "mystira_oidc_end_session_endpoint must be an HTTPS /connect/endsession URL."
   }
 }
 

--- a/terraform/modules/webapp/main.tf
+++ b/terraform/modules/webapp/main.tf
@@ -15,6 +15,7 @@ locals {
     { AUTH_TRUST_HOST = "true" },
     var.mystira_oidc_issuer != "" ? { MYSTIRA_OIDC_ISSUER = var.mystira_oidc_issuer } : {},
     var.mystira_oidc_authorization_endpoint != "" ? { MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT = var.mystira_oidc_authorization_endpoint } : {},
+    var.mystira_oidc_end_session_endpoint != "" ? { MYSTIRA_OIDC_END_SESSION_ENDPOINT = var.mystira_oidc_end_session_endpoint } : {},
     var.mystira_oidc_client_id != "" ? { MYSTIRA_OIDC_CLIENT_ID = var.mystira_oidc_client_id } : {},
     local.mystira_oidc_client_secret_setting != "" ? { MYSTIRA_OIDC_CLIENT_SECRET = local.mystira_oidc_client_secret_setting } : {},
     var.auth_url != "" ? { AUTH_URL = var.auth_url } : {},

--- a/terraform/modules/webapp/main.tf
+++ b/terraform/modules/webapp/main.tf
@@ -14,6 +14,7 @@ locals {
   auth_app_settings = merge(
     { AUTH_TRUST_HOST = "true" },
     var.mystira_oidc_issuer != "" ? { MYSTIRA_OIDC_ISSUER = var.mystira_oidc_issuer } : {},
+    var.mystira_oidc_authorization_endpoint != "" ? { MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT = var.mystira_oidc_authorization_endpoint } : {},
     var.mystira_oidc_client_id != "" ? { MYSTIRA_OIDC_CLIENT_ID = var.mystira_oidc_client_id } : {},
     local.mystira_oidc_client_secret_setting != "" ? { MYSTIRA_OIDC_CLIENT_SECRET = local.mystira_oidc_client_secret_setting } : {},
     var.auth_url != "" ? { AUTH_URL = var.auth_url } : {},

--- a/terraform/modules/webapp/variables.tf
+++ b/terraform/modules/webapp/variables.tf
@@ -181,8 +181,19 @@ variable "mystira_oidc_authorization_endpoint" {
   default     = ""
 
   validation {
-    condition     = var.mystira_oidc_authorization_endpoint == "" || can(regex("^https://[^/]+/connect/authorize$", var.mystira_oidc_authorization_endpoint))
+    condition     = var.mystira_oidc_authorization_endpoint == "" || can(regex("^https://[a-z0-9.-]+(:[0-9]+)?/connect/authorize$", var.mystira_oidc_authorization_endpoint))
     error_message = "mystira_oidc_authorization_endpoint must be empty or an HTTPS /connect/authorize URL."
+  }
+}
+
+variable "mystira_oidc_end_session_endpoint" {
+  description = "Browser-facing Mystira end-session endpoint. Use the authorization hostname so the host-only Identity session cookie is cleared."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.mystira_oidc_end_session_endpoint == "" || can(regex("^https://[a-z0-9.-]+(:[0-9]+)?/connect/endsession$", var.mystira_oidc_end_session_endpoint))
+    error_message = "mystira_oidc_end_session_endpoint must be empty or an HTTPS /connect/endsession URL."
   }
 }
 

--- a/terraform/modules/webapp/variables.tf
+++ b/terraform/modules/webapp/variables.tf
@@ -175,6 +175,17 @@ variable "mystira_oidc_issuer" {
   default     = ""
 }
 
+variable "mystira_oidc_authorization_endpoint" {
+  description = "Browser-facing Mystira authorization endpoint. May use an HOV-owned custom hostname while issuer/token endpoints remain canonical Mystira Identity."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.mystira_oidc_authorization_endpoint == "" || can(regex("^https://[^/]+/connect/authorize$", var.mystira_oidc_authorization_endpoint))
+    error_message = "mystira_oidc_authorization_endpoint must be empty or an HTTPS /connect/authorize URL."
+  }
+}
+
 variable "mystira_oidc_client_id" {
   description = "Mystira OIDC client ID for the House of Veritas relying party"
   type        = string

--- a/tests/lib/auth-config.test.ts
+++ b/tests/lib/auth-config.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+async function loadProvider() {
+  vi.resetModules()
+  const { default: config } = await import("@/auth.config")
+  return config.providers[0]
+}
+
+describe("Mystira OIDC provider configuration", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it("uses the canonical issuer authorization endpoint by default", async () => {
+    vi.stubEnv("MYSTIRA_OIDC_ISSUER", "https://identity.example.test")
+    vi.stubEnv("MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT", "")
+
+    const provider = await loadProvider()
+
+    expect(provider.authorization).toEqual({
+      url: "https://identity.example.test/connect/authorize",
+      params: { scope: "openid profile email offline_access" },
+    })
+    expect(provider.issuer).toBe("https://identity.example.test")
+  })
+
+  it("can keep the issuer canonical while using an HOV browser endpoint", async () => {
+    vi.stubEnv("MYSTIRA_OIDC_ISSUER", "https://identity.mystira.app")
+    vi.stubEnv(
+      "MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT",
+      "https://login.hov.neuralliquid.ai/connect/authorize"
+    )
+
+    const provider = await loadProvider()
+
+    expect(provider.authorization).toMatchObject({
+      url: "https://login.hov.neuralliquid.ai/connect/authorize",
+    })
+    expect(provider.issuer).toBe("https://identity.mystira.app")
+    expect(provider.checks).toEqual(["pkce", "state"])
+  })
+})

--- a/tests/lib/auth-config.test.ts
+++ b/tests/lib/auth-config.test.ts
@@ -3,7 +3,13 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 async function loadProvider() {
   vi.resetModules()
   const { default: config } = await import("@/auth.config")
-  return config.providers[0]
+  const provider = config.providers.find(
+    (candidate) => typeof candidate !== "function" && candidate.id === "mystira"
+  )
+  if (!provider || typeof provider === "function") {
+    throw new Error("Mystira OIDC provider is missing")
+  }
+  return provider
 }
 
 describe("Mystira OIDC provider configuration", () => {
@@ -39,5 +45,31 @@ describe("Mystira OIDC provider configuration", () => {
     })
     expect(provider.issuer).toBe("https://identity.mystira.app")
     expect(provider.checks).toEqual(["pkce", "state"])
+  })
+
+  it("does not throw at module load for a malformed issuer", async () => {
+    vi.stubEnv("MYSTIRA_OIDC_ISSUER", "not-an-absolute-url")
+    vi.stubEnv("MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT", "")
+
+    const provider = await loadProvider()
+
+    expect(provider.authorization).toMatchObject({
+      url: "http://localhost:5262/connect/authorize",
+    })
+    expect(provider.issuer).toBe("not-an-absolute-url")
+  })
+
+  it("rejects an unsafe authorization endpoint and falls back to the issuer", async () => {
+    vi.stubEnv("MYSTIRA_OIDC_ISSUER", "https://identity.example.test")
+    vi.stubEnv(
+      "MYSTIRA_OIDC_AUTHORIZATION_ENDPOINT",
+      "https://identity.example.test@evil.example/connect/authorize?redirect=1"
+    )
+
+    const provider = await loadProvider()
+
+    expect(provider.authorization).toMatchObject({
+      url: "https://identity.example.test/connect/authorize",
+    })
   })
 })

--- a/tests/lib/federated-logout.test.ts
+++ b/tests/lib/federated-logout.test.ts
@@ -45,6 +45,33 @@ describe("resolveEndSessionEndpoint", () => {
     vi.unstubAllGlobals()
   })
 
+  it("uses a valid configured endpoint without discovery", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+
+    const endpoint = await resolveEndSessionEndpoint(
+      "https://identity.example.com",
+      "https://login.hov.neuralliquid.ai/connect/endsession"
+    )
+
+    expect(endpoint).toBe("https://login.hov.neuralliquid.ai/connect/endsession")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("ignores an unsafe configured endpoint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({}) }))
+    )
+
+    const endpoint = await resolveEndSessionEndpoint(
+      "https://safe-issuer.example.com",
+      "https://safe-issuer.example.com@evil.example/connect/endsession"
+    )
+
+    expect(endpoint).toBe("https://safe-issuer.example.com/connect/endsession")
+  })
+
   it("uses the discovered end_session_endpoint when discovery succeeds", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
- route the browser authorization request through the isolated HOV login hostname
- keep Mystira Identity as the canonical issuer, discovery, JWKS, and token authority
- retain PKCE/state checks and add focused provider configuration tests
- document the required cross-repository deployment order

## Verification
- focused auth configuration tests: 2 passed
- ESLint: passed
- Prettier: passed
- TypeScript noEmit: passed
- Next.js production build: compiled and type-checked; prerender then hit the Next.js 16 `Expected workStore to be initialized` invariant on `/_global-error`
- Terraform fmt: passed
- Terraform validate: deferred to CI because the local sandbox could not create/read provider plugin data

## Deployment boundary
Draft only. Do not deploy until DNS is applied and HTTPS is verified on `login.hov.neuralliquid.ai` after the Mystira Identity binding/certificate apply.

## Companion PRs and order
1. DNS: https://github.com/neuralliquid/neuralliquid-org/pull/4
2. Identity hostname/TLS: https://github.com/phoenixvc/mystira-workspace/pull/3481
3. This HOV configuration PR