### PR TITLE
fix(onboarding): stop opening the login modal over an authenticated session

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -40,7 +40,7 @@ const ROLES = ["operator", "employee", "resident"] as const
 
 export default function OnboardingPage() {
   const router = useRouter()
-  const { user, isAuthenticated, refresh } = useAuth()
+  const { user, isAuthenticated, isLoading: authLoading, refresh } = useAuth()
   const { openLoginModal } = useLoginModal()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
@@ -56,12 +56,16 @@ export default function OnboardingPage() {
 
   const profileUser = fetchedUser ?? user
 
-  // Open login modal when auth is required (but not when auth error is already handled)
+  // Open login modal when auth is required (but not when auth error is already handled).
+  // `isAuthenticated` is false while the session probe is still in flight, so this
+  // must wait for it to settle. Without that guard every visit — including a fully
+  // authenticated one — opened the login modal over the onboarding card, and
+  // nothing ever closes it again (the modal only closes on explicit dismissal).
   useEffect(() => {
-    if (!isAuthenticated && !authError) {
+    if (!authLoading && !isAuthenticated && !authError) {
       openLoginModal()
     }
-  }, [isAuthenticated, openLoginModal, authError])
+  }, [authLoading, isAuthenticated, openLoginModal, authError])
   const [confirmedRole, setConfirmedRole] = useState(false)
   const [confirmedResponsibilities, setConfirmedResponsibilities] = useState(false)
   const [selectedResponsibilities, setSelectedResponsibilities] = useState<Set<string>>(new Set())
@@ -308,7 +312,10 @@ export default function OnboardingPage() {
   return (
     <ErrorBoundary>
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-        <Card className="relative max-h-[90vh] w-full max-w-lg overflow-hidden border-white/20 bg-[#0d0d12] shadow-2xl">
+        <Card
+          className="relative max-h-[90vh] w-full max-w-lg overflow-hidden border-white/20 bg-[#0d0d12] shadow-2xl"
+          data-testid="onboarding-page"
+        >
           <button
             onClick={handleClose}
             className="absolute top-4 right-4 z-10 rounded-lg p-2 text-white/60 transition-colors hover:bg-white/10 hover:text-white"
@@ -557,13 +564,19 @@ export default function OnboardingPage() {
               </div>
 
               <div className="flex justify-end gap-2 pt-4">
-                <Button variant="outline" onClick={handleClose} className="border-white/20">
+                <Button
+                  variant="outline"
+                  onClick={handleClose}
+                  className="border-white/20"
+                  data-testid="onboarding-complete-later"
+                >
                   Complete later
                 </Button>
                 <Button
                   onClick={handleStartTutorial}
                   disabled={!confirmedRole || !confirmedResponsibilities}
                   className="bg-blue-600 hover:bg-blue-700"
+                  data-testid="onboarding-start-tutorial"
                 >
                   Start Guided Tour
                   <ArrowRight className="ml-2 h-4 w-4" />

--- a/tests/e2e/07-onboarding-theme-resilience.spec.ts
+++ b/tests/e2e/07-onboarding-theme-resilience.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, type Page } from "@playwright/test"
+import { seedSession } from "./helpers/auth"
+
+/**
+ * Onboarding saves the chosen workspace theme through an optional
+ * `PATCH /api/users/me` call. That preference must never gate completion: a user
+ * whose theme save fails still has to be able to finish onboarding and reach
+ * their dashboard.
+ *
+ * The theme save is issued from the browser, so Playwright can fail it directly
+ * without touching the server or any production state.
+ *
+ * Users resolve without Postgres in this environment, where every id except
+ * `hans` reports onboardingStatus "pending" (lib/user-management.ts) — so a
+ * seeded non-admin session lands on onboarding rather than being redirected past
+ * it.
+ */
+const pendingUser = {
+  id: "charl",
+  role: "operator" as const,
+  email: "charl@example.invalid",
+}
+
+async function failThemeSave(page: Page) {
+  await page.route("**/api/users/me", async (route) => {
+    if (route.request().method() !== "PATCH") return route.fallback()
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Update failed" }),
+    })
+  })
+}
+
+test.describe("onboarding survives a failed theme save", () => {
+  test.beforeEach(async ({ context, page }) => {
+    await seedSession(context, pendingUser)
+    await failThemeSave(page)
+  })
+
+  test("completes onboarding and reaches the dashboard when the theme PATCH fails", async ({
+    page,
+  }) => {
+    await page.goto("/onboarding")
+    await expect(page.getByTestId("onboarding-page")).toBeVisible()
+
+    const startTutorial = page.getByTestId("onboarding-start-tutorial")
+    await expect(startTutorial).toBeDisabled()
+
+    await page.locator("#confirm-role").click()
+    await page.locator("#confirm-resp").click()
+    await expect(startTutorial).toBeEnabled()
+
+    const themeSave = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/users/me") &&
+        response.request().method() === "PATCH" &&
+        response.status() === 500
+    )
+
+    await startTutorial.click()
+
+    // Prove the failure actually happened rather than passing because the call
+    // was never made.
+    await themeSave
+
+    await expect(page).toHaveURL(new RegExp(`/dashboard/${pendingUser.id}\\?tutorial=1$`))
+  })
+
+  test("leaves onboarding via Complete later when the theme PATCH fails", async ({ page }) => {
+    await page.goto("/onboarding")
+    await expect(page.getByTestId("onboarding-page")).toBeVisible()
+
+    const themeSave = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/users/me") &&
+        response.request().method() === "PATCH" &&
+        response.status() === 500
+    )
+
+    await page.getByTestId("onboarding-complete-later").click()
+    await themeSave
+
+    await expect(page).toHaveURL(new RegExp(`/dashboard/${pendingUser.id}$`))
+  })
+})


