### PR TITLE
fix(users): create the users table before altering it

### DIFF
--- a/lib/user-management.ts
+++ b/lib/user-management.ts
@@ -1,4 +1,4 @@
-import { isPostgresConfigured, query, withClient } from "@/lib/db/postgres"
+import { ensureSchema, isPostgresConfigured, query, withClient } from "@/lib/db/postgres"
 import { User, UserRole, findUserByIdAsync, getAllUsersAsync } from "@/lib/users"
 import { defaultUserThemeForColor, isUserThemeId } from "@/lib/user-themes"
 
@@ -25,6 +25,17 @@ let schemaEnsured = false
 
 async function ensureUserManagementSchema(): Promise<void> {
   if (!schemaEnsured && isPostgresConfigured()) {
+    // Everything below is ALTER TABLE users — additive columns on a table this
+    // module does not create. ensureSchema() owns `users`, and it is idempotent,
+    // so establishing that dependency here costs nothing and removes the
+    // assumption that some other caller happened to run first.
+    //
+    // On a database where nothing had yet created `users`, the first ALTER threw
+    // 42P01 relation "users" does not exist. That was invisible while Baserow was
+    // the backend — isPostgresConfigured() was false, so none of this ran — and
+    // surfaced immediately on the 2026-08-07 Postgres cutover.
+    await ensureSchema()
+
     await withClient(async (client) => {
       await client.query(`
         DO $$ BEGIN

--- a/tests/lib/user-management-schema.test.ts
+++ b/tests/lib/user-management-schema.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Schema ordering for the user-management module.
+ *
+ * Everything this module does to `users` is ALTER TABLE — it adds columns to a
+ * table owned by `ensureSchema()` in lib/db/postgres. It used to assume some
+ * other caller had already created that table. On a database where nothing had,
+ * the first ALTER threw `42P01 relation "users" does not exist`.
+ *
+ * That was invisible for as long as Baserow was the backend, because
+ * isPostgresConfigured() was false and none of this ran. It surfaced the moment
+ * production moved to Postgres on 2026-08-07.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const postgres = vi.hoisted(() => ({
+  ensureSchema: vi.fn(),
+  isPostgresConfigured: vi.fn(() => true),
+  query: vi.fn(),
+  withClient: vi.fn(),
+}))
+
+vi.mock("@/lib/db/postgres", () => postgres)
+
+describe("user-management schema bootstrap", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    postgres.ensureSchema.mockReset()
+    postgres.isPostgresConfigured.mockReturnValue(true)
+    postgres.query.mockReset()
+    postgres.query.mockResolvedValue({ rows: [], rowCount: 0 })
+    postgres.withClient.mockReset()
+    postgres.withClient.mockResolvedValue(undefined)
+  })
+
+  it("creates the base schema before altering users", async () => {
+    const { getAllUsersWithManagement } = await import("@/lib/user-management")
+    await getAllUsersWithManagement()
+
+    expect(postgres.ensureSchema).toHaveBeenCalled()
+
+    // Ordering is the whole point: the ALTERs run inside withClient, and they
+    // fail outright if the table does not exist yet.
+    const ensuredAt = postgres.ensureSchema.mock.invocationCallOrder[0]
+    const alteredAt = postgres.withClient.mock.invocationCallOrder[0]
+    expect(ensuredAt).toBeLessThan(alteredAt)
+  })
+
+  it("does not touch Postgres at all when it is not configured", async () => {
+    postgres.isPostgresConfigured.mockReturnValue(false)
+
+    const { getAllUsersWithManagement } = await import("@/lib/user-management")
+    await getAllUsersWithManagement()
+
+    expect(postgres.ensureSchema).not.toHaveBeenCalled()
+    expect(postgres.withClient).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Found while verifying today's Postgres cutover. Production's estate database has the 18 estate tables but **no `users` and no `audit_logs`**, and App Insights recorded:

```
42P01: relation "users" does not exist
```

## Cause

`ensureUserManagementSchema()` is entirely `ALTER TABLE users` — additive columns on a table it does not own. `users` is created by `ensureSchema()` in `lib/db/postgres`, and this module assumed some other caller had already run it. On a database where nothing had, the first `ALTER` threw.

That assumption was invisible for as long as Baserow was the backend: `isPostgresConfigured()` was false, so none of this code ran at all. It surfaced the moment production moved to Postgres.

## Fix

Call `ensureSchema()` first. It is idempotent, so depending on it explicitly costs nothing and removes the ordering assumption.

`lib/users.ts` and `lib/uploads.ts` already do this. A scan of every `ALTER TABLE` in `lib/` confirms this module was the only outlier.

## Blast radius, honestly

**Sign-in was not affected.** `findUserByEmailAsync` goes through `ensureUsersSchemaOnce`, which *does* call `ensureSchema`, so the login path creates and seeds the table on first use. The failure was confined to the user-management admin path — which is why the error appeared once rather than continuously.

The missing tables will be created by whichever path runs first after this deploys.

## Tests

`tests/lib/user-management-schema.test.ts` asserts `ensureSchema()` runs *before* the ALTERs (via `invocationCallOrder`, since ordering is the whole point), and that nothing touches Postgres when it is unconfigured.

`tsc` and `eslint` clean.

Note: this repo's unit suite is intermittently flaky — this file reported "no tests, 1 error" on one run and passed cleanly on the next. Pre-existing, see #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)