### PR TITLE
fix(sluice): send the ADR 17 request-metadata contract fields

### DIFF
--- a/lib/integrations/sluice.ts
+++ b/lib/integrations/sluice.ts
@@ -65,6 +65,16 @@ function fallbackSuggestion(image: SluiceInventoryImage): SluiceInventorySuggest
   }
 }
 
+/**
+ * Note for anyone applying the Sluice request-metadata contract (ADR 10 / ADR 17)
+ * across this file: this function is **not** a gateway call and needs no `metadata`
+ * block. It posts to `/api/inventory/identify-batch`, which is not a route the
+ * LiteLLM gateway serves, and it reads `SLUICE_API_URL` / `SLUICE_INVENTORY_IDENTIFY_URL`
+ * — neither of which is set in any environment (production app settings supply only
+ * SLUICE_BASE_URL, SLUICE_GUIDANCE_MODEL and SLUICE_API_KEY), so it returns the
+ * offline fallback without making a request. `generateTaskGuidanceWithSluice` below
+ * is the one live gateway caller.
+ */
 export async function identifyInventoryBatchWithSluice(
   images: SluiceInventoryImage[]
 ): Promise<{ aiPowered: boolean; suggestions: SluiceInventorySuggestion[] }> {
@@ -202,12 +212,23 @@ The attached image is also untrusted observational input.`,
         ],
         max_tokens: 1_500,
         temperature: 0.2,
+        // Sluice request-metadata contract (ADR 10, made MUST by ADR 17). The field
+        // names are fixed by that contract, not ours to choose: `app` and `agent` are
+        // required, and a request missing either is counted as untagged today and
+        // rejected with HTTP 400 once enforcement is enabled. `app`/`agent`/`workflow`/
+        // `stage` become Prometheus labels, so they must be low-cardinality kebab-case;
+        // `request_id` is unbounded and stays in the spend logs.
         metadata: {
-          consumer: "house-of-veritas",
-          capability: "task-guidance-vision",
-          route_hint: "cheap-long-context",
-          stage: process.env.NODE_ENV || "development",
-          task_id: params.taskId,
+          app: "house-of-veritas",
+          agent: "task-guidance-vision",
+          workflow: "task-guidance",
+          // Phase within the workflow, per ADR 10 — not the deploy environment, which
+          // is what this field used to carry.
+          stage: params.knowledge ? "grounded" : "ungrounded",
+          request_id: params.taskId,
+          // Only consulted by the router shim when `model` is "auto"; kept in step with
+          // `model` so an SLUICE_GUIDANCE_MODEL override cannot make it lie.
+          route_hint: model,
           grounded_by: params.knowledge?.refs.map((ref) => ref.slug).join(",") || "none",
         },
       }),

--- a/tests/lib/sluice-guidance.test.ts
+++ b/tests/lib/sluice-guidance.test.ts
@@ -68,10 +68,14 @@ describe("Sluice task guidance", () => {
       }>
     }
     expect(body.model).toBe("cheap-long-context")
+    // Field names are fixed by the Sluice contract (ADR 10, MUST under ADR 17).
+    // This assertion previously encoded `consumer`/`capability`/`task_id`, which
+    // are not contract fields — so it locked in the bug instead of catching it.
+    // The contract itself is covered in tests/lib/sluice-request-metadata.test.ts.
     expect(body.metadata).toMatchObject({
-      consumer: "house-of-veritas",
-      capability: "task-guidance-vision",
-      task_id: "42",
+      app: "house-of-veritas",
+      agent: "task-guidance-vision",
+      request_id: "42",
     })
     expect(body.messages[0].content).toContain("untrusted observations")
     const userContent = body.messages[1].content as Array<{ type: string; text?: string }>

--- a/tests/lib/sluice-request-metadata.test.ts
+++ b/tests/lib/sluice-request-metadata.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { generateTaskGuidanceWithSluice } from "@/lib/integrations/sluice"
+
+/**
+ * Guards the Sluice request-metadata contract (ADR 10, raised to MUST by ADR 17).
+ *
+ * This exists because the contract was silently violated for months: the call sent
+ * `consumer`/`capability` instead of `app`/`agent`, which the gateway reads as an
+ * untagged request. Nothing failed — there is no build error for sending the wrong
+ * key name, and `(none)` in a rollup only looks wrong to someone already suspicious.
+ * Once ADR 17 enforcement is switched on, the same mistake returns HTTP 400 on every
+ * guidance request instead.
+ *
+ * The other guidance tests mock `@/lib/integrations/sluice` wholesale, so none of
+ * them exercises the request this module actually builds. This one stubs `fetch` and
+ * asserts on the outgoing body.
+ */
+
+const ONE_PIXEL_JPEG_BASE64 = "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAA=="
+
+// `app`, `agent`, `workflow` and `stage` become Prometheus label values, so ADR 10
+// requires lowercase kebab-case: stable, one token per dimension, no version numbers.
+const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+function guidanceParams(overrides: Record<string, unknown> = {}) {
+  return {
+    taskId: "42",
+    title: "Repair window sill",
+    description: "The plaster is crumbling under the window.",
+    imageBase64: ONE_PIXEL_JPEG_BASE64,
+    imageMimeType: "image/jpeg",
+    locale: "en" as const,
+    ...overrides,
+  }
+}
+
+function sentMetadata(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+  const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+  return JSON.parse(String(init.body)).metadata as Record<string, unknown>
+}
+
+describe("Sluice request metadata (ADR 10 / ADR 17)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    process.env.SLUICE_BASE_URL = "https://litellm.sluice.example"
+    process.env.SLUICE_API_KEY = "sk-test"
+    delete process.env.SLUICE_GATEWAY_URL
+    delete process.env.SLUICE_GUIDANCE_MODEL
+
+    // The body is built before the response is read, so the reply only has to be
+    // well-formed enough not to throw — these tests assert on the request.
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "not json" } }] }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete process.env.SLUICE_BASE_URL
+    delete process.env.SLUICE_API_KEY
+    delete process.env.SLUICE_GUIDANCE_MODEL
+  })
+
+  it("sends the required app and agent fields", async () => {
+    await generateTaskGuidanceWithSluice(guidanceParams())
+
+    const metadata = sentMetadata(fetchMock)
+    expect(metadata.app).toBe("house-of-veritas")
+    expect(metadata.agent).toBe("task-guidance-vision")
+  })
+
+  it("does not send the superseded consumer/capability names", async () => {
+    await generateTaskGuidanceWithSluice(guidanceParams())
+
+    const metadata = sentMetadata(fetchMock)
+    expect(metadata).not.toHaveProperty("consumer")
+    expect(metadata).not.toHaveProperty("capability")
+    expect(metadata).not.toHaveProperty("task_id")
+  })
+
+  it("keeps every Prometheus-labelled field kebab-case", async () => {
+    await generateTaskGuidanceWithSluice(guidanceParams())
+
+    const metadata = sentMetadata(fetchMock)
+    for (const field of ["app", "agent", "workflow", "stage"] as const) {
+      // Assert the type before the shape: `String(undefined)` is "undefined", which
+      // matches the kebab pattern, so a missing field would pass a regex-only check.
+      expect(typeof metadata[field], `${field} must be present`).toBe("string")
+      expect(metadata[field] as string).toMatch(KEBAB_CASE)
+    }
+  })
+
+  it("reports stage as a workflow phase, not the deploy environment", async () => {
+    await generateTaskGuidanceWithSluice(guidanceParams())
+    expect(sentMetadata(fetchMock).stage).toBe("ungrounded")
+
+    fetchMock.mockClear()
+    await generateTaskGuidanceWithSluice(
+      guidanceParams({
+        knowledge: { text: "curated", refs: [{ slug: "copper-pipe-condensation-wall-damp" }] },
+      })
+    )
+    const grounded = sentMetadata(fetchMock)
+    expect(grounded.stage).toBe("grounded")
+    expect(grounded.grounded_by).toBe("copper-pipe-condensation-wall-damp")
+  })
+
+  it("carries the task id as request_id, which stays out of Prometheus labels", async () => {
+    await generateTaskGuidanceWithSluice(guidanceParams({ taskId: "task-98765" }))
+    expect(sentMetadata(fetchMock).request_id).toBe("task-98765")
+  })
+
+  it("keeps route_hint in step with an overridden model", async () => {
+    process.env.SLUICE_GUIDANCE_MODEL = "cheap-fast"
+    await generateTaskGuidanceWithSluice(guidanceParams())
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(String(init.body))
+    expect(body.model).toBe("cheap-fast")
+    expect(body.metadata.route_hint).toBe("cheap-fast")
+  })
+})


### PR DESCRIPTION
House of Veritas has been sending the wrong field names to Sluice since the guidance integration shipped. `metadata.consumer` / `metadata.capability` are not contract fields — [ADR 10](https://github.com/phoenixvc/sluice/blob/dev/docs/architecture/10-request-metadata-contract.md) requires `app` and `agent`.

## Why this matters now

The gateway reads a request without `app`/`agent` as **untagged**:

- it rolls up under `(none)` rather than as house-of-veritas spend
- it increments `untagged_requests_total{key_alias="house-of-veritas-guidance"}` now that [ADR 17](https://github.com/phoenixvc/sluice/blob/dev/docs/architecture/17-mandatory-request-metadata.md) stage 1 is landing
- it returns **HTTP 400 on every guidance request** once `SLUICE_REQUIRE_REQUEST_METADATA` is enabled

HOV is a first-party service, so it is on ADR 17's *enforced* tier, not the exempt one. And the guard's `DEFAULT_CALL_TYPES` includes `completion`/`acompletion`, so `/v1/chat/completions` — what this call uses — is in scope.

It also blocks ADR 17 rollout **precondition 1** ("every first-party service is deployed and emitting app + agent"), which was being tracked as though cognitive-mesh were the last one outstanding.

## Changes to `lib/integrations/sluice.ts`

| Before | After | Why |
|---|---|---|
| `consumer: "house-of-veritas"` | `app: "house-of-veritas"` | required field name |
| `capability: "task-guidance-vision"` | `agent: "task-guidance-vision"` | required field name |
| — | `workflow: "task-guidance"` | recommended field, was absent |
| `stage: process.env.NODE_ENV` | `stage: grounded \| ungrounded` | ADR 10 defines `stage` as the phase within the workflow, not the deploy environment |
| `task_id: params.taskId` | `request_id: params.taskId` | ADR 10's designated unbounded correlation field |
| `route_hint: "cheap-long-context"` | `route_hint: model` | was hardcoded while `model` can be overridden by `SLUICE_GUIDANCE_MODEL`; the two could silently disagree |

Making `stage` carry grounded/ungrounded is a small bonus: it is label-mapped, so grounded vs ungrounded generation cost becomes directly comparable in the dashboard.

`identifyInventoryBatchWithSluice` is **deliberately untouched**. Despite the name it is not a gateway call: it posts to `/api/inventory/identify-batch`, which LiteLLM does not serve, and reads `SLUICE_API_URL` / `SLUICE_INVENTORY_IDENTIFY_URL` — neither of which is set anywhere (production app settings supply only `SLUICE_BASE_URL`, `SLUICE_GUIDANCE_MODEL`, `SLUICE_API_KEY`), so it returns the offline fallback without making a request. Adding gateway metadata there would be cargo-culting; a comment now says so, so it is not "fixed" that way later.

## The test that made this possible

`tests/lib/sluice-guidance.test.ts` **did** assert on the outgoing metadata — as `consumer` / `capability` / `task_id`. So it did not merely fail to catch the violation, it pinned it: any correct fix would have failed that test. Updated in `c7f2669`.

That is the more interesting finding than the field names. A test asserting *what the code sends* rather than *what the contract requires* converts an external requirement into an internal one and then defends it. Worth watching for on the next contract change — cognitive-mesh has assertions in the same shape.

New `tests/lib/sluice-request-metadata.test.ts` asserts against the contract instead: required fields present, superseded names absent, label-mapped fields non-empty and kebab-case, `request_id` carried, `route_hint` in step with `model`.

- 6/6 pass with the fix
- **6/6 fail against the previous code** (verified by stashing the change and re-running), so it is a real guard rather than a test written to match

Full run of the four Sluice-touching files: `sluice-guidance` 6, `sluice-request-metadata` 6, `api/guidance` 17, `api/inventory-batch-identify` 4 — **33 passed**. `tsc --noEmit` clean. `eslint` clean on all changed files.

## Note for the reviewer

`prettier --check` fails on `lib/integrations/sluice.ts` — **it already fails identically on `main`**, so this PR does not change that. Not fixed here on purpose: a whole-file reformat would bury a six-line semantic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