### PR DESCRIPTION
## The bug

Visiting `/onboarding` while **fully authenticated** popped the "Bound by Oath" login modal over the onboarding card and left it there, its overlay swallowing clicks on both exits.

```ts
// before
useEffect(() => {
  if (!isAuthenticated && !authError) openLoginModal()
}, [isAuthenticated, openLoginModal, authError])
```

`isAuthenticated` is `!!user`, and `user` is `null` until the session probe resolves. So the effect fired on **every** mount during the loading window — and `LoginModalProvider` has no auto-close, only explicit dismissal. Once opened, it stayed.

`dashboard-layout.tsx` gets this right by gating on `requiresAuth`, a flag set only after a real 401. Onboarding was the outlier. The fix waits for the probe to settle.

I found this because the overlay blocked every click in the E2E I was writing — which is exactly what a real user would have hit.

## Coverage added

The onboarding theme save (`PATCH /api/users/me`) is optional and must never gate completion — there's an explicit `catch {}` saying so, but nothing tested it.

Both exits are now covered with the PATCH forced to 500. The call is client-side, so `page.route()` fails it directly — no server or production state touched. Each test `await`s the intercepted 500 **before** asserting navigation, so it cannot pass by the request never being made.

Added `data-testid` to the onboarding card and both exit buttons, per the project's Next.js rule.

## Verification

| Check | Result |
|---|---|
| `pnpm exec tsc --noEmit` | clean |
| `pnpm run lint` | clean |
| `pnpm run test:e2e` | **27 passed, 7 skipped, 0 failed** (was 25) |

On the unit suite: my machine produced intermittent 10s timeouts under load, which cascaded into false mock-leak assertions in neighbouring tests. Every implicated file passes in isolation (`user-theme`, `onboarding-feedback`, `users-management`, `ai-project-suggestions`, `job-workspace` — 13/13 and 9/9), and a clean run gave 801/801. None of them touch this change. Deferring to CI as the authority.

## Relation to Baton

Closes the code-side risk on the "user-selectable themes" acceptance gate, requirement 4 (Continue must complete onboarding even when the optional theme PATCH fails). The production-session evidence that task asks for is still outstanding and unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)