### PR TITLE
Reconcile Mystira OIDC secret during deploys

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -161,9 +161,12 @@ jobs:
 
       - name: Reconcile Mystira OIDC Client Secret
         env:
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP || 'nl-prod-hov-rg' }}
+          AZURE_SUBSCRIPTION_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).subscriptionId }}
           KEY_VAULT_NAME: ${{ vars.HOV_KEY_VAULT_NAME || 'nl-prod-hov-kv' }}
           KEY_VAULT_SECRET_NAME: ${{ vars.MYSTIRA_OIDC_CLIENT_SECRET_KEY_VAULT_SECRET_NAME || 'mystira-oidc-client-secret' }}
           MYSTIRA_OIDC_CLIENT_SECRET: ${{ secrets.MYSTIRA_OIDC_CLIENT_SECRET }}
+          WEBAPP_NAME: ${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}
         run: |
           set -euo pipefail
 
@@ -186,7 +189,12 @@ jobs:
               --value "$MYSTIRA_OIDC_CLIENT_SECRET" \
               --output none \
               --only-show-errors
-            echo "Mystira OIDC client secret synchronized"
+            az rest \
+              --method post \
+              --url "https://management.azure.com/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$AZURE_RESOURCE_GROUP/providers/Microsoft.Web/sites/$WEBAPP_NAME/config/configreferences/appsettings/refresh?api-version=2022-03-01" \
+              --output none \
+              --only-show-errors
+            echo "Mystira OIDC client secret synchronized and App Service reference refreshed"
           fi
 
           unset CURRENT_SECRET MYSTIRA_OIDC_CLIENT_SECRET

--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -159,6 +159,38 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Reconcile Mystira OIDC Client Secret
+        env:
+          KEY_VAULT_NAME: ${{ vars.HOV_KEY_VAULT_NAME || 'nl-prod-hov-kv' }}
+          KEY_VAULT_SECRET_NAME: ${{ vars.MYSTIRA_OIDC_CLIENT_SECRET_KEY_VAULT_SECRET_NAME || 'mystira-oidc-client-secret' }}
+          MYSTIRA_OIDC_CLIENT_SECRET: ${{ secrets.MYSTIRA_OIDC_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${MYSTIRA_OIDC_CLIENT_SECRET:-}" ]; then
+            echo "::error::MYSTIRA_OIDC_CLIENT_SECRET is required in the production environment"
+            exit 1
+          fi
+
+          if CURRENT_SECRET=$(az keyvault secret show \
+            --vault-name "$KEY_VAULT_NAME" \
+            --name "$KEY_VAULT_SECRET_NAME" \
+            --query value \
+            --output tsv \
+            --only-show-errors 2>/dev/null) && [ "$CURRENT_SECRET" = "$MYSTIRA_OIDC_CLIENT_SECRET" ]; then
+            echo "Mystira OIDC client secret is already synchronized"
+          else
+            az keyvault secret set \
+              --vault-name "$KEY_VAULT_NAME" \
+              --name "$KEY_VAULT_SECRET_NAME" \
+              --value "$MYSTIRA_OIDC_CLIENT_SECRET" \
+              --output none \
+              --only-show-errors
+            echo "Mystira OIDC client secret synchronized"
+          fi
+
+          unset CURRENT_SECRET MYSTIRA_OIDC_CLIENT_SECRET
+
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -325,6 +325,39 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Reconcile Mystira OIDC Client Secret
+        if: ${{ (inputs.environment || 'production') == 'production' }}
+        env:
+          KEY_VAULT_NAME: ${{ vars.HOV_KEY_VAULT_NAME || 'nl-prod-hov-kv' }}
+          KEY_VAULT_SECRET_NAME: ${{ vars.MYSTIRA_OIDC_CLIENT_SECRET_KEY_VAULT_SECRET_NAME || 'mystira-oidc-client-secret' }}
+          MYSTIRA_OIDC_CLIENT_SECRET: ${{ secrets.MYSTIRA_OIDC_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${MYSTIRA_OIDC_CLIENT_SECRET:-}" ]; then
+            echo "::error::MYSTIRA_OIDC_CLIENT_SECRET is required in the production environment"
+            exit 1
+          fi
+
+          if CURRENT_SECRET=$(az keyvault secret show \
+            --vault-name "$KEY_VAULT_NAME" \
+            --name "$KEY_VAULT_SECRET_NAME" \
+            --query value \
+            --output tsv \
+            --only-show-errors 2>/dev/null) && [ "$CURRENT_SECRET" = "$MYSTIRA_OIDC_CLIENT_SECRET" ]; then
+            echo "Mystira OIDC client secret is already synchronized"
+          else
+            az keyvault secret set \
+              --vault-name "$KEY_VAULT_NAME" \
+              --name "$KEY_VAULT_SECRET_NAME" \
+              --value "$MYSTIRA_OIDC_CLIENT_SECRET" \
+              --output none \
+              --only-show-errors
+            echo "Mystira OIDC client secret synchronized"
+          fi
+
+          unset CURRENT_SECRET MYSTIRA_OIDC_CLIENT_SECRET
+
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -328,9 +328,12 @@ jobs:
       - name: Reconcile Mystira OIDC Client Secret
         if: ${{ (inputs.environment || 'production') == 'production' }}
         env:
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP || 'nl-prod-hov-rg' }}
+          AZURE_SUBSCRIPTION_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).subscriptionId }}
           KEY_VAULT_NAME: ${{ vars.HOV_KEY_VAULT_NAME || 'nl-prod-hov-kv' }}
           KEY_VAULT_SECRET_NAME: ${{ vars.MYSTIRA_OIDC_CLIENT_SECRET_KEY_VAULT_SECRET_NAME || 'mystira-oidc-client-secret' }}
           MYSTIRA_OIDC_CLIENT_SECRET: ${{ secrets.MYSTIRA_OIDC_CLIENT_SECRET }}
