### PR TITLE
test: give the heaviest tests timeout headroom

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,18 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     globals: true,
-    testTimeout: 10000,
+    // The heaviest component tests land within a few percent of a 10s budget, so
+    // on a loaded machine they tip over and the suite fails for no reason that
+    // reflects the code. One observed failure came in at 10255ms — a 2.5%
+    // overshoot — while the same file passes comfortably when run alone.
+    //
+    // This is headroom, not a way to hide a hang: a genuinely stuck test still
+    // fails, just 20s later. The real cost driver is that every one of the 116
+    // test files builds a happy-dom environment, including the API and lib suites
+    // that never touch a DOM. Moving those to the node environment is the actual
+    // fix and a larger change than raising a limit.
+    testTimeout: 20000,
+    hookTimeout: 20000,
     setupFiles: ["./tests/setup.ts"],
     include: ["tests/**/*.test.{ts,tsx}"],
     // Inline next-auth so vite transforms it (rather than letting Node


### PR DESCRIPTION
The suite fails intermittently for reasons that have nothing to do with the code. Across repeated full runs today it produced 0, 1, 6 and 7 failures on identical commits, and the failing files moved around each time.

## What it actually is

Captured:

```
FAIL tests/components/recipe-guidance-ui.test.tsx
Error: Test timed out in 10000ms.        (the test took 10255ms)
```

A **2.5% overshoot**. The same file passes comfortably run on its own. That is a timing margin, not a defect — and notably it is a *component* test, unrelated to the Postgres work that was landing today.

## Change

`testTimeout` 10s → 20s, `hookTimeout` with it.

This is headroom, not a way to hide a hang: a genuinely stuck test still fails, twenty seconds later instead of ten. Nothing is being made to pass that was failing on its merits.

## The real cost driver, not fixed here

All 116 test files construct a `happy-dom` environment — including every API and lib suite that never touches a DOM. Cumulative environment setup runs to several times the time spent actually executing tests (`environment 1274s` against `tests 123s` on one run).

Moving the non-DOM suites to the `node` environment is the actual fix. That is a materially larger change with its own risk of destabilising things, so it is left as follow-up rather than bundled into a one-line limit change.

## Verification

Full suite green before and after on a quiet machine: **1068 passed, 5 skipped**.

Worth noting for anyone reading the earlier PRs: I described this flakiness in #186, #187 and #189 without having isolated it. It is pre-existing and unrelated to those changes, which this confirms — but "pre-existing flakiness" was an observation at the time, not a diagnosis. This is the diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)