### PR TITLE
fix(api): stop probing Baserow once Postgres is the active backend

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -30,10 +30,20 @@ function serviceBaseUrl(url: string | undefined): string | undefined {
 }
 
 export async function GET() {
+  const estate = getEstateRepository()
+
+  // Probe Baserow only when Baserow is the store actually in use. This used to
+  // key off `estate.isConfigured()`, which conflated "the estate repository is
+  // configured" with "Baserow is configured" — fine while Baserow was the only
+  // backend, wrong the moment ESTATE_BACKEND=postgres. On cutover it started
+  // pinging a Baserow instance that had never been configured, which answered
+  // "down" and reported the whole service degraded while it was in fact healthy.
+  const baserowInUse = estate.backend === "baserow" && estate.isConfigured()
+
   const checks = await Promise.all([
     checkService(
       "baserow",
-      getEstateRepository().isConfigured()
+      baserowInUse
         ? serviceBaseUrl(process.env.BASEROW_API_URL || process.env.NEXT_PUBLIC_BASEROW_URL)
         : undefined,
       "/api/_health/"
@@ -53,7 +63,11 @@ export async function GET() {
     {
       status: overall ? "healthy" : "degraded",
       build: { commit: buildCommit },
-      dataMode: getEstateRepository().isConfigured()
+      // Which store is actually backing estate data. Reported because "is this
+      // deployment on Postgres yet?" was previously only answerable by reading
+      // app settings, and dataMode alone cannot distinguish the backends.
+      backend: estate.backend,
+      dataMode: estate.isConfigured()
         ? "live"
         : process.env.ALLOW_DEMO_DATA === "true"
           ? "demo"

--- a/tests/api/health.test.ts
+++ b/tests/api/health.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect } from "vitest"
+import { afterEach, describe, it, expect } from "vitest"
 import { GET } from "@/app/api/health/route"
 
 describe("GET /api/health", () => {
+  const originalBackend = process.env.ESTATE_BACKEND
+  const originalBaserowUrl = process.env.BASEROW_API_URL
+
+  afterEach(() => {
+    if (originalBackend === undefined) delete process.env.ESTATE_BACKEND
+    else process.env.ESTATE_BACKEND = originalBackend
+    if (originalBaserowUrl === undefined) delete process.env.BASEROW_API_URL
+    else process.env.BASEROW_API_URL = originalBaserowUrl
+  })
+
   it("returns 200 with health status", async () => {
     const response = await GET()
     expect(response.status).toBe(200)
@@ -14,5 +24,34 @@ describe("GET /api/health", () => {
     expect(data).toHaveProperty("timestamp")
     expect(response.headers.get("cache-control")).toContain("no-store")
     expect(response.headers.get("pragma")).toBe("no-cache")
+  })
+
+  it("reports which store is backing estate data", async () => {
+    const data = await (await GET()).json()
+    expect(["baserow", "postgres"]).toContain(data.backend)
+  })
+
+  /**
+   * Regression guard for the 2026-08-07 cutover.
+   *
+   * The Baserow probe used to be gated on `getEstateRepository().isConfigured()`,
+   * which is true whenever *any* backend is configured. On switching to Postgres
+   * that started pinging a Baserow instance which had never been configured; it
+   * answered "down", and the endpoint reported the whole service degraded while
+   * production was in fact healthy.
+   *
+   * Baserow is unconfigured in the test environment either way, so the assertion
+   * is on the probe being skipped rather than on the request outcome — that is
+   * the actual behaviour change, and it holds without any network access.
+   */
+  it("does not probe Baserow when it is not the active backend", async () => {
+    process.env.ESTATE_BACKEND = "postgres"
+    process.env.BASEROW_API_URL = "https://baserow.invalid/api"
+
+    const data = await (await GET()).json()
+    const baserow = data.services.find((s: { name: string }) => s.name === "baserow")
+
+    expect(baserow.status).toBe("unconfigured")
+    expect(baserow.latencyMs).toBeNull()
   })
 })


### PR DESCRIPTION
Production was cut over to PostgreSQL today. `/api/health` immediately began reporting `"status": "degraded"` while the service was in fact healthy.

## Cause

The Baserow probe was gated on `getEstateRepository().isConfigured()` — which is true whenever *any* backend is configured. That was fine while Baserow was the only backend, and wrong the moment `ESTATE_BACKEND=postgres`.

So on cutover the endpoint started pinging a Baserow instance that had never been configured, got `down` back, and downgraded overall status:

```json
{"status":"degraded","dataMode":"live",
 "services":[{"name":"baserow","status":"down","latencyMs":302}, ...]}
```

Nothing about the deployment was unhealthy. The check was asking the wrong question.

## Fix

Gate the probe on Baserow actually being the active store (`backend === "baserow" && isConfigured()`).

## Also

The response gains a `backend` field. Whether a deployment was on Postgres yet was previously only answerable by reading app settings — `dataMode` says *a* store is configured, not which one — and that gap made today's cutover meaningfully harder to verify.

## Tests

A regression guard asserting the probe is skipped when Postgres is active, plus a check that `backend` is reported. Baserow is unconfigured in the test environment either way, so the assertion is on the probe being skipped rather than on a request outcome — that is the actual behaviour change, and it needs no network access.

`tsc` and `eslint` clean.

Note: the unit suite is intermittently flaky in this repo — one run of this file reported "no tests, 1 error" before passing cleanly. That predates these changes (see #186) and is worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)