+          WEBAPP_NAME: ${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}
         run: |
           set -euo pipefail
 
@@ -353,7 +356,12 @@ jobs:
               --value "$MYSTIRA_OIDC_CLIENT_SECRET" \
               --output none \
               --only-show-errors
-            echo "Mystira OIDC client secret synchronized"
+            az rest \
+              --method post \
+              --url "https://management.azure.com/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$AZURE_RESOURCE_GROUP/providers/Microsoft.Web/sites/$WEBAPP_NAME/config/configreferences/appsettings/refresh?api-version=2022-03-01" \
+              --output none \
+              --only-show-errors
+            echo "Mystira OIDC client secret synchronized and App Service reference refreshed"
           fi
 
           unset CURRENT_SECRET MYSTIRA_OIDC_CLIENT_SECRET

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -55,6 +55,38 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Reconcile Mystira OIDC Client Secret
+        env:
+          KEY_VAULT_NAME: ${{ vars.HOV_KEY_VAULT_NAME || 'nl-prod-hov-kv' }}
+          KEY_VAULT_SECRET_NAME: ${{ vars.MYSTIRA_OIDC_CLIENT_SECRET_KEY_VAULT_SECRET_NAME || 'mystira-oidc-client-secret' }}
+          MYSTIRA_OIDC_CLIENT_SECRET: ${{ secrets.MYSTIRA_OIDC_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${MYSTIRA_OIDC_CLIENT_SECRET:-}" ]; then
+            echo "::error::MYSTIRA_OIDC_CLIENT_SECRET is required in the production environment"
+            exit 1
+          fi
+
+          if CURRENT_SECRET=$(az keyvault secret show \
+            --vault-name "$KEY_VAULT_NAME" \
+            --name "$KEY_VAULT_SECRET_NAME" \
+            --query value \
+            --output tsv \
+            --only-show-errors 2>/dev/null) && [ "$CURRENT_SECRET" = "$MYSTIRA_OIDC_CLIENT_SECRET" ]; then
+            echo "Mystira OIDC client secret is already synchronized"
+          else
+            az keyvault secret set \
+              --vault-name "$KEY_VAULT_NAME" \
+              --name "$KEY_VAULT_SECRET_NAME" \
+              --value "$MYSTIRA_OIDC_CLIENT_SECRET" \
+              --output none \
+              --only-show-errors
+            echo "Mystira OIDC client secret synchronized"
+          fi
+
+          unset CURRENT_SECRET MYSTIRA_OIDC_CLIENT_SECRET
+
       - name: Set Terraform ARM credentials
         run: |
           CREDS='${{ secrets.AZURE_CREDENTIALS }}'

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -57,9 +57,12 @@ jobs:
 
       - name: Reconcile Mystira OIDC Client Secret
         env:
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP || 'nl-prod-hov-rg' }}
+          AZURE_SUBSCRIPTION_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).subscriptionId }}
           KEY_VAULT_NAME: ${{ vars.HOV_KEY_VAULT_NAME || 'nl-prod-hov-kv' }}
           KEY_VAULT_SECRET_NAME: ${{ vars.MYSTIRA_OIDC_CLIENT_SECRET_KEY_VAULT_SECRET_NAME || 'mystira-oidc-client-secret' }}
           MYSTIRA_OIDC_CLIENT_SECRET: ${{ secrets.MYSTIRA_OIDC_CLIENT_SECRET }}
+          WEBAPP_NAME: ${{ vars.WEBAPP_NAME || 'nl-prod-hov-app' }}
         run: |
           set -euo pipefail
 
@@ -82,7 +85,12 @@ jobs:
               --value "$MYSTIRA_OIDC_CLIENT_SECRET" \
               --output none \
               --only-show-errors
-            echo "Mystira OIDC client secret synchronized"
+            az rest \
+              --method post \
+              --url "https://management.azure.com/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$AZURE_RESOURCE_GROUP/providers/Microsoft.Web/sites/$WEBAPP_NAME/config/configreferences/appsettings/refresh?api-version=2022-03-01" \
+              --output none \
+              --only-show-errors
+            echo "Mystira OIDC client secret synchronized and App Service reference refreshed"
           fi
 
           unset CURRENT_SECRET MYSTIRA_OIDC_CLIENT_SECRET

