### PR TITLE
test(governance): add operator-authorised durable-write acceptance probe

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "playwright test",
     "test:e2e:gate0": "playwright test tests/e2e/06-post-deploy-gate0-acceptance.spec.ts",
     "test:e2e:post-deploy-gate0": "playwright test tests/e2e/06-post-deploy-gate0-acceptance.spec.ts",
+    "test:e2e:post-deploy-governance-write": "playwright test tests/e2e/08-post-deploy-governance-write.spec.ts",
     "test:e2e:install": "npx playwright install chromium",
     "verify:alpha-review-e2e": "node scripts/verify-alpha-review-e2e.mjs tests/fixtures/alpha-review/synthetic-complete.json",
     "inngest:dev": "npx --ignore-scripts=false @inngest/cli@1.17.1 dev",

--- a/scripts/run-post-deploy-gate0.ps1
+++ b/scripts/run-post-deploy-gate0.ps1
@@ -4,7 +4,11 @@ param(
   # Production issues no identity with role=operator, so the denial probe runs as
   # an employee by default. Pass this only when a genuine operator session exists;
   # otherwise the operator scenarios skip rather than silently passing.
-  [switch]$IncludeOperator
+  [switch]$IncludeOperator,
+  # Opt in to the durable-write acceptance. This APPENDS ONE REAL RECORD to
+  # production governance storage, runs only after the read-only probes pass, and
+  # asks for the decision plus an explicit WRITE confirmation first.
+  [switch]$GovernanceWrite
 )
 
 $ErrorActionPreference = "Stop"
@@ -23,7 +27,8 @@ $environmentNames = @(
   "POST_DEPLOY_EMPLOYEE_SESSION",
   "POST_DEPLOY_ADMIN_SESSION_COOKIES",
   "POST_DEPLOY_OPERATOR_SESSION_COOKIES",
-  "POST_DEPLOY_EMPLOYEE_SESSION_COOKIES"
+  "POST_DEPLOY_EMPLOYEE_SESSION_COOKIES",
+  "POST_DEPLOY_GOVERNANCE_DECISION"
 )
 
 function Read-SecretToProcessEnvironment {
@@ -80,6 +85,36 @@ try {
   # a console-only reporter as a second boundary so no HTML report is retained.
   & pnpm run test:e2e:post-deploy-gate0 -- --reporter=line
   $exitCode = $LASTEXITCODE
+
+  if ($GovernanceWrite) {
+    if ($exitCode -ne 0) {
+      Write-Host "Read-only acceptance failed. Refusing to run the mutating governance write." -ForegroundColor Yellow
+    } else {
+      # Governance content is not a secret — it is recorded verbatim in an
+      # append-only production record — so it is echoed back for confirmation
+      # before anything is written.
+      Write-Host ""
+      Write-Host "The next step APPENDS ONE REAL RECORD to production governance storage." -ForegroundColor Yellow
+      Write-Host 'Supply the decision as JSON, e.g.' -ForegroundColor Yellow
+      Write-Host '  {"decisionId":"O1","status":"approved_in_principle","rationale":"Owner accepted ...","evidenceRefs":[]}'
+      $decision = Read-Host -Prompt "POST_DEPLOY_GOVERNANCE_DECISION"
+
+      if ([string]::IsNullOrWhiteSpace($decision)) {
+        Write-Host "No decision supplied; skipping the governance write." -ForegroundColor Yellow
+      } else {
+        Write-Host ""
+        Write-Host "About to write: $decision"
+        $confirm = Read-Host -Prompt "Type WRITE to confirm"
+        if ($confirm -ceq "WRITE") {
+          [Environment]::SetEnvironmentVariable("POST_DEPLOY_GOVERNANCE_DECISION", $decision, "Process")
+          & pnpm run test:e2e:post-deploy-governance-write -- --reporter=line
+          $exitCode = $LASTEXITCODE
+        } else {
+          Write-Host "Not confirmed; nothing was written." -ForegroundColor Yellow
+        }
+      }
+    }
+  }
 } finally {
   foreach ($name in $environmentNames) {
     [Environment]::SetEnvironmentVariable($name, $previousEnvironment[$name], "Process")

--- a/tests/e2e/08-post-deploy-governance-write.spec.ts
+++ b/tests/e2e/08-post-deploy-governance-write.spec.ts
@@ -1,0 +1,179 @@
+import { expect, test, type APIRequestContext, type BrowserContext } from "@playwright/test"
+import { seedSession } from "./helpers/auth"
+import { productionSessionCookies, type SessionCookie } from "./helpers/production-session"
+
+/**
+ * Durable-write acceptance for the Gate governance store.
+ *
+ * This is the only probe in the suite that MUTATES production. It appends one
+ * real, append-only governance record, so the decision it records is supplied by
+ * the operator at run time rather than hardcoded here — a probe must not assert a
+ * governance position on the owner's behalf.
+ *
+ * Supply POST_DEPLOY_GOVERNANCE_DECISION as JSON, e.g.
+ *   {"decisionId":"O1","status":"approved_in_principle","rationale":"...","evidenceRefs":[]}
+ * Without it the probe skips rather than inventing a decision.
+ *
+ * Exactly one new record is written. The idempotent replay returns the existing
+ * event, and the stale-version case is rejected before any insert, so neither
+ * adds history.
+ *
+ * Restart persistence is deliberately NOT covered here: it needs an app restart
+ * between two reads, which is an operator step outside a single Playwright run.
+ * Re-running the read-only assertions after a restart completes that leg.
+ */
+const baseUrl = process.env.BASE_URL
+const isPostDeployProbe = process.env.POST_DEPLOY_PROBE === "true"
+const adminSessionCookies = productionSessionCookies("admin")
+
+const GATE_ID = "under-sink-leak-gate-0"
+const PROTOCOL_VERSION = "v1-draft"
+
+type OperatorDecision = {
+  decisionId: "O1" | "O2" | "O3" | "O4" | "O7"
+  status: "approved_in_principle" | "rejected" | "superseded"
+  rationale: string
+  evidenceRefs?: string[]
+}
+
+/**
+ * Reject anything that could activate a decision or touch the reviewer (O5) and
+ * privacy-protocol (O6) decisions, whose activation carries recruitment and
+ * personal-data consequences. Those must stay inactive, so this probe refuses
+ * them outright rather than relying on the server to fail closed.
+ */
+function parseOperatorDecision(): OperatorDecision | null {
+  const raw = process.env.POST_DEPLOY_GOVERNANCE_DECISION
+  if (!raw) return null
+
+  const parsed = JSON.parse(raw) as OperatorDecision
+
+  if (parsed.decisionId === ("O5" as string) || parsed.decisionId === ("O6" as string)) {
+    throw new Error(
+      "This probe refuses O5 and O6. Activating either has recruitment or personal-data consequences and must not be driven by an automated probe."
+    )
+  }
+  if ((parsed.status as string) === "active") {
+    throw new Error(
+      "This probe refuses status 'active'. Activation must never be triggered automatically."
+    )
+  }
+  if (!parsed.rationale || parsed.rationale.trim().length < 3) {
+    throw new Error("A rationale is required so the recorded decision is self-explaining.")
+  }
+
+  return parsed
+}
+
+const operatorDecision = (() => {
+  try {
+    return parseOperatorDecision()
+  } catch (error) {
+    // Surface a misconfigured decision as a failure at run time, not a silent skip.
+    return error as Error
+  }
+})()
+
+async function addSessionCookies(context: BrowserContext, sessionCookies: SessionCookie[]) {
+  const hostname = new URL(baseUrl!).hostname
+  await context.addCookies(
+    sessionCookies.map(({ name, value }) => ({
+      name,
+      value,
+      domain: hostname,
+      path: "/",
+      httpOnly: true,
+      secure: true,
+      sameSite: "Lax",
+    }))
+  )
+}
+
+async function readDecision(request: APIRequestContext, decisionId: string) {
+  const response = await request.get("/api/governance/gates")
+  expect(
+    response.status(),
+    "Governance read must succeed before a write is attempted. 503 means the datastore is unreachable — stop and fix that first."
+  ).toBe(200)
+
+  const body = await response.json()
+  const projection = body.data.decisions.find(
+    (entry: { definition: { id: string } }) => entry.definition.id === decisionId
+  )
+  expect(projection, `Decision ${decisionId} must exist in the projection`).toBeTruthy()
+  return projection as { current: { version: number; id: string; status: string } | null }
+}
+
+test.describe("Post-deployment Gate governance durable write", () => {
+  test.skip(
+    !isPostDeployProbe || !baseUrl || adminSessionCookies.length === 0,
+    "Requires POST_DEPLOY_PROBE, BASE_URL, and a legitimate short-lived admin session."
+  )
+  test.skip(
+    operatorDecision === null,
+    "Requires POST_DEPLOY_GOVERNANCE_DECISION describing the decision the owner is recording."
+  )
+
+  test.beforeEach(async ({ context }) => {
+    if (isPostDeployProbe) {
+      await addSessionCookies(context, adminSessionCookies)
+      return
+    }
+    await seedSession(context, { id: "hans", role: "admin", email: "admin@example.invalid" })
+  })
+
+  test("persists an appended decision and survives a re-read", async ({ page }) => {
+    if (operatorDecision instanceof Error) throw operatorDecision
+    const decision = operatorDecision!
+
+    const before = await readDecision(page.request, decision.decisionId)
+    const expectedVersion = before.current?.version ?? 0
+    const idempotencyKey = crypto.randomUUID()
+
+    const body = {
+      gateId: GATE_ID,
+      protocolVersion: PROTOCOL_VERSION,
+      decisionId: decision.decisionId,
+      status: decision.status,
+      rationale: decision.rationale,
+      evidenceRefs: decision.evidenceRefs ?? [],
+      expectedVersion,
+      idempotencyKey,
+    }
+
+    // 1. Append — the single mutating call in this suite.
+    const created = await page.request.post("/api/governance/gates", { data: body })
+    expect(created.status(), await created.text()).toBe(201)
+    const createdBody = await created.json()
+    expect(createdBody.summary.created).toBe(true)
+    expect(createdBody.data.storage).toBe("mongodb")
+    expect(createdBody.data.event.version).toBe(expectedVersion + 1)
+    // The actor must come from the session, never from the request body.
+    expect(createdBody.data.event.actorRole).toBe("admin")
+    expect(createdBody.data.event.actorId).toBeTruthy()
+
+    // 2. Durable read-back through a fresh request.
+    const after = await readDecision(page.request, decision.decisionId)
+    expect(after.current?.version).toBe(expectedVersion + 1)
+    expect(after.current?.status).toBe(decision.status)
+    expect(after.current?.id).toBe(createdBody.data.event.id)
+
+    // 3. Idempotent replay must return the same event and write nothing new.
+    const replay = await page.request.post("/api/governance/gates", { data: body })
+    expect(replay.status()).toBe(200)
+    const replayBody = await replay.json()
+    expect(replayBody.summary.created).toBe(false)
+    expect(replayBody.data.event.id).toBe(createdBody.data.event.id)
+
+    // 4. A stale expectedVersion must be rejected before any insert.
+    const stale = await page.request.post("/api/governance/gates", {
+      data: { ...body, expectedVersion, idempotencyKey: crypto.randomUUID() },
+    })
+    expect(stale.status()).toBe(409)
+
+    // 5. History grew by exactly one.
+    const final = await readDecision(page.request, decision.decisionId)
+    expect(final.current?.version).toBe(expectedVersion + 1)
+    expect(final.current?.id).toBe(createdBody.data.event.id)
+  })
+})


### PR DESCRIPTION
## What this is

The last automated gap on the Gate governance evidence gate: **durable write and read-back against the real production store.**

This is the only probe in the suite that mutates production, so it's built to be refusable rather than convenient.

## Safety design

- **The decision is supplied by the operator at run time** via `POST_DEPLOY_GOVERNANCE_DECISION`, never hardcoded. A probe must not assert a governance position on the owner's behalf. Without it, the spec skips.
- **O5 and O6 are refused outright.** Activating the reviewer or privacy-protocol decisions carries recruitment and personal-data consequences — the probe rejects them locally rather than trusting the server to fail closed.
- **`status: "active"` is refused** for the same reason.
- **Exactly one record is written.** The idempotent replay returns the existing event; the stale-version case is rejected before any insert. Both are asserted, and the final read confirms history grew by exactly one.
- **A 503 stops the run before any write**, with an explicit message pointing at the unreachable datastore.

## What it pins

Beyond persistence, the assertions cover the properties this gate actually cares about:

| Assertion | Why |
|---|---|
| `storage === "mongodb"` | proves it isn't silently on the in-memory repository |
| `actorRole` / `actorId` present | actor is server-derived from the session, not the request body |
| `version === expectedVersion + 1` | optimistic concurrency is real |
| replay → `created: false`, same event id | idempotency key works |
| stale version → `409` | concurrent writes can't clobber |

## Out of scope, deliberately

**Restart persistence.** It needs an app restart between two reads — an operator step, not something one Playwright run can stage. Re-running the read-only assertions after a restart completes that leg. Noted in the spec rather than faked.

## Runner

`-GovernanceWrite` runs only after the read-only probes pass, echoes the decision back, and requires a case-sensitive `WRITE` confirmation:

```
pwsh scripts/run-post-deploy-gate0.ps1 -GovernanceWrite
```

## Verification

| Check | Result |
|---|---|
| `pnpm exec tsc --noEmit` | clean |
| `pnpm run lint` | clean |
| `pnpm run test:e2e` | **27 passed, 8 skipped, 0 failed** |

The new spec is among the skips locally, as intended — it requires `POST_DEPLOY_PROBE`, a production admin session, and an explicit decision.

**It has not been executed against production.** That needs a legitimate short-lived admin session, which this branch does not and must not contain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)