### PR TITLE
docs(infra): warn that the OIDC issuer default does not match production

### DIFF
--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -551,12 +551,30 @@ variable "custom_domain" {
 # -----------------------------------------------------------------------------
 # Auth.js v5 + Mystira OIDC (relying party: neuralliquid-hov-web)
 # -----------------------------------------------------------------------------
-# The issuer defaults to the production Mystira Identity host that HOV currently
-# authenticates against. The issuer host is public config, not a secret; keep the
-# client secret in Key Vault and reference it via
-# mystira_oidc_client_secret_key_vault_secret_name.
+# WARNING: this default does NOT match production. Verified 2026-08-07.
+#
+#   default (here):  https://identity.mystira.app
+#   nl-prod-hov-app: https://mys-dev-id-webapi.azurewebsites.net
+#
+# Production authenticates against the *dev* Mystira Identity host, with a
+# dev-default client secret. So a plain `terraform apply` will flip production
+# authentication to the production IdP while leaving the client secret pointing
+# at the dev one — which will break sign-in, not fix it. A real plan on
+# 2026-08-07 showed exactly that change queued.
+#
+# Until the move is done deliberately, pin the live value for any apply:
+#
+#   -var 'mystira_oidc_issuer=https://mys-dev-id-webapi.azurewebsites.net'
+#
+# Completing the move means registering HOV at identity.mystira.app with the
+# right redirect URIs, issuing a client secret there, storing it in
+# nl-prod-hov-kv, and changing issuer and secret together. See
+# docs/handoffs/2026-07-23-hov-mystira-oidc-prod-closeout.md.
+#
+# The issuer host is public config, not a secret; keep the client secret in Key
+# Vault and reference it via mystira_oidc_client_secret_key_vault_secret_name.
 variable "mystira_oidc_issuer" {
-  description = "Mystira OIDC issuer URL"
+  description = "Mystira OIDC issuer URL. NOTE: the default does not match production — see the comment above before applying."
   type        = string
   default     = "https://identity.mystira.app"
 }


### PR DESCRIPTION
Found while cutting production over to PostgreSQL. The comment above `mystira_oidc_issuer` claimed the default was *"the production Mystira Identity host that HOV currently authenticates against"*. It is not.

Verified 2026-08-07:

| | Value |
| --- | --- |
| Terraform default | `https://identity.mystira.app` |
| `nl-prod-hov-app` live | `https://mys-dev-id-webapi.azurewebsites.net` |

Production authenticates against the **dev** Identity host, with a dev-default client secret.

## Why this matters

A plain `terraform apply` flips production authentication to the production IdP **while leaving the client secret pointing at the dev one** — which breaks sign-in rather than fixing it.

Not theoretical: a real plan during today's cutover had exactly that change queued, and the cutover apply had to pin the live value to avoid taking it along:

```
~ MYSTIRA_OIDC_ISSUER: "https://mys-dev-id-webapi.azurewebsites.net" -> "https://identity.mystira.app"
```

This is the same class of trap as the `DB_HOST` revert found in convolens today — configuration that silently disagrees with the deployment it describes, waiting for whoever applies next.

## No behaviour change

The default is left alone deliberately. Correcting it means registering HOV at `identity.mystira.app` with the right redirect URIs, issuing a client secret there, storing it in `nl-prod-hov-kv`, and changing issuer and secret **together**. That is an auth migration, not a variable edit, and it needs someone able to verify sign-in end to end.

Until then the comment tells you to pin the live value, and how.

🤖 Generated with [Claude Code](https://claude.com/claude-code)