--- a/docs/handoffs/2026-08-03-hov-mystira-oidc-secret-drift.md
+++ b/docs/handoffs/2026-08-03-hov-mystira-oidc-secret-drift.md
@@ -1,0 +1,64 @@
+# HOV Mystira OIDC client-secret drift
+
+- **Date:** 2026-08-03
+- **Repository:** `C:\Users\smitj\repos\house-of-veritas`
+- **Baton task:** `dd38d58a-c815-4689-a980-82acaf08ac62`
+- **Area:** production authentication, Azure Key Vault, deployment workflows
+
+## Incident
+
+A fresh `omniposthq@gmail.com` sign-in reached Microsoft and returned to HOV, but
+Auth.js ended at `/api/auth/error?error=Configuration` with HTTP 500. The HOV App
+Service runtime log recorded Mystira's token response as `invalid_client`
+(`ID2055`): the configured client credentials were invalid.
+
+A non-user token probe established that Mystira's persisted
+`neuralliquid-hov-web` client still recognized the intended development client
+secret. HOV's `nl-prod-hov-kv/mystira-oidc-client-secret` value had drifted from
+that recognized value, so the callback failed before HOV could resolve the email
+to a local persona.
+
+## Live repair
+
+With explicit operator approval:
+
+1. The current operator received temporary `Set` permission on `nl-prod-hov-kv`.
+2. Only `mystira-oidc-client-secret` was restored to the IdP-recognized value.
+3. The temporary Key Vault policy was removed and its absence was verified.
+4. App Service Key Vault references were refreshed and `nl-prod-hov-app` was
+   restarted.
+5. `https://hov.neuralliquid.ai/api/health` returned healthy on build
+   `e627181c6fe8661f8352aaa894e1fc6151195764`.
+
+No secret value, browser session, token, or user credential was recorded.
+
+## Durable workflow guard
+
+The protected GitHub `production` environment now contains
+`MYSTIRA_OIDC_CLIENT_SECRET`. Production deployment workflows reconcile that
+value into the versionless Key Vault secret before an App Service deployment or
+manual Terraform apply:
+
+- `.github/workflows/deploy-on-merge.yml`
+- `.github/workflows/deploy.yml`
+- `.github/workflows/terraform-apply.yml`
+
+The step fails closed if the GitHub environment secret is absent. It first reads
+and compares the current Key Vault value, creates a new version only when the
+values differ, emits no secret material, and unsets local shell variables after
+the comparison. Staging skips the production-only reconciliation in the full
+deployment workflow.
+
+## Verification
+
+- `pnpm install --frozen-lockfile`
+- `pnpm exec prettier --check .github/workflows/deploy-on-merge.yml .github/workflows/deploy.yml .github/workflows/terraform-apply.yml`
+- `pnpm run lint`
+- `git diff --check`
+
+## Remaining acceptance
+
+Complete a fresh visible Microsoft sign-in using `omniposthq@gmail.com`, then
+verify that `/api/auth/me` identifies the Lucky operator before and after a page
+refresh. Deployment health and a successful token exchange are not substitutes
+for that authenticated persona-link proof.

--- a/docs/handoffs/2026-08-03-hov-mystira-oidc-secret-drift.md
+++ b/docs/handoffs/2026-08-03-hov-mystira-oidc-secret-drift.md
@@ -45,9 +45,10 @@ manual Terraform apply:
 
 The step fails closed if the GitHub environment secret is absent. It first reads
 and compares the current Key Vault value, creates a new version only when the
-values differ, emits no secret material, and unsets local shell variables after
-the comparison. Staging skips the production-only reconciliation in the full
-deployment workflow.
+values differ, immediately refreshes the App Service's versionless Key Vault
+references after a change, emits no secret material, and unsets local shell
+variables after the comparison. Staging skips the production-only
+reconciliation in the full deployment workflow.
 
 ## Verification
 


### PR DESCRIPTION
## What changed

- reconcile the protected production OIDC client secret into HOV Key Vault before production web-app deploys and manual Terraform apply
- fail closed when the production environment secret is absent
- avoid unnecessary Key Vault versions by comparing before setting
- document the production drift incident, live repair, and remaining authentic Lucky acceptance

## Why

Production login reached the Mystira token endpoint but failed with invalid_client because HOV Key Vault drifted from the IdP-recognized client secret. The workflow referenced a GitHub secret that did not exist and never wrote the value into Key Vault.

## Validation

- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm exec prettier --check .github/workflows/deploy-on-merge.yml .github/workflows/deploy.yml .github/workflows/terraform-apply.yml docs/handoffs/2026-08-03-hov-mystira-oidc-secret-drift.md
- git diff --check

## Coordination

- Baton: dd38d58a-c815-4689-a980-82acaf08ac62
- production environment secret created without exposing its value
- live Key Vault repair and App Service restart already completed with explicit operator approval
- authentic omniposthq@gmail.com to Lucky verification remains operator-held