### PR TITLE
fix(governance): fail closed with 503 when the gate datastore is unreachable

### DIFF
--- a/lib/repositories/gate-governance-repository.ts
+++ b/lib/repositories/gate-governance-repository.ts
@@ -9,6 +9,41 @@ export class GateGovernanceConflictError extends Error {}
 export class GateGovernanceIdempotencyError extends Error {}
 export class GateGovernanceStoreUnavailableError extends Error {}
 
+// Driver errors raised when the cluster cannot be reached at all, as opposed to
+// a query that reached the server and was rejected. `isMongoConfigured()` only
+// proves MONGODB_URI is set, never that the cluster answers — so without this
+// mapping an unreachable-but-configured store escapes as a generic error and the
+// route reports 500 instead of failing closed with 503.
+const UNAVAILABLE_ERROR_NAMES = new Set([
+  "MongoNetworkError",
+  "MongoNetworkTimeoutError",
+  "MongoServerSelectionError",
+  "MongoTopologyClosedError",
+  "MongoNotConnectedError",
+])
+
+function isStoreUnavailableError(error: unknown): boolean {
+  return error instanceof Error && UNAVAILABLE_ERROR_NAMES.has(error.name)
+}
+
+/**
+ * Re-throw connectivity failures as `GateGovernanceStoreUnavailableError` so the
+ * route fails closed, while letting genuine outcomes (conflict, idempotency
+ * reuse, duplicate key) through untouched for their own status codes.
+ */
+async function withStoreAvailability<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation()
+  } catch (error) {
+    if (isStoreUnavailableError(error)) {
+      throw new GateGovernanceStoreUnavailableError(
+        error instanceof Error ? error.message : "Gate governance datastore is unreachable"
+      )
+    }
+    throw error
+  }
+}
+
 export interface AppendGateDecisionInput {
   request: GateDecisionRequest
   actorId: string
@@ -90,30 +125,34 @@ const memoryRepository: GateGovernanceRepository = {
 }
 
 async function createMongoRepository(): Promise<GateGovernanceRepository> {
-  const collection: Collection<GateDecisionEvent> =
-    await getCollection<GateDecisionEvent>(COLLECTION_NAME)
-  await Promise.all([
-    collection.createIndex({ id: 1 }, { unique: true }),
-    collection.createIndex({ idempotencyKey: 1 }, { unique: true }),
-    collection.createIndex(
-      { gateId: 1, protocolVersion: 1, decisionId: 1, version: 1 },
-      { unique: true }
-    ),
-  ])
+  const collection: Collection<GateDecisionEvent> = await withStoreAvailability(() =>
+    getCollection<GateDecisionEvent>(COLLECTION_NAME)
+  )
+  await withStoreAvailability(() =>
+    Promise.all([
+      collection.createIndex({ id: 1 }, { unique: true }),
+      collection.createIndex({ idempotencyKey: 1 }, { unique: true }),
+      collection.createIndex(
+        { gateId: 1, protocolVersion: 1, decisionId: 1, version: 1 },
+        { unique: true }
+      ),
+    ])
+  )
 
   return {
     async list(gateId, protocolVersion) {
-      const documents = await collection
-        .find({ gateId, protocolVersion })
-        .sort({ createdAt: 1 })
-        .toArray()
+      const documents = await withStoreAvailability(() =>
+        collection.find({ gateId, protocolVersion }).sort({ createdAt: 1 }).toArray()
+      )
       return documents.map(withoutMongoId)
     },
     async append(input) {
       const fingerprint = fingerprintGateDecision(input.request)
-      const idempotent = await collection.findOne({
-        idempotencyKey: input.request.idempotencyKey,
-      })
+      const idempotent = await withStoreAvailability(() =>
+        collection.findOne({
+          idempotencyKey: input.request.idempotencyKey,
+        })
+      )
       if (idempotent) {
         if (idempotent.requestFingerprint !== fingerprint) {
           throw new GateGovernanceIdempotencyError("Idempotency key was reused")
@@ -121,13 +160,15 @@ async function createMongoRepository(): Promise<GateGovernanceRepository> {
         return { event: withoutMongoId(idempotent), created: false }
       }
 
-      const current = await collection.findOne(
-        {
-          gateId: input.request.gateId,
-          protocolVersion: input.request.protocolVersion,
-          decisionId: input.request.decisionId,
-        },
-        { sort: { version: -1 } }
+      const current = await withStoreAvailability(() =>
+        collection.findOne(
+          {
+            gateId: input.request.gateId,
+            protocolVersion: input.request.protocolVersion,
+            decisionId: input.request.decisionId,
+          },
+          { sort: { version: -1 } }
+        )
       )
       if ((current?.version ?? 0) !== input.request.expectedVersion) {
         throw new GateGovernanceConflictError("Decision version changed")
@@ -135,7 +176,7 @@ async function createMongoRepository(): Promise<GateGovernanceRepository> {
 
       const event = createEvent(input)
       try {
-        await collection.insertOne(event)
+        await withStoreAvailability(() => collection.insertOne(event))
         return { event, created: true }
       } catch (error) {
         if (
@@ -144,9 +185,11 @@ async function createMongoRepository(): Promise<GateGovernanceRepository> {
           "code" in error &&
           error.code === 11000
         ) {
-          const retry = await collection.findOne({
-            idempotencyKey: input.request.idempotencyKey,
-          })
+          const retry = await withStoreAvailability(() =>
+            collection.findOne({
+              idempotencyKey: input.request.idempotencyKey,
+            })
+          )
           if (retry) {
             if (retry.requestFingerprint !== fingerprint) {
               throw new GateGovernanceIdempotencyError("Idempotency key was reused")

--- a/scripts/run-post-deploy-gate0.ps1
+++ b/scripts/run-post-deploy-gate0.ps1
@@ -1,18 +1,29 @@
 [CmdletBinding()]
 param(
-  [switch]$UseChunkedCookies
+  [switch]$UseChunkedCookies,
+  # Production issues no identity with role=operator, so the denial probe runs as
+  # an employee by default. Pass this only when a genuine operator session exists;
+  # otherwise the operator scenarios skip rather than silently passing.
+  [switch]$IncludeOperator
 )
 
 $ErrorActionPreference = "Stop"
 
 $baseUrl = "https://hov.neuralliquid.ai"
+$denialRoles = @("EMPLOYEE")
+if ($IncludeOperator) {
+  $denialRoles += "OPERATOR"
+}
+
 $environmentNames = @(
   "BASE_URL",
   "POST_DEPLOY_PROBE",
   "POST_DEPLOY_ADMIN_SESSION",
   "POST_DEPLOY_OPERATOR_SESSION",
+  "POST_DEPLOY_EMPLOYEE_SESSION",
   "POST_DEPLOY_ADMIN_SESSION_COOKIES",
-  "POST_DEPLOY_OPERATOR_SESSION_COOKIES"
+  "POST_DEPLOY_OPERATOR_SESSION_COOKIES",
+  "POST_DEPLOY_EMPLOYEE_SESSION_COOKIES"
 )
 
 function Read-SecretToProcessEnvironment {
@@ -52,19 +63,19 @@ try {
   [Environment]::SetEnvironmentVariable("BASE_URL", $baseUrl, "Process")
   [Environment]::SetEnvironmentVariable("POST_DEPLOY_PROBE", "true", "Process")
 
-  if ($UseChunkedCookies) {
-    [Environment]::SetEnvironmentVariable("POST_DEPLOY_ADMIN_SESSION", $null, "Process")
-    [Environment]::SetEnvironmentVariable("POST_DEPLOY_OPERATOR_SESSION", $null, "Process")
-    Read-SecretToProcessEnvironment "POST_DEPLOY_ADMIN_SESSION_COOKIES"
-    Read-SecretToProcessEnvironment "POST_DEPLOY_OPERATOR_SESSION_COOKIES"
-  } else {
-    [Environment]::SetEnvironmentVariable("POST_DEPLOY_ADMIN_SESSION_COOKIES", $null, "Process")
-    [Environment]::SetEnvironmentVariable("POST_DEPLOY_OPERATOR_SESSION_COOKIES", $null, "Process")
-    Read-SecretToProcessEnvironment "POST_DEPLOY_ADMIN_SESSION"
-    Read-SecretToProcessEnvironment "POST_DEPLOY_OPERATOR_SESSION"
+  $roles = @("ADMIN") + $denialRoles
+  $suffix = if ($UseChunkedCookies) { "_COOKIES" } else { "" }
+  $unusedSuffix = if ($UseChunkedCookies) { "" } else { "_COOKIES" }
+
+  foreach ($role in $roles) {
+    # Clear the form that is not in use so a stale value from a previous shape
+    # can never be picked up alongside the one being entered now.
+    [Environment]::SetEnvironmentVariable("POST_DEPLOY_${role}_SESSION${unusedSuffix}", $null, "Process")
+    Read-SecretToProcessEnvironment "POST_DEPLOY_${role}_SESSION${suffix}"
   }
 
   Write-Host "Running the production-auth Gate 0 acceptance probe against $baseUrl."
+  Write-Host "Denial roles this run: $($denialRoles -join ', '). Any role without a supplied session skips."
   # The production probe policy disables retries, traces, and screenshots. Use
   # a console-only reporter as a second boundary so no HTML report is retained.
   & pnpm run test:e2e:post-deploy-gate0 -- --reporter=line

--- a/tests/e2e/04-clean-default.spec.ts
+++ b/tests/e2e/04-clean-default.spec.ts
@@ -138,6 +138,12 @@ test.describe("clean-default mode", () => {
     await expect(page.locator("body")).not.toContainText(cleanModeText)
 
     await page.goto("/login")
+    // The login page holds a spinner until the Auth.js session probe resolves and
+    // only then renders the submit button. Arriving here after several dashboard
+    // loads, that probe intermittently outlasts the default assertion timeout,
+    // which surfaced as a flaky "element(s) not found". Wait for the button to
+    // exist before asserting its text.
+    await expect(page.getByTestId("login-submit")).toBeVisible({ timeout: 15_000 })
     await expect(page.getByTestId("login-submit")).toContainText("Continue with Mystira")
     await expect(page.locator("body")).not.toContainText(/demo-user|Demo Mode/i)
 

--- a/tests/e2e/06-post-deploy-gate0-acceptance.spec.ts
+++ b/tests/e2e/06-post-deploy-gate0-acceptance.spec.ts
@@ -8,8 +8,18 @@ import {
 
 const baseUrl = process.env.BASE_URL
 const adminSessionCookies = productionSessionCookies("admin")
-const operatorSessionCookies = productionSessionCookies("operator")
 const isPostDeployProbe = process.env.POST_DEPLOY_PROBE === "true"
+
+// Production issues no identity with role=operator, so the denial boundary is
+// proved against whichever non-admin roles are actually available. Both are
+// equally unauthorized for admin routes, so each independently proves the same
+// withRole("admin") boundary. Locally both are seeded; against a deployment only
+// the roles whose sessions were supplied run, and the rest skip rather than
+// silently pass.
+const denialRoles = [
+  { role: "employee", seedId: "lucky" },
+  { role: "operator", seedId: "charl" },
+] as const satisfies ReadonlyArray<{ role: ProbeRole; seedId: string }>
 
 test.describe.configure({ timeout: 60_000 })
 
@@ -50,7 +60,8 @@ async function addSessionCookies(context: BrowserContext, sessionCookies: Sessio
 async function prepareRoleSession(
   context: BrowserContext,
   role: ProbeRole,
-  sessionCookies: SessionCookie[]
+  sessionCookies: SessionCookie[],
+  seedId = role === "admin" ? "hans" : "charl"
 ) {
   if (isPostDeployProbe) {
     await addSessionCookies(context, sessionCookies)
@@ -58,7 +69,7 @@ async function prepareRoleSession(
   }
 
   await seedSession(context, {
-    id: role === "admin" ? "hans" : "charl",
+    id: seedId,
     role,
     email: `${role}@example.invalid`,
   })
@@ -129,32 +140,38 @@ test.describe("Post-deployment Gate 0 admin acceptance", () => {
   })
 })
 
-test.describe("Post-deployment Gate 0 operator denial", () => {
-  test.skip(
-    isPostDeployProbe && (!baseUrl || operatorSessionCookies.length === 0),
-    "Requires POST_DEPLOY_PROBE, BASE_URL, and a legitimate short-lived operator session."
-  )
+for (const { role, seedId } of denialRoles) {
+  test.describe(`Post-deployment Gate 0 ${role} denial`, () => {
+    const sessionCookies = productionSessionCookies(role)
 
-  test.beforeEach(async ({ context }) => {
-    await prepareRoleSession(context, "operator", operatorSessionCookies)
+    test.skip(
+      isPostDeployProbe && (!baseUrl || sessionCookies.length === 0),
+      `Requires POST_DEPLOY_PROBE, BASE_URL, and a legitimate short-lived ${role} session.`
+    )
+
+    test.beforeEach(async ({ context }) => {
+      await prepareRoleSession(context, role, sessionCookies, seedId)
+    })
+
+    for (const path of ["/api/reviewer-trials/domain-safety", "/api/governance/gates"] as const) {
+      test(`denies ${role} API access to ${path}`, async ({ page }) => {
+        const response = await page.request.get(path)
+
+        expect(response.status()).toBe(403)
+        await expect(response.json()).resolves.toMatchObject({ error: "Insufficient permissions" })
+      })
+    }
+
+    for (const path of ["/dashboard/hans/reviewer-lab", "/dashboard/hans/governance"] as const) {
+      test(`redirects ${role === "employee" ? "an" : "a"} ${role} away from ${path}`, async ({
+        page,
+      }) => {
+        await page.goto(path)
+
+        await expect(page).not.toHaveURL(new RegExp(`${path.replaceAll("/", "\\/")}(?:\\?.*)?$`))
+        await expect(page.getByTestId("domain-reviewer-lab-page")).toHaveCount(0)
+        await expect(page.getByTestId("gate-governance-page")).toHaveCount(0)
+      })
+    }
   })
-
-  for (const path of ["/api/reviewer-trials/domain-safety", "/api/governance/gates"] as const) {
-    test(`denies operator API access to ${path}`, async ({ page }) => {
-      const response = await page.request.get(path)
-
-      expect(response.status()).toBe(403)
-      await expect(response.json()).resolves.toMatchObject({ error: "Insufficient permissions" })
-    })
-  }
-
-  for (const path of ["/dashboard/hans/reviewer-lab", "/dashboard/hans/governance"] as const) {
-    test(`redirects an operator away from ${path}`, async ({ page }) => {
-      await page.goto(path)
-
-      await expect(page).not.toHaveURL(new RegExp(`${path.replaceAll("/", "\\/")}(?:\\?.*)?$`))
-      await expect(page.getByTestId("domain-reviewer-lab-page")).toHaveCount(0)
-      await expect(page.getByTestId("gate-governance-page")).toHaveCount(0)
-    })
-  }
-})
+}

--- a/tests/e2e/helpers/production-session.ts
+++ b/tests/e2e/helpers/production-session.ts
@@ -1,6 +1,10 @@
 const DEFAULT_SESSION_COOKIE_NAME = "__Secure-authjs.session-token"
 
-export type ProbeRole = "admin" | "operator"
+// `employee` exists because production has no identity with role=operator, so the
+// admin-route denial probe is run against the real non-admin role the estate
+// actually issues. Both are unauthorized for admin routes, so either proves the
+// same withRole() boundary.
+export type ProbeRole = "admin" | "operator" | "employee"
 
 export type SessionCookie = {
   name: string
@@ -9,8 +13,14 @@ export type SessionCookie = {
 
 type SessionEnvironment = Readonly<Record<string, string | undefined>>
 
+const ENVIRONMENT_PREFIXES: Record<ProbeRole, string> = {
+  admin: "POST_DEPLOY_ADMIN_SESSION",
+  operator: "POST_DEPLOY_OPERATOR_SESSION",
+  employee: "POST_DEPLOY_EMPLOYEE_SESSION",
+}
+
 function environmentPrefix(role: ProbeRole) {
-  return role === "admin" ? "POST_DEPLOY_ADMIN_SESSION" : "POST_DEPLOY_OPERATOR_SESSION"
+  return ENVIRONMENT_PREFIXES[role]
 }
 
 function cookieBaseName(role: ProbeRole, environment: SessionEnvironment) {

--- a/tests/lib/gate-governance-repository.test.ts
+++ b/tests/lib/gate-governance-repository.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mongoMocks = vi.hoisted(() => ({
+  configured: true,
+  createIndex: vi.fn(),
+  find: vi.fn(),
+  findOne: vi.fn(),
+  getCollection: vi.fn(),
+  insertOne: vi.fn(),
+  toArray: vi.fn(),
+}))
+
+vi.mock("@/lib/db/mongodb", () => ({
+  getCollection: mongoMocks.getCollection,
+  isMongoConfigured: () => mongoMocks.configured,
+  withoutMongoId: <T extends { _id?: unknown }>(document: T) => {
+    const { _id, ...rest } = document
+    return rest
+  },
+}))
+
+// These cases must run as NODE_ENV=production to reach the Mongo branch, and
+// production RBAC deliberately refuses the `x-user-*` headers that test-mode
+// routes accept. Authorization is covered by tests/api/gate-governance.test.ts
+// and the E2E denial probes; stubbing it here isolates the error-to-status
+// mapping that is actually under test.
+vi.mock("@/lib/auth/rbac", () => ({
+  withRole:
+    () =>
+    (handler: (request: Request, context: Record<string, unknown>) => Promise<Response>) =>
+    (request: Request) =>
+      handler(request, { userId: "admin-1", role: "admin", email: "admin@example.test" }),
+}))
+
+import { GET } from "@/app/api/governance/gates/route"
+import { GATE_ZERO_ID, GATE_ZERO_PROTOCOL_VERSION } from "@/lib/governance/gate-definitions"
+import {
+  GateGovernanceStoreUnavailableError,
+  getGateGovernanceRepository,
+  resetGateGovernanceRepositoryForTests,
+} from "@/lib/repositories/gate-governance-repository"
+
+/**
+ * Mongo signals "the cluster never answered" through the error name rather than a
+ * distinct class hierarchy, so tests reproduce failures the same way the driver
+ * reports them.
+ */
+function driverError(name: string, message = "cluster unreachable"): Error {
+  const error = new Error(message)
+  error.name = name
+  return error
+}
+
+const adminRequest = () =>
+  new Request("http://localhost/api/governance/gates", {
+    headers: {
+      "x-user-id": "admin-1",
+      "x-user-role": "admin",
+      "x-user-email": "admin@example.test",
+    },
+  })
+
+describe("gate governance repository store availability", () => {
+  beforeEach(() => {
+    // Production is the only mode that resolves the Mongo branch; the default
+    // test short-circuit returns the in-memory repository and would never
+    // exercise the driver error mapping this suite covers.
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("E2E_TEST", "")
+    vi.stubEnv("CI", "")
+    mongoMocks.configured = true
+
+    mongoMocks.toArray.mockReset().mockResolvedValue([])
+    mongoMocks.find.mockReset().mockReturnValue({
+      sort: () => ({ toArray: mongoMocks.toArray }),
+    })
+    mongoMocks.findOne.mockReset().mockResolvedValue(null)
+    mongoMocks.insertOne.mockReset().mockResolvedValue({ acknowledged: true })
+    mongoMocks.createIndex.mockReset().mockResolvedValue("index")
+    mongoMocks.getCollection.mockReset().mockResolvedValue({
+      createIndex: mongoMocks.createIndex,
+      find: mongoMocks.find,
+      findOne: mongoMocks.findOne,
+      insertOne: mongoMocks.insertOne,
+    })
+
+    resetGateGovernanceRepositoryForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    resetGateGovernanceRepositoryForTests()
+  })
+
+  it.each([
+    "MongoServerSelectionError",
+    "MongoNetworkError",
+    "MongoNetworkTimeoutError",
+    "MongoTopologyClosedError",
+    "MongoNotConnectedError",
+  ])("treats a %s while connecting as an unavailable store", async (name) => {
+    mongoMocks.getCollection.mockRejectedValue(driverError(name))
+
+    await expect(getGateGovernanceRepository()).rejects.toBeInstanceOf(
+      GateGovernanceStoreUnavailableError
+    )
+  })
+
+  it("treats an index-creation connectivity failure as an unavailable store", async () => {
+    mongoMocks.createIndex.mockRejectedValue(driverError("MongoNetworkError"))
+
+    await expect(getGateGovernanceRepository()).rejects.toBeInstanceOf(
+      GateGovernanceStoreUnavailableError
+    )
+  })
+
+  it("treats a read connectivity failure as an unavailable store", async () => {
+    mongoMocks.toArray.mockRejectedValue(driverError("MongoNetworkTimeoutError"))
+
+    const { repository } = await getGateGovernanceRepository()
+
+    await expect(repository.list(GATE_ZERO_ID, GATE_ZERO_PROTOCOL_VERSION)).rejects.toBeInstanceOf(
+      GateGovernanceStoreUnavailableError
+    )
+  })
+
+  it("leaves non-connectivity driver errors unmapped so they keep their own handling", async () => {
+    const schemaError = driverError("MongoServerError", "unauthorized")
+    mongoMocks.toArray.mockRejectedValue(schemaError)
+
+    const { repository } = await getGateGovernanceRepository()
+
+    await expect(repository.list(GATE_ZERO_ID, GATE_ZERO_PROTOCOL_VERSION)).rejects.toBe(schemaError)
+  })
+
+  it("fails closed with 503 rather than 500 when the configured cluster is unreachable", async () => {
+    mongoMocks.getCollection.mockRejectedValue(driverError("MongoServerSelectionError"))
+
+    const response = await GET(adminRequest())
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      error: "Gate governance datastore is unavailable",
+    })
+  })
+
+  it("still fails closed with 503 when Mongo is not configured at all", async () => {
+    mongoMocks.configured = false
+
+    const response = await GET(adminRequest())
+
+    expect(response.status).toBe(503)
+  })
+})


### PR DESCRIPTION
## Why

Production admin reads of `/api/governance/gates` returned **HTTP 500** on 2026-08-01, blocking two Baton evidence gates. Root cause found by inspection and reproduced in tests.

`isMongoConfigured()` only checks that `MONGODB_URI`/`MONGO_URL` is a non-empty string — it never proves the cluster answers. So:

- **unconfigured** store → `GateGovernanceStoreUnavailableError` → 503 fail-closed ✅
- **configured but unreachable** store → raw `MongoServerSelectionError` from `getCollection()` → matches no handler → **500** ❌

The error class is literally named `StoreUnavailableError`, but the fail-closed contract only ever covered "not configured", not "unavailable".

## What changed

Map the driver's connectivity errors — `MongoServerSelectionError`, `MongoNetworkError`, `MongoNetworkTimeoutError`, `MongoTopologyClosedError`, `MongoNotConnectedError` — to `GateGovernanceStoreUnavailableError` across connect, index creation, reads and writes. Genuine outcomes (conflict, idempotency reuse, duplicate key) are deliberately left unmapped so they keep their own status codes.

Note this makes the endpoint fail *correctly*; it does not make Mongo reachable. Why the production cluster is unreachable is still open — but the 503 plus the existing `MongoDB connection error` log line makes that diagnosable instead of opaque.

## Why it wasn't caught

Every existing governance test runs under `NODE_ENV=test`, which short-circuits `getGateGovernanceRepository()` to the **in-memory** repository. The Mongo branch — the only one production uses — had **zero** coverage, and so did the 503 path.

The new tests reach it the way the rest of the repo does (`vi.stubEnv("NODE_ENV", "production")` + mocked `@/lib/db/mongodb`), matching the convention in `recipe-guidance-repository.test.ts`.

## Also in this PR

- **`employee` probe role.** The Gate 0 denial probe had no eligible production session: no identity has `role=operator` (Lucky is `employee`). Employee is the real non-admin role the estate issues and proves the same `withRole("admin")` boundary. Operator scenarios are retained and become opt-in via `-IncludeOperator`; any role without a supplied session **skips** rather than silently passing.
- **Flaky test fix.** `04-clean-default` intermittently failed on `/login` with "element(s) not found" — the page holds a spinner until the Auth.js session probe resolves, and arriving after several dashboard loads that probe outlasted the default assertion timeout. Reproduced on main before this branch.

## Verification

| Check | Result |
|---|---|
| `pnpm exec tsc --noEmit` | clean |
| `pnpm run lint` | clean |
| `pnpm test` | **801 passed** / 99 files |
| `pnpm run test:e2e` | **25 passed, 7 skipped, 0 failed** (was 24 passed + 1 flaky fail) |

The 7 skips are post-deploy probes that require production sessions.

## Not covered here

Four Baton evidence gates still need legitimate short-lived production sessions and cannot be closed locally — in particular the resident guidance flow, which needs real Baserow, uploads and Sluice, so no honest local proof exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)