### PR TITLE
chore: ignore Playwright CLI console captures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ test-results/
 playwright-report/
 playwright/.cache/
 blob-report/
+# Browser console captures; production probe runs record live page output here.
+.playwright-cli/
 
 # Local dev-run output logs
 output/


### PR DESCRIPTION
## Summary

`.playwright-cli/` accumulates browser console captures from CLI-driven Playwright runs. Locally it currently holds 17 logs, several recorded against **production** (`https://hov.neuralliquid.ai`). The directory is untracked but not ignored, so a `git add -A` would commit production console output.

That is the same class of artifact the Gate 0 probe policy already refuses to emit — `productionProbePolicy` returns `trace: "off"` and `screenshot: "off"` for post-deploy probes precisely because production run artifacts retain live session and UI data. The console capture path was the remaining gap.

## Changes

- `.gitignore` — ignore `.playwright-cli/`, alongside the existing `test-results/` / `playwright-report/` / `blob-report/` entries.

No tracked files are affected, so nothing is removed from history by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)