### PR TITLE
fix(observability): route logger output into Azure Monitor

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,11 +1,55 @@
+// Type-only, so it is erased at compile time and never pulls lib/logger into a
+// runtime that cannot load it.
+import type { LogLevel } from "@/lib/logger"
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
       const azureMonitor = await import("@azure/monitor-opentelemetry")
       azureMonitor.useAzureMonitor()
+      await bridgeLoggerToAzureMonitor()
     }
 
     const { logger } = await import("@/lib/logger")
     logger.info("Next.js server starting")
   }
+}
+
+/**
+ * Route `lib/logger` output into Azure Monitor.
+ *
+ * `useAzureMonitor()` auto-instruments requests and dependencies but does not
+ * capture plain `console` calls, so every `logger.*` line was reaching stdout and
+ * nothing else — the App Insights `traces` and `exceptions` tables stayed empty
+ * while `requests` and `dependencies` filled up. That made server-side failures
+ * invisible in production, including the MongoDB connection errors needed to
+ * diagnose the Gate governance datastore.
+ *
+ * Emitting through the OpenTelemetry logs API sends entries to whichever provider
+ * `useAzureMonitor()` registered. This must run after it, and only in the Node
+ * runtime, since the SDK cannot load on the Edge runtime.
+ */
+async function bridgeLoggerToAzureMonitor() {
+  const { logs, SeverityNumber } = await import("@opentelemetry/api-logs")
+  const { setLogSink } = await import("@/lib/logger")
+
+  const severityByLevel: Record<LogLevel, number> = {
+    debug: SeverityNumber.DEBUG,
+    info: SeverityNumber.INFO,
+    warn: SeverityNumber.WARN,
+    error: SeverityNumber.ERROR,
+  }
+
+  const otelLogger = logs.getLogger("house-of-veritas")
+
+  setLogSink(({ level, message, timestamp, ...attributes }) => {
+    otelLogger.emit({
+      severityNumber: severityByLevel[level],
+      severityText: level.toUpperCase(),
+      body: message,
+      // `timestamp` is dropped from the attributes because the log record carries
+      // its own; the rest of the structured metadata is preserved for querying.
+      attributes: attributes as Record<string, string | number | boolean>,
+    })
+  })
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,10 +1,27 @@
-type LogLevel = "debug" | "info" | "warn" | "error"
+export type LogLevel = "debug" | "info" | "warn" | "error"
 
-interface LogEntry {
+export interface LogEntry {
   level: LogLevel
   message: string
   timestamp: string
   [key: string]: unknown
+}
+
+export type LogSink = (entry: LogEntry) => void
+
+/**
+ * Optional second destination for log entries, installed at startup by
+ * `instrumentation.ts` when Azure Monitor is configured.
+ *
+ * The sink is injected rather than imported here on purpose: this module is
+ * reachable from the Edge runtime, which cannot load the OpenTelemetry SDK, and
+ * keeping the dependency in the Node-only instrumentation hook avoids pulling it
+ * in where it cannot run.
+ */
+let sink: LogSink | null = null
+
+export function setLogSink(next: LogSink | null): void {
+  sink = next
 }
 
 const LOG_LEVELS: Record<LogLevel, number> = {
@@ -28,6 +45,14 @@ function emit(entry: LogEntry) {
     console.warn(output)
   } else {
     console.log(output)
+  }
+
+  if (!sink) return
+  try {
+    sink(entry)
+  } catch {
+    // Telemetry is never allowed to break the code path that logged. The console
+    // line above has already been written, so the entry is not lost.
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@azure/storage-blob": "^12.31.0",
     "@emotion/is-prop-valid": "latest",
     "@hookform/resolvers": "^3.10.0",
+    "@opentelemetry/api-logs": "^0.219.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.71.2(react@19.2.0))
+      '@opentelemetry/api-logs':
+        specifier: ^0.219.0
+        version: 0.219.0
       '@radix-ui/react-accordion':
         specifier: 1.2.2
         version: 1.2.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)

--- a/tests/lib/logger-sink.test.ts
+++ b/tests/lib/logger-sink.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { logger, setLogSink, type LogEntry } from "@/lib/logger"
+
+describe("logger sink", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {})
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+    vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    setLogSink(null)
+    vi.restoreAllMocks()
+  })
+
+  it("forwards entries to an installed sink with level, message and metadata", () => {
+    const received: LogEntry[] = []
+    setLogSink((entry) => received.push(entry))
+
+    logger.error("MongoDB connection error", { error: "connection timed out" })
+
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({
+      level: "error",
+      message: "MongoDB connection error",
+      error: "connection timed out",
+    })
+    expect(received[0].timestamp).toBeTruthy()
+  })
+
+  it("still writes to the console when a sink is installed", () => {
+    setLogSink(() => {})
+
+    logger.error("boom")
+
+    expect(console.error).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not let a failing sink break the caller", () => {
+    setLogSink(() => {
+      throw new Error("exporter unavailable")
+    })
+
+    // Telemetry must never propagate into the path that logged.
+    expect(() => logger.error("boom")).not.toThrow()
+    expect(console.error).toHaveBeenCalledTimes(1)
+  })
+
+  it("stops forwarding once the sink is removed", () => {
+    const received: LogEntry[] = []
+    setLogSink((entry) => received.push(entry))
+    logger.info("first")
+
+    setLogSink(null)
+    logger.info("second")
+
+    expect(received.map((entry) => entry.message)).toEqual(["first"])
+  })
+
+  it("respects the level threshold before reaching the sink", () => {
+    const received: LogEntry[] = []
+    setLogSink((entry) => received.push(entry))
+
+    // LOG_LEVEL defaults to "info", so debug is filtered out before emit.
+    logger.debug("noisy")
+
+    expect(received).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## The problem

App Insights `traces` and `exceptions` were **completely empty over a 90-day window**, while `requests`, `dependencies` and `customMetrics` filled up normally.

`useAzureMonitor()` auto-instruments HTTP and dependency calls but does **not** capture plain `console` output — and `lib/logger.ts` writes via `console.*`. So every `logger.*` call in the codebase reached stdout and nothing else.

Every server-side failure was invisible in production telemetry. That includes the `MongoDB connection error` line the Gate governance investigation depends on, which is how I found this: I told you to read that line out of App Insights, then discovered it could never have been there.

## The fix

Emit log entries through the OpenTelemetry logs API so they reach the provider `useAzureMonitor()` already registers.

**The sink is injected from `instrumentation.ts`, not imported inside `lib/logger.ts`.** That module is reachable from the Edge runtime, which cannot load the OTel SDK — keeping the dependency in the Node-only instrumentation hook avoids pulling it in where it can't run. The `LogLevel` import there is type-only and erased at compile time for the same reason.

Two deliberate properties:
- **Console output is retained**, so local development and container logs are unchanged.
- **A throwing sink is swallowed.** Telemetry must never break the code path that logged, and the console line has already been written by then.

`@opentelemetry/api-logs` is promoted to an explicit dependency — it was only present transitively and is now imported directly.

## Scope limit

This populates **`traces`, not `exceptions`** — errors arrive as log records with severity `ERROR`. Exception telemetry needs a separate call and isn't required to read the connection failures this unblocks. Calling it out so nobody expects `exceptions` to fill up.

## Verification

| Check | Result |
|---|---|
| `pnpm exec tsc --noEmit` | clean |
| `pnpm run lint` | clean |
| `pnpm run build` | clean |
| `pnpm test` | **806 passed** / 100 files |
| `pnpm run test:e2e` | **27 passed, 8 skipped, 0 failed** |

Five new tests cover the sink: forwarding with level/message/metadata, console output preserved, a throwing sink not propagating, removal, and the level threshold applying before the sink.

## Verifying after deploy

Once merged, a server-side error should appear in `traces`. Quickest confirmation — the startup line is logged on every boot:

```bash
az monitor app-insights query --app 071a085a-1a61-43bb-b558-48c466cec0d7 --analytics-query "traces | where timestamp > ago(1h) | project timestamp, message, severityLevel | order by timestamp desc | take 20"
```

Expect `Next.js server starting`. Empty means the bridge didn't take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)