### PR TITLE
docs(camera): record local viewer acceptance

### DIFF
--- a/docs/specs/front-yard-camera-alert-prd.md
+++ b/docs/specs/front-yard-camera-alert-prd.md
@@ -1,0 +1,299 @@
+# PRD: Front-Yard Person Alert
+
+**Status:** Ready to decompose into Baton tasks in the next session  
+**Parent Baton task:** `2e4d5f5d-4a90-4099-9f97-d6059ac4b54c`  
+**Related architecture:** [Camera Security and Governance Integration](camera-security-governance.md)  
+**Device onboarding:** [JOOAN A2R-U Local Onboarding Runbook](jooan-a2r-u-local-onboarding-runbook.md)  
+**Target:** One current front-yard camera, one responder (Charl), one alert rule
+
+## 1. Outcome
+
+When an informed test participant walks through the gate into the configured front-yard zone:
+
+1. the locally running PhoenixVC Deck shows the real camera feed;
+2. a local NexaMesh-backed detector identifies a `person` object without identifying the person;
+3. Deck creates one deduplicated front-yard security event;
+4. HOV persists the event and a hash-verifiable snapshot as reviewable evidence;
+5. HOV notifies Charl to check the front yard; and
+6. the notification opens a muted HOV live view that is available for two minutes and then stops.
+
+The end-to-end path must continue to respect the primary architecture boundary: Deck owns the
+camera, credentials, full-time stream, and local vision. HOV receives only the event, selected
+evidence, and an expiring live session.
+
+## 2. Product story
+
+> As Charl, when a person enters the front yard while the security rule is armed, I want a prompt
+> HOV alert with a trustworthy snapshot and a brief live view so I can check what is happening
+> without exposing a permanent household-camera stream.
+
+The alert means “a model observed a person-shaped object in this zone.” It does not mean the person
+is an intruder, identify them, prove wrongdoing, or authorize an enforcement action.
+
+## 3. The thinnest cake
+
+Each slice must produce something independently demonstrable. Do not start by building a generic
+camera marketplace, multi-camera orchestration, continuous cloud recorder, or broad vision platform.
+
+### Slice 0 — Prove the wire
+
+**Question:** Can the camera provide a local stream Deck can consume?
+
+- Record make/model, firmware, camera LAN isolation, and local-account support.
+- Enable and test ONVIF Profile T/S or RTSP locally.
+- Capture the capability result: stream URI availability, codec, resolution, snapshot, PTZ, audio,
+  event support, and camera-clock offset.
+- Do not store the password or full RTSP URI in Baton, docs, logs, screenshots, or HOV.
+
+**Demo:** A local diagnostic confirms one usable video profile or records an exact vendor-adapter
+blocker.  
+**Time box:** 2 hours.  
+**Stop condition:** If neither ONVIF nor RTSP is available, choose a vendor adapter or replacement
+camera before writing the viewer.
+
+### Slice 1 — See
+
+**Outcome:** Deck can show the real camera locally.
+
+- Add a compiled camera-adapter interface in Deck; a marketplace/dynamic plugin loader is deferred.
+- Implement only the adapter proven by Slice 0.
+- Keep configuration, discovery, LAN endpoint, and credential reference in Deck.
+- Store credentials in an OS-protected credential store; configuration stores only the reference.
+- Add one camera alias, `front-yard`, one selected stream profile, reconnect/backoff, and health.
+- Add a local privacy switch that immediately closes the stream.
+- Keep audio, recording, HOV, and remote control off.
+
+**Demo:** Start Deck, connect, view for ten minutes, stop with the privacy switch, restart Deck, and
+reconnect without revealing credentials.  
+**Accepted 2026-08-10:** The authentic camera rendered locally for more than ten minutes while Deck
+remained responsive. Privacy changed the viewer immediately to black; reopening reconnected the
+real feed. After a normal Deck shutdown and restart, the viewer defaulted to privacy-on and required
+an explicit local open before reconnecting. Credentials remained in Windows Credential Manager;
+audio, recording, HOV publishing, and remote access stayed disabled. No address, credential, full
+URI, device identifier, or image evidence was promoted into project systems.  
+**PR boundary:** Deck only.  
+**Estimate:** 1–2 focused days after Slice 0.
+
+### Slice 2 — Spot
+
+**Outcome:** Deck labels a person entering a configured zone.
+
+- Add a NexaMesh vision-adapter contract and one approved local/runtime implementation.
+- Define a polygon named `front-yard-entry`; the user draws and saves it locally in Deck.
+- Run only the `person` detector on a low-rate derived frame stream; do not send the full live stream
+  to HOV.
+- Display the current bounding box, confidence, model/deployment ID, and processing location.
+- Confirm an event only after the configurable temporal rule passes. Recommended starting policy:
+  confidence at least `0.75` in two frames within 1.5 seconds.
+- Deduplicate detections under one event while a track remains in the zone and apply a five-minute
+  notification cooldown after it leaves.
+- Keep the rule in `observe` mode: on-screen event only, no HOV write or notification.
+
+**Demo:** A person walks through the gate and Deck produces one local candidate event; an animal,
+empty scene, and repeated frames do not create duplicate person events.  
+**PR boundary:** Deck/NexaMesh adapter only.  
+**Estimate:** 1–2 focused days once the callable NexaMesh runtime is identified.
+
+### Slice 3 — Tell
+
+**Outcome:** A synthetic or manually replayed Deck event reaches HOV and notifies Charl with a
+snapshot.
+
+- Pair one Deck instance to HOV with a one-time code and device-held signing key.
+- Add a purpose-specific camera-event endpoint and persistent repository.
+- Accept an event manifest plus one JPEG evidence snapshot using a private, short-lived upload grant.
+- Preserve the original snapshot hash and store bounding-box/zone annotations separately.
+- Resolve the responder from an admin-owned rule configuration whose initial value is Charl's stable
+  HOV user ID. Do not address the alert using a display name, hard-coded email, or client-supplied
+  recipient.
+- Persist the event before dispatching notifications.
+- Add a persistent HOV alert record and emit a real-time in-app update. The current notification
+  service's `in_app` branch only returns a simulated-success receipt; that is not acceptance.
+- Give Charl an alert card with time, camera alias, “person detected” wording, snapshot, confidence,
+  acknowledgement, and `False alarm` / `Needs attention` review actions.
+- Use one event ID as the idempotency key for ingest, evidence, notification, and review.
+
+**Demo:** Replay a signed synthetic event twice; HOV stores one event, one evidence object, and one
+Charl alert. Another user cannot read the snapshot.  
+**PR boundary:** One Deck event-export PR and one HOV event/evidence/alert PR, linked by a versioned
+fixture.  
+**Estimate:** 2–3 focused days.
+
+### Slice 4 — Open the brief window
+
+**Outcome:** Charl's alert offers a muted, expiring live view.
+
+- Add a pre-approved unattended-export rule scoped to `front-yard-entry + person + armed`.
+- On the first accepted event, HOV creates a single-use incident lease with a 120-second effective
+  duration. Make the default configurable from 30 to 120 seconds; hard-cap this rule at 180 seconds.
+- Deck validates the signed lease and publishes a muted derived stream outbound to a selected
+  WebRTC/WHIP relay. No router port is opened.
+- The Charl alert deep-links to an authenticated HOV viewer. The viewer token is bound to Charl's
+  user ID, event ID, camera alias, and lease expiry.
+- Deck and HOV show the same countdown; Deck independently stops the publisher at expiry.
+- Opening or refreshing after expiry shows the snapshot/event, not a renewed stream.
+- Charl may revoke immediately. Extension is not included in this slice.
+- The relay must not record, archive, or expose a reusable public URL.
+
+**Demo:** Replay an event, open the alert as Charl, view live video, revoke once, then repeat and prove
+automatic expiry plus reconnect denial.  
+**PR boundary:** Relay adapter/Deck publisher plus HOV lease/viewer; use versioned contracts and
+separate repo PRs.  
+**Estimate:** 2–4 focused days after relay selection.
+
+### Slice 5 — Walk through the gate
+
+**Outcome:** The real, staffed end-to-end acceptance works once without bypasses.
+
+- Arm the rule locally with a visible Deck indicator.
+- Have an informed participant walk through the gate once.
+- Record exact timestamps for camera frame, Deck candidate, Deck confirmed event, HOV receipt,
+  evidence finalization, notification dispatch, Charl view open, and stream teardown.
+- Charl acknowledges or marks the event false alarm.
+- Verify bytes are private, the manifest digest matches, the live lease expires, and no duplicate
+  alert appears after the cooldown window.
+- Exercise camera offline, NexaMesh unavailable, HOV unavailable, and relay unavailable separately.
+  Each failure is visible; none produces a false all-clear or endless stream.
+
+**Demo:** One authentic gate walk produces one reviewable HOV alert with evidence and a two-minute
+maximum live window.  
+**PR boundary:** No feature expansion; fixes and evidence only.  
+**Estimate:** Half a day when all preceding slices are deployed to the test environment.
+
+## 4. Functional requirements
+
+### Deck
+
+- `FR-D1`: Deck is the only holder of camera credentials and LAN connection details.
+- `FR-D2`: The camera remains locally viewable when HOV or the internet is unavailable.
+- `FR-D3`: The front-yard zone, armed state, thresholds, cooldown, and responder rule are explicit
+  configuration, not model prompt text.
+- `FR-D4`: Detection produces `person` class, confidence, bounding box, track/time range,
+  model/version, processing location, input hash, and privacy-mask version.
+- `FR-D5`: Deck defaults to privacy mode on for a newly discovered camera until the owner enables
+  live processing.
+- `FR-D6`: Audio capture and talkback remain disabled for this workflow.
+- `FR-D7`: The privacy switch stops decoding, inference, evidence creation, and live publishing.
+- `FR-D8`: Event export and live publishing are outbound-only and idempotent.
+
+### HOV
+
+- `FR-H1`: HOV verifies the paired Deck signature and rejects stale, malformed, replayed, or
+  cross-camera events.
+- `FR-H2`: HOV stores receipt facts separately from Deck-claimed capture facts.
+- `FR-H3`: Only configured authorized roles can change the rule or responder; Charl can read and
+  review only alerts assigned to him unless a broader estate role explicitly permits access.
+- `FR-H4`: Evidence bytes are private and resource-scoped; every view/download is audited.
+- `FR-H5`: Notification persistence occurs before external delivery attempts.
+- `FR-H6`: Duplicate ingest cannot create another evidence object, notification, or live lease.
+- `FR-H7`: The viewer token and lease cannot outlive the effective expiry or be used by another user.
+- `FR-H8`: Evidence review separates machine finding, human interpretation, and resulting action.
+
+### NexaMesh
+
+- `FR-N1`: NexaMesh is called through a versioned Deck adapter and cannot call HOV directly.
+- `FR-N2`: Only the configured detector and necessary derived frames are supplied.
+- `FR-N3`: Model unavailable, timeout, or below-threshold output is `inconclusive`, never `no person`.
+- `FR-N4`: A model/deployment change resets the rule to observe mode until the regression corpus
+  passes.
+
+## 5. Non-functional targets
+
+These are acceptance targets for a healthy local network, not promises before measurement.
+
+| Target                                          | Initial threshold                                               |
+| ----------------------------------------------- | --------------------------------------------------------------- |
+| Camera-to-Deck local live latency               | Under 2 seconds                                                 |
+| Confirmed person event after threshold frames   | Under 3 seconds from first qualifying frame                     |
+| HOV receipt after Deck confirms                 | Under 5 seconds when online                                     |
+| Charl alert visible                             | Under 10 seconds from confirmation                              |
+| Live playback after Charl opens an active alert | Under 5 seconds                                                 |
+| Duplicate alerts                                | One event/notification per continuous track and cooldown window |
+| Incident live duration                          | 120 seconds default, 180 seconds hard cap                       |
+| Camera credentials in HOV/logs                  | Zero                                                            |
+| Face identity/biometric templates               | Zero                                                            |
+
+## 6. Evidence and retention
+
+The thinnest evidence is one original JPEG snapshot plus a signed manifest and separate annotation
+JSON. MP4 event clips are a later enhancement; they are not required to prove the first cake.
+
+- The snapshot is captured at or immediately after event confirmation.
+- Deck hashes the original bytes before annotation or resizing.
+- HOV verifies the uploaded object hash and preserves the original privately.
+- The UI may render an annotated derivative, but it must link back to the immutable original digest.
+- Recommended initial retention is 30 days for unreviewed/false-alarm events, subject to the estate's
+  approved privacy policy. `Needs attention` may be promoted to a separately owned case retention
+  policy.
+- Deletion removes object bytes and leaves an auditable tombstone. A hold requires reason, owner, and
+  review date.
+
+## 7. Safety and abuse cases
+
+| Risk                                   | Required control                                                      |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| Notification spam from repeated frames | Track/event idempotency plus cooldown                                 |
+| False person detection                 | Multi-frame threshold, observe mode, Charl review                     |
+| Compromised camera/plugin              | IoT network isolation, minimum plugin permissions, no HOV credential  |
+| Forged or replayed event               | Paired Deck signature, nonce/event ID, timestamp window, idempotency  |
+| Live-link sharing                      | User-bound token, short expiry, no URL bearer, viewer audit           |
+| Relay/session leak                     | Deck and HOV dual expiry, revoke, teardown monitoring, no recording   |
+| Model drift                            | Versioned evaluation corpus and observe-mode reset                    |
+| Monitoring people beyond the purpose   | Fixed zone, privacy masks, notice, bounded evidence, no identity      |
+| HOV or internet outage                 | Local Deck event remains visible/retryable; no false delivery receipt |
+
+## 8. Explicitly deferred
+
+- Multiple cameras, camera groups, patrol tours, or remote PTZ from HOV.
+- Continuous recording or cloud NVR.
+- Audio, talkback, facial recognition, licence-plate recognition, identity watchlists, emotion, or
+  employee scoring.
+- SMS/WhatsApp/email escalation. First acceptance is a durable HOV alert; channel escalation is a
+  later policy slice after delivery and consent are proven.
+- Automatic task completion, police/security dispatch, sirens, access denial, or disciplinary action.
+- Generic third-party plugin marketplace, hot-loaded native plugins, or arbitrary plugin cloud access.
+- Event video clips; start with one snapshot.
+
+## 9. Baton task packet for the next session
+
+Do **not** create these as unrelated root tasks. In the next session, first re-open parent task
+`2e4d5f5d-4a90-4099-9f97-d6059ac4b54c`, confirm current repo/worktree/Baton state, then create these
+as child tasks or correctly related repo tasks. Preserve the dependency order.
+
+| Order | Proposed task title                                                                 | Repo/owner               | Closeout evidence                                                      | Estimate |
+| ----- | ----------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------- | -------- |
+| 0     | Probe front-yard camera ONVIF/RTSP capabilities safely                              | Deck / human+agent       | Redacted capability report and selected adapter decision               | 2h       |
+| 1     | Add Deck one-camera local adapter, credential reference, viewer, and privacy switch | Deck                     | Real ten-minute local view, restart, privacy stop, Rust/UI tests       | 1–2d     |
+| 2     | Add NexaMesh person detector and front-yard observe-only zone rule                  | Deck + NexaMesh          | Labeled walk/no-person/animal/repeat corpus and one local event        | 1–2d     |
+| 3     | Define and fixture-sign camera event/evidence/live-lease contracts                  | Deck + HOV               | Versioned cross-repo fixtures; no network calls                        | 0.5–1d   |
+| 4     | Persist HOV camera events and private snapshot evidence idempotently                | HOV                      | Auth/API/storage/delete tests and cross-user denial                    | 1–2d     |
+| 5     | Deliver a persistent HOV front-yard alert to configured responder Charl             | HOV                      | One replay -> one durable alert; realtime delivery and acknowledgement | 1d       |
+| 6     | Add 120-second muted incident live lease and viewer                                 | Deck + HOV + relay       | Expiry, revoke, refresh denial, no relay recording/object              | 2–4d     |
+| 7     | Run staffed front-yard gate-walk acceptance and failure matrix                      | Cross-repo / human+agent | Timestamp trace, screenshot, digest, notification, teardown evidence   | 0.5d     |
+| 8     | Decide launch posture from authentic acceptance evidence                            | HOV / human              | Explicit enable/hold decision, residual risk, rollback/kill switch     | 0.5h     |
+
+Recommended task relations:
+
+- Task 0 blocks 1.
+- Task 1 blocks 2 and authentic acceptance, but task 3 can start with the simulator.
+- Task 3 blocks 4 and 6.
+- Task 4 blocks 5.
+- Tasks 2, 5, and 6 all block 7.
+- Task 7 blocks 8.
+
+Each task body must include the parent task ID, exact repo path/branch, relevant section of this PRD,
+non-goals, files changed, commands run, tests/manual checks, and the next dependency. The task is not
+done merely because its PR merges; retain authentic camera and staffed gate-walk acceptance as
+separate gates.
+
+## 10. First-session decisions
+
+The next session should answer only the decisions necessary for Task 0 and Task 1:
+
+1. What local protocol does the camera actually expose: ONVIF, RTSP, or vendor-only?
+2. Which codec/profile gives stable low-latency local viewing on the Deck PC?
+3. Which OS credential-store integration will Deck use?
+4. Where does the callable NexaMesh vision runtime live, and can it process frames locally?
+5. Is the front-yard camera placement and zone notice/privacy mask approved for this test?
+
+Relay vendor/hosting and long-term retention do not need to block the first local Deck slices.

--- a/docs/specs/jooan-a2r-u-local-onboarding-runbook.md
+++ b/docs/specs/jooan-a2r-u-local-onboarding-runbook.md
@@ -1,0 +1,229 @@
+# JOOAN A2R-U Local Onboarding Runbook
+
+**Applies to:** One JOOAN A2R-U camera and the front-yard camera pilot  
+**Baton task:** `6a546afb-6397-44bb-af3e-2278cc48cb6d`  
+**Goal:** Obtain a local Cam720 picture, then enable a private local RTSP stream for Deck to probe  
+**Not in this runbook:** mounting, cloud recording, SD-card recording, audio, person detection, HOV, or remote access
+
+## 1. Safety and privacy rules
+
+- Do the first setup indoors with the camera facing a blank wall.
+- Use only the supplied 5V/2A power adapter or a confirmed equivalent.
+- Leave the microSD card out for now.
+- Do not subscribe to cloud storage or enable recording, microphone, intercom, auto-tracking,
+  device sharing, or alarm notifications.
+- Do not post the camera QR code, device ID, Wi-Fi password, local IP address, camera username,
+  camera password, or RTSP URL in chat, Baton, docs, screenshots, or source control.
+- Unplugging the power is the reliable privacy stop until Deck's software privacy switch exists.
+- Do not open router ports, enable port forwarding, or expose the camera to the public internet.
+
+## 2. What you need
+
+- The JOOAN A2R-U camera and its power adapter.
+- An Android phone or iPhone.
+- The name and password of a **2.4 GHz** Wi-Fi network.
+- Access to the home router's connected-device list later in the runbook.
+- A new, unique camera password. Do not reuse the Wi-Fi, email, HOV, or Cam720 password.
+
+If the router combines 2.4 GHz and 5 GHz under one name, try the normal network first. If setup
+fails repeatedly, temporarily use a 2.4-GHz-only or IoT network for onboarding.
+
+## 3. Install Cam720 safely
+
+1. On the phone, open Google Play or the Apple App Store.
+2. Search for **Cam720**. Prefer the store listing reached from the QR/link in the printed JOOAN
+   guide. Do not install an APK from an unrelated download site.
+3. Install and open the app.
+4. Grant Local Network or nearby-device access when requested. Camera access is needed only if the
+   app asks to scan a setup QR code. Leave microphone and photo-library access denied unless a
+   specific setup screen requires them.
+5. If Cam720 offers **stand-alone**, **local**, or **guest** mode, use it first. The JOOAN guide says
+   local viewing can work without account registration. If this firmware requires an account,
+   create one with a dedicated email address and a unique app password.
+
+Do not use the camera/device password as the Cam720 account password.
+
+## 4. Reset and power the camera
+
+1. Place the camera on a stable table facing a wall. Do not mount it yet.
+2. Plug in the 5V/2A adapter.
+3. Wait for the camera to rotate or announce that it is ready.
+4. Locate the reset button. On this camera family it is commonly beside the microSD slot, sometimes
+   revealed by gently tilting the lens assembly upward. Do not force the mechanism.
+5. With power on, hold reset for about 5 seconds. Release it after the beep or voice prompt.
+6. Wait for the self-test and the ready/configuration prompt.
+
+If it reports that it is bound to another account after a reset, stop. Do not try random passwords;
+the seller or JOOAN must release the device from the previous account.
+
+## 5. Put the camera on Wi-Fi
+
+1. Connect the phone to the intended 2.4 GHz Wi-Fi network.
+2. In Cam720, tap **+** and choose **WiFi connection**.
+3. Confirm the checkbox saying that the camera made its configuration tone, then tap **Next**.
+4. When instructed, open the phone's Wi-Fi settings and join the temporary camera network. Its name
+   normally starts with `JA-` or `JAA-`.
+5. Return to Cam720. If the phone warns that the temporary network has no internet, choose to stay
+   connected.
+6. Select the intended home/IoT Wi-Fi and enter its password in the app.
+7. Wait without unplugging the camera until Cam720 says the camera is online.
+8. Tap the camera tile. Confirm that a live picture appears.
+
+**Checkpoint A:** Stop here if no live picture appears. Record only the visible error wording and
+the step that failed; do not include network names, QR codes, IDs, IP addresses, or passwords.
+
+## 6. Apply safe initial settings
+
+Open the camera tile, then use the gear or **More function settings** menu.
+
+1. Rename the camera to `front-yard`.
+2. Open **Camera information** and privately note the firmware/version number.
+3. Set the correct time zone and confirm the displayed time is approximately correct.
+4. Set or change the local device/camera password to the unique password prepared earlier.
+5. Keep these features off:
+   - microphone and voice intercom;
+   - screen recording, SD-card recording, and cloud recording;
+   - device sharing;
+   - auto-tracking, cruise, and alarm actions.
+6. Do not update firmware yet. First record the installed version and prove local RTSP. A firmware
+   update will be considered afterward and must be followed by the same local-stream test.
+
+Cam720's live-view microphone button must remain off. A disabled phone speaker is not proof that the
+camera stopped capturing audio; Deck will later use a video-only stream path.
+
+## 7. Find the camera locally without publishing its address
+
+1. On the Deck PC, sign in to the home router's administration page.
+2. Open **Connected devices**, **DHCP clients**, or **Network map**.
+3. Identify the newly connected device by disconnecting and reconnecting camera power if necessary.
+   It may appear as JOOAN, the temporary `JA-` name, or an unknown device.
+4. Privately note its local IP address. Do not paste it into chat or Baton.
+5. If the router supports a DHCP reservation, reserve the current address for this camera. This is
+   optional for the first probe but will make Deck reconnect reliably.
+6. Confirm there is no port-forwarding rule for this device. Do not create one.
+
+## 8. Enable the local RTSP service
+
+The exact menu varies by A2R-U firmware. Try the local web page first, then Cam720.
+
+### Option A - local camera web page
+
+1. On the Deck PC, open a browser and enter `http://` followed by the camera's private local IP.
+   Keep that address out of screenshots and chat.
+2. Sign in as `admin` using the local device password set in Cam720. Do not use the Cam720 account
+   password. Do not continue with a blank/default camera password.
+3. Look under **Network**, **Service**, **Advanced**, or **Protocol**.
+4. Enable **RTSP** and require **Digest authentication**.
+5. Chinese firmware may label these settings:
+   - `RTSP使能` - RTSP enable;
+   - `摘要认证` - digest authentication.
+6. If an ONVIF switch or ONVIF user page exists, note that it exists but do not enable extra remote
+   access, UPnP, P2P, or port forwarding.
+7. Save and allow the camera to restart.
+
+### Option B - Cam720 advanced settings
+
+1. Open the camera tile, then the gear or **More function settings**.
+2. Check **Camera information**, **Advanced settings**, **Local service**, **RTSP**, or **ONVIF**.
+3. Enable RTSP with digest authentication if offered.
+4. Privately note whether ONVIF is present and whether it uses a separate local username/password.
+
+Do not construct or paste a credential-bearing RTSP URL. Deck's local probe will assemble and use it
+inside the trusted backend. Public reports suggest this model commonly provides two H.264 profiles
+under `/live/ch00_0` and `/live/ch00_1`, but the probe must confirm which profile this unit exposes.
+
+**Checkpoint B:** Stop if neither the local web page nor Cam720 exposes RTSP/ONVIF. Do not install
+replacement firmware or open the camera. Report only: `No RTSP/ONVIF setting found`.
+
+## 9. What to report back
+
+Reply with only this template:
+
+```text
+Cam720 live picture: yes/no
+Firmware version: <version only>
+Local web page: yes/no
+RTSP setting: enabled/not found
+Digest authentication: enabled/not found
+ONVIF setting: present/not found
+Camera/device password changed from default: yes/no
+Audio, recording, sharing, and auto-tracking off: yes/no
+Camera time approximately correct: yes/no
+```
+
+Do not include the camera IP, device ID, QR code, username, password, Wi-Fi name, Wi-Fi password, or
+full RTSP URL.
+
+## 10. Troubleshooting
+
+### No power or self-test
+
+- Reseat the supplied adapter at both ends and try a known-working outlet.
+- Confirm the adapter output matches the camera label: 5V/2A.
+- Stop if the adapter or camera becomes unusually hot, smells burnt, or shows cable damage.
+
+### The `JA-` or `JAA-` Wi-Fi network never appears
+
+- Keep the phone close to the camera.
+- Repeat the powered reset and wait for the ready prompt.
+- Temporarily disable mobile data or the phone's automatic switch-away-from-no-internet feature.
+
+### Wi-Fi setup fails
+
+- Confirm the phone is using 2.4 GHz Wi-Fi.
+- Re-enter the Wi-Fi password locally.
+- Avoid a guest network that prevents devices from reaching each other; Deck must be able to reach
+  the camera locally.
+- Move the camera beside the router for onboarding, then test the intended placement later.
+
+### Cam720 says the device belongs to another account
+
+- Perform one factory reset.
+- If the message remains, stop and contact the seller/JOOAN with the device details privately.
+
+### Cam720 works but the local web page does not
+
+- Confirm the PC and camera are on networks allowed to communicate.
+- Recheck the current address in the router's connected-device list.
+- Do not scan the whole LAN or disable the firewall. Report `Cam720 works; local web page absent`.
+
+### RTSP exists but ONVIF does not
+
+- This is acceptable for Slice 0. Deck can proceed with a compiled RTSP adapter if the real stream
+  probe confirms a stable H.264 profile. PTZ remains out of scope.
+
+## 11. Completion boundary
+
+This runbook is complete only when:
+
+- Cam720 shows the real camera locally;
+- a unique local camera password is set;
+- audio, recording, sharing, tracking, and cloud subscription remain off;
+- the firmware and clock state are known;
+- RTSP is enabled with digest authentication, or an exact `not found` blocker is recorded; and
+- no secret, full URI, device identifier, or local address has been copied into project systems.
+
+After Checkpoint B, Codex owns the bounded Deck probe, redacted capability report, and adapter
+decision. The operator should not test a credential-bearing URL in a shell command or screenshot.
+
+Run the repository probe from PowerShell when Codex requests Checkpoint C:
+
+```powershell
+pwsh -NoProfile -File .\scripts\probe-camera-onvif.ps1 `
+  -RtspProbeExecutable C:\tmp\deck-camera-edge\target\debug\camera_rtsp_probe.exe `
+  -CredentialProvisionExecutable C:\tmp\deck-camera-edge\target\debug\camera_credential_provision.exe
+```
+
+Enter the camera address, local username, and password only at the masked prompts. The probe follows
+only ONVIF service addresses returned for the same camera host and prints a redacted profile report;
+it passes the selected RTSP locator and credentials to Deck over redirected standard input, proves a
+real H.264 frame twice, and never prints the address, username, password, profile token, or RTSP URI.
+When the optional provisioning executable is supplied, the same already-masked values are written
+once to Windows Credential Manager under Deck's opaque `front-yard` reference. They are not written
+to JSON config, shell arguments, environment variables, logs, or the webview.
+
+## Sources
+
+- [JOOAN A2R-U WiFi Camera User Guide](https://manuals.plus/jooan/a2r-u-wifi-camera-manual)
+- [JOOAN A2R-U local RTSP setup report](https://community.home-assistant.io/t/recommended-ip-cams-for-home-and-outdoor-usage-with-ha/57781/27)
+- [JOOAN A2R-U RTSP path catalogue](https://www.ispyconnect.com/camera/jooan)

--- a/scripts/probe-camera-onvif.ps1
+++ b/scripts/probe-camera-onvif.ps1
@@ -1,0 +1,680 @@
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 65535)]
+    [int]$OnvifPort = 8899,
+
+    [ValidateRange(2, 30)]
+    [int]$TimeoutSeconds = 8,
+
+    [string]$RtspProbeExecutable,
+
+    [string]$CredentialProvisionExecutable
+)
+
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-TemporaryPlainText {
+    param([Parameter(Mandatory)][Security.SecureString]$SecureValue)
+
+    $pointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureValue)
+    try {
+        [Runtime.InteropServices.Marshal]::PtrToStringBSTR($pointer)
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($pointer)
+    }
+}
+
+function Get-NodeText {
+    param(
+        [Parameter(Mandatory)][System.Xml.XmlNode]$Node,
+        [Parameter(Mandatory)][string]$LocalName
+    )
+
+    $match = $Node.SelectSingleNode(".//*[local-name()='$LocalName']")
+    if ($null -eq $match) { return $null }
+    return $match.InnerText
+}
+
+function Get-ShortHash {
+    param([Parameter(Mandatory)][string]$Value)
+
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Value)
+    try {
+        $hash = [Security.Cryptography.SHA256]::HashData($bytes)
+        return ([Convert]::ToHexString($hash)).Substring(0, 12).ToLowerInvariant()
+    }
+    finally {
+        [Array]::Clear($bytes, 0, $bytes.Length)
+    }
+}
+
+function New-OnvifEnvelope {
+    param(
+        [Parameter(Mandatory)][string]$Username,
+        [Parameter(Mandatory)][string]$Password,
+        [Parameter(Mandatory)][string]$Body
+    )
+
+    $nonce = [byte[]]::new(16)
+    [Security.Cryptography.RandomNumberGenerator]::Fill($nonce)
+    $created = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+    $createdBytes = [Text.Encoding]::UTF8.GetBytes($created)
+    $passwordBytes = [Text.Encoding]::UTF8.GetBytes($Password)
+    $digestInput = [byte[]]::new($nonce.Length + $createdBytes.Length + $passwordBytes.Length)
+
+    try {
+        [Array]::Copy($nonce, 0, $digestInput, 0, $nonce.Length)
+        [Array]::Copy($createdBytes, 0, $digestInput, $nonce.Length, $createdBytes.Length)
+        [Array]::Copy($passwordBytes, 0, $digestInput, $nonce.Length + $createdBytes.Length, $passwordBytes.Length)
+        $digest = [Convert]::ToBase64String([Security.Cryptography.SHA1]::HashData($digestInput))
+        $nonceText = [Convert]::ToBase64String($nonce)
+        $escapedUsername = [Security.SecurityElement]::Escape($Username)
+
+        return @"
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+            xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+            xmlns:tds="http://www.onvif.org/ver10/device/wsdl"
+            xmlns:trt="http://www.onvif.org/ver10/media/wsdl"
+            xmlns:tt="http://www.onvif.org/ver10/schema">
+  <s:Header>
+    <wsse:Security s:mustUnderstand="1">
+      <wsse:UsernameToken>
+        <wsse:Username>$escapedUsername</wsse:Username>
+        <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">$digest</wsse:Password>
+        <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">$nonceText</wsse:Nonce>
+        <wsu:Created>$created</wsu:Created>
+      </wsse:UsernameToken>
+    </wsse:Security>
+  </s:Header>
+  <s:Body>$Body</s:Body>
+</s:Envelope>
+"@
+    }
+    finally {
+        [Array]::Clear($nonce, 0, $nonce.Length)
+        [Array]::Clear($createdBytes, 0, $createdBytes.Length)
+        [Array]::Clear($passwordBytes, 0, $passwordBytes.Length)
+        [Array]::Clear($digestInput, 0, $digestInput.Length)
+    }
+}
+
+function Invoke-OnvifRequest {
+    param(
+        [Parameter(Mandatory)][Net.Http.HttpClient]$Client,
+        [Parameter(Mandatory)][Uri]$Endpoint,
+        [Parameter(Mandatory)][string]$Action,
+        [Parameter(Mandatory)][string]$Username,
+        [Parameter(Mandatory)][string]$Password,
+        [Parameter(Mandatory)][string]$Body
+    )
+
+    $envelope = New-OnvifEnvelope -Username $Username -Password $Password -Body $Body
+    $content = [Net.Http.StringContent]::new($envelope, [Text.Encoding]::UTF8)
+    $content.Headers.ContentType = [Net.Http.Headers.MediaTypeHeaderValue]::Parse(
+        "application/soap+xml; charset=utf-8; action=`"$Action`""
+    )
+
+    try {
+        $response = $Client.PostAsync($Endpoint, $content).GetAwaiter().GetResult()
+        try {
+            if (-not $response.IsSuccessStatusCode) {
+                throw "ONVIF request failed with HTTP $([int]$response.StatusCode). Response body suppressed."
+            }
+
+            $responseText = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+            try {
+                return [xml]$responseText
+            }
+            finally {
+                $responseText = $null
+            }
+        }
+        finally {
+            $response.Dispose()
+        }
+    }
+    finally {
+        $content.Dispose()
+        $envelope = $null
+    }
+}
+
+function Assert-LocalServiceUri {
+    param(
+        [Parameter(Mandatory)][Uri]$Uri,
+        [Parameter(Mandatory)][string]$ExpectedHost
+    )
+
+    if ($Uri.Scheme -notin @('http', 'https')) {
+        throw 'Camera returned a service address with an unsupported scheme.'
+    }
+    if (-not [string]::Equals($Uri.DnsSafeHost, $ExpectedHost, [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Camera returned a service address for a different host; refusing to follow it.'
+    }
+}
+
+function Get-Md5Hex {
+    param([Parameter(Mandatory)][string]$Value)
+
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Value)
+    try {
+        return ([Convert]::ToHexString([Security.Cryptography.MD5]::HashData($bytes))).ToLowerInvariant()
+    }
+    finally {
+        [Array]::Clear($bytes, 0, $bytes.Length)
+    }
+}
+
+function Read-ExactBytes {
+    param(
+        [Parameter(Mandatory)][IO.Stream]$Stream,
+        [Parameter(Mandatory)][int]$Length
+    )
+
+    $buffer = [byte[]]::new($Length)
+    $offset = 0
+    while ($offset -lt $Length) {
+        $read = $Stream.Read($buffer, $offset, $Length - $offset)
+        if ($read -le 0) { throw 'RTSP connection closed unexpectedly.' }
+        $offset += $read
+    }
+    return $buffer
+}
+
+function Read-RtspResponse {
+    param([Parameter(Mandatory)][IO.Stream]$Stream)
+
+    $headerBytes = [Collections.Generic.List[byte]]::new()
+    while ($headerBytes.Count -lt 32768) {
+        $value = $Stream.ReadByte()
+        if ($value -lt 0) { throw 'RTSP connection closed before a response arrived.' }
+        $headerBytes.Add([byte]$value)
+        $count = $headerBytes.Count
+        if ($count -ge 4 -and
+            $headerBytes[$count - 4] -eq 13 -and $headerBytes[$count - 3] -eq 10 -and
+            $headerBytes[$count - 2] -eq 13 -and $headerBytes[$count - 1] -eq 10) {
+            break
+        }
+    }
+    if ($headerBytes.Count -ge 32768) { throw 'RTSP response headers exceeded the safe limit.' }
+
+    $headerText = [Text.Encoding]::ASCII.GetString($headerBytes.ToArray())
+    $lines = $headerText -split "`r`n"
+    if ($lines[0] -notmatch '^RTSP/\d\.\d\s+(\d{3})') { throw 'Camera returned an invalid RTSP status line.' }
+    $statusCode = [int]$Matches[1]
+    $headers = @{}
+    foreach ($line in $lines | Select-Object -Skip 1) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $separator = $line.IndexOf(':')
+        if ($separator -gt 0) {
+            $headers[$line.Substring(0, $separator).Trim()] = $line.Substring($separator + 1).Trim()
+        }
+    }
+
+    $contentLength = 0
+    if ($headers.ContainsKey('Content-Length')) {
+        $contentLength = [int]$headers['Content-Length']
+        if ($contentLength -lt 0 -or $contentLength -gt 1048576) {
+            throw 'RTSP response body exceeded the safe limit.'
+        }
+    }
+    $bodyBytes = if ($contentLength -gt 0) { Read-ExactBytes -Stream $Stream -Length $contentLength } else { [byte[]]::new(0) }
+    try {
+        [pscustomobject]@{
+            StatusCode = $statusCode
+            Headers = $headers
+            Body = [Text.Encoding]::UTF8.GetString($bodyBytes)
+        }
+    }
+    finally {
+        if ($bodyBytes.Length -gt 0) { [Array]::Clear($bodyBytes, 0, $bodyBytes.Length) }
+    }
+}
+
+function Send-RtspRequest {
+    param(
+        [Parameter(Mandatory)][IO.Stream]$Stream,
+        [Parameter(Mandatory)][string]$Method,
+        [Parameter(Mandatory)][Uri]$Uri,
+        [Parameter(Mandatory)][int]$CSeq,
+        [hashtable]$Headers = @{}
+    )
+
+    $builder = [Text.StringBuilder]::new()
+    [void]$builder.Append("$Method $($Uri.AbsoluteUri) RTSP/1.0`r`n")
+    [void]$builder.Append("CSeq: $CSeq`r`n")
+    [void]$builder.Append("User-Agent: Deck camera transport proof`r`n")
+    foreach ($entry in $Headers.GetEnumerator()) {
+        [void]$builder.Append("$($entry.Key): $($entry.Value)`r`n")
+    }
+    [void]$builder.Append("`r`n")
+    $requestBytes = [Text.Encoding]::ASCII.GetBytes($builder.ToString())
+    try {
+        $Stream.Write($requestBytes, 0, $requestBytes.Length)
+        $Stream.Flush()
+        return Read-RtspResponse -Stream $Stream
+    }
+    finally {
+        [Array]::Clear($requestBytes, 0, $requestBytes.Length)
+        $builder.Clear() | Out-Null
+    }
+}
+
+function New-RtspDigestState {
+    param([Parameter(Mandatory)][string]$Challenge)
+
+    if ($Challenge -notmatch '^Digest\s+') { throw 'RTSP did not require Digest authentication.' }
+    $values = @{}
+    foreach ($match in [regex]::Matches($Challenge.Substring(7), '(?<key>[A-Za-z]+)=(?:"(?<quoted>[^"]*)"|(?<token>[^,\s]+))')) {
+        $value = if ($match.Groups['quoted'].Success) { $match.Groups['quoted'].Value } else { $match.Groups['token'].Value }
+        $values[$match.Groups['key'].Value] = $value
+    }
+    if (-not $values['realm'] -or -not $values['nonce']) { throw 'RTSP Digest challenge was incomplete.' }
+    if ($values['algorithm'] -and $values['algorithm'] -ne 'MD5') { throw 'RTSP Digest algorithm is unsupported.' }
+    if ($values['qop'] -and ($values['qop'] -split ',' | ForEach-Object Trim) -notcontains 'auth') {
+        throw 'RTSP Digest challenge did not offer qop=auth.'
+    }
+
+    [pscustomobject]@{
+        Realm = $values['realm']
+        Nonce = $values['nonce']
+        Opaque = $values['opaque']
+        Qop = if ($values['qop']) { 'auth' } else { $null }
+        NextNonceCount = 1
+    }
+}
+
+function New-RtspAuthorization {
+    param(
+        [Parameter(Mandatory)]$Digest,
+        [Parameter(Mandatory)][string]$Username,
+        [Parameter(Mandatory)][string]$Password,
+        [Parameter(Mandatory)][string]$Method,
+        [Parameter(Mandatory)][Uri]$Uri
+    )
+
+    $nonceCount = $Digest.NextNonceCount.ToString('x8')
+    $Digest.NextNonceCount++
+    $cnonceBytes = [byte[]]::new(12)
+    [Security.Cryptography.RandomNumberGenerator]::Fill($cnonceBytes)
+    try {
+        $cnonce = [Convert]::ToHexString($cnonceBytes).ToLowerInvariant()
+        $digestUri = $Uri.AbsoluteUri
+        $ha1 = Get-Md5Hex "$Username`:$($Digest.Realm)`:$Password"
+        $ha2 = Get-Md5Hex "$Method`:$digestUri"
+        $response = if ($Digest.Qop) {
+            Get-Md5Hex "$ha1`:$($Digest.Nonce)`:$nonceCount`:$cnonce`:auth`:$ha2"
+        }
+        else {
+            Get-Md5Hex "$ha1`:$($Digest.Nonce)`:$ha2"
+        }
+
+        $parts = @(
+            "username=`"$Username`"",
+            "realm=`"$($Digest.Realm)`"",
+            "nonce=`"$($Digest.Nonce)`"",
+            "uri=`"$digestUri`"",
+            "response=`"$response`"",
+            'algorithm=MD5'
+        )
+        if ($Digest.Qop) { $parts += "qop=auth, nc=$nonceCount, cnonce=`"$cnonce`"" }
+        if ($Digest.Opaque) { $parts += "opaque=`"$($Digest.Opaque)`"" }
+        return 'Digest ' + ($parts -join ', ')
+    }
+    finally {
+        [Array]::Clear($cnonceBytes, 0, $cnonceBytes.Length)
+    }
+}
+
+function Get-H264ControlUri {
+    param(
+        [Parameter(Mandatory)][string]$Sdp,
+        [Parameter(Mandatory)][Uri]$BaseUri
+    )
+
+    if ($Sdp -notmatch '(?im)^a=rtpmap:\d+\s+H264/90000') { throw 'RTSP SDP did not advertise H.264 video.' }
+    $inVideo = $false
+    $control = $null
+    foreach ($line in $Sdp -split "`r?`n") {
+        if ($line -match '^m=') { $inVideo = $line -match '^m=video\s' }
+        elseif ($inVideo -and $line -match '^a=control:(.+)$') { $control = $Matches[1].Trim(); break }
+    }
+    if (-not $control) { throw 'RTSP SDP did not provide a video control address.' }
+    if ($control -match '^rtsp://') { return [Uri]::new($control) }
+    return [Uri]::new($BaseUri, $control)
+}
+
+function Test-RtspTransportOnce {
+    param(
+        [Parameter(Mandatory)][Uri]$Uri,
+        [Parameter(Mandatory)][string]$Username,
+        [Parameter(Mandatory)][string]$Password,
+        [Parameter(Mandatory)][int]$Attempt,
+        [Parameter(Mandatory)][int]$TimeoutMilliseconds
+    )
+
+    $client = [Net.Sockets.TcpClient]::new()
+    $stream = $null
+    $sessionId = $null
+    try {
+        if (-not $client.ConnectAsync($Uri.DnsSafeHost, $Uri.Port).Wait($TimeoutMilliseconds) -or -not $client.Connected) {
+            throw 'RTSP TCP connection timed out.'
+        }
+        $stream = $client.GetStream()
+        $stream.ReadTimeout = $TimeoutMilliseconds
+        $stream.WriteTimeout = $TimeoutMilliseconds
+
+        $unauthenticated = Send-RtspRequest -Stream $stream -Method 'DESCRIBE' -Uri $Uri -CSeq 1 -Headers @{ Accept = 'application/sdp' }
+        if ($unauthenticated.StatusCode -eq 200) { throw 'RTSP accepted an unauthenticated request; stop and isolate the camera.' }
+        if ($unauthenticated.StatusCode -ne 401 -or -not $unauthenticated.Headers['WWW-Authenticate']) {
+            throw "RTSP authentication challenge failed with status $($unauthenticated.StatusCode)."
+        }
+        $digest = New-RtspDigestState $unauthenticated.Headers['WWW-Authenticate']
+
+        $describeAuth = New-RtspAuthorization -Digest $digest -Username $Username -Password $Password -Method 'DESCRIBE' -Uri $Uri
+        $described = Send-RtspRequest -Stream $stream -Method 'DESCRIBE' -Uri $Uri -CSeq 2 -Headers @{ Accept = 'application/sdp'; Authorization = $describeAuth }
+        if ($described.StatusCode -ne 200) { throw "Authenticated RTSP DESCRIBE failed with status $($described.StatusCode)." }
+        $baseUri = if ($described.Headers['Content-Base']) { [Uri]::new($described.Headers['Content-Base']) } else { $Uri }
+        if ($baseUri.DnsSafeHost -ne $Uri.DnsSafeHost) { throw 'RTSP returned a control address for a different host.' }
+        $controlUri = Get-H264ControlUri -Sdp $described.Body -BaseUri $baseUri
+        if ($controlUri.DnsSafeHost -ne $Uri.DnsSafeHost) { throw 'RTSP returned a video address for a different host.' }
+
+        $setupAuth = New-RtspAuthorization -Digest $digest -Username $Username -Password $Password -Method 'SETUP' -Uri $controlUri
+        $setup = Send-RtspRequest -Stream $stream -Method 'SETUP' -Uri $controlUri -CSeq 3 -Headers @{
+            Authorization = $setupAuth
+            Transport = 'RTP/AVP/TCP;unicast;interleaved=0-1'
+        }
+        if ($setup.StatusCode -ne 200 -or -not $setup.Headers['Session']) { throw "RTSP video SETUP failed with status $($setup.StatusCode)." }
+        $sessionId = ($setup.Headers['Session'] -split ';')[0].Trim()
+
+        $playAuth = New-RtspAuthorization -Digest $digest -Username $Username -Password $Password -Method 'PLAY' -Uri $Uri
+        $played = Send-RtspRequest -Stream $stream -Method 'PLAY' -Uri $Uri -CSeq 4 -Headers @{ Authorization = $playAuth; Session = $sessionId }
+        if ($played.StatusCode -ne 200) { throw "RTSP PLAY failed with status $($played.StatusCode)." }
+
+        for ($packet = 0; $packet -lt 30; $packet++) {
+            $marker = $stream.ReadByte()
+            if ($marker -ne 0x24) { throw 'RTSP interleaved stream returned an unexpected frame marker.' }
+            $channel = $stream.ReadByte()
+            $lengthBytes = Read-ExactBytes -Stream $stream -Length 2
+            $length = ([int]$lengthBytes[0] -shl 8) -bor [int]$lengthBytes[1]
+            $payload = Read-ExactBytes -Stream $stream -Length $length
+            try {
+                if ($channel -eq 0 -and $payload.Length -gt 12 -and (($payload[0] -shr 6) -eq 2)) {
+                    return [pscustomobject]@{
+                        Attempt = $Attempt
+                        Authenticated = $true
+                        Transport = 'rtsp_tcp'
+                        Encoding = 'h264'
+                        AudioSetUp = $false
+                        RtpPacketBytes = $payload.Length
+                        TeardownRequested = $true
+                    }
+                }
+            }
+            finally {
+                [Array]::Clear($lengthBytes, 0, $lengthBytes.Length)
+                [Array]::Clear($payload, 0, $payload.Length)
+            }
+        }
+        throw 'No interleaved H.264 RTP packet arrived within the bounded read.'
+    }
+    finally {
+        if ($null -ne $stream -and $sessionId) {
+            try {
+                $teardownAuth = New-RtspAuthorization -Digest $digest -Username $Username -Password $Password -Method 'TEARDOWN' -Uri $Uri
+                $null = Send-RtspRequest -Stream $stream -Method 'TEARDOWN' -Uri $Uri -CSeq 5 -Headers @{ Authorization = $teardownAuth; Session = $sessionId }
+            } catch { }
+        }
+        if ($null -ne $stream) { $stream.Dispose() }
+        $client.Dispose()
+    }
+}
+
+function Invoke-DeckRtspProbe {
+    param(
+        [Parameter(Mandatory)][string]$Executable,
+        [Parameter(Mandatory)][Uri]$Uri,
+        [Parameter(Mandatory)][string]$Username,
+        [Parameter(Mandatory)][string]$Password,
+        [Parameter(Mandatory)][int]$TimeoutMilliseconds
+    )
+
+    $resolvedExecutable = (Resolve-Path -LiteralPath $Executable -ErrorAction Stop).Path
+    if ([IO.Path]::GetExtension($resolvedExecutable) -ne '.exe') {
+        throw 'The Deck RTSP probe path must identify an executable.'
+    }
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $resolvedExecutable
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    $payload = $null
+    try {
+        if (-not $process.Start()) { throw 'Deck RTSP probe could not start.' }
+        $payload = @{
+            url = $Uri.AbsoluteUri
+            username = $Username
+            password = $Password
+        } | ConvertTo-Json -Compress
+        $process.StandardInput.WriteLine($payload)
+        $process.StandardInput.Close()
+
+        if (-not $process.WaitForExit($TimeoutMilliseconds)) {
+            $process.Kill($true)
+            throw 'Deck RTSP probe exceeded its bounded runtime.'
+        }
+        $stdout = $process.StandardOutput.ReadToEnd()
+        $stderr = $process.StandardError.ReadToEnd()
+        if ($process.ExitCode -ne 0) {
+            $safeFailure = if ($stderr -match 'camera_rtsp_probe failed safely: ([a-z0-9_]+)') { $Matches[1] } else { 'unknown_failure' }
+            throw "Deck RTSP probe failed safely: $safeFailure"
+        }
+        return $stdout | ConvertFrom-Json
+    }
+    finally {
+        $payload = $null
+        $process.Dispose()
+    }
+}
+
+function Invoke-DeckCredentialProvision {
+    param(
+        [Parameter(Mandatory)][string]$Executable,
+        [Parameter(Mandatory)][Uri]$Uri,
+        [Parameter(Mandatory)][string]$Username,
+        [Parameter(Mandatory)][string]$Password
+    )
+
+    $resolvedExecutable = (Resolve-Path -LiteralPath $Executable -ErrorAction Stop).Path
+    if ([IO.Path]::GetExtension($resolvedExecutable) -ne '.exe') {
+        throw 'The Deck credential provision path must identify an executable.'
+    }
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $resolvedExecutable
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    $payload = $null
+    try {
+        if (-not $process.Start()) { throw 'Deck credential provision could not start.' }
+        $payload = @{
+            credential_ref = 'front-yard'
+            url = $Uri.AbsoluteUri
+            username = $Username
+            password = $Password
+        } | ConvertTo-Json -Compress
+        $process.StandardInput.WriteLine($payload)
+        $process.StandardInput.Close()
+
+        if (-not $process.WaitForExit(10000)) {
+            $process.Kill($true)
+            throw 'Deck credential provision exceeded its bounded runtime.'
+        }
+        $stdout = $process.StandardOutput.ReadToEnd()
+        $stderr = $process.StandardError.ReadToEnd()
+        if ($process.ExitCode -ne 0) {
+            $safeFailure = if ($stderr -match 'camera_credential_provision failed safely: ([a-z0-9_]+)') { $Matches[1] } else { 'unknown_failure' }
+            throw "Deck credential provision failed safely: $safeFailure"
+        }
+        if ($stdout.Trim() -ne 'camera credential stored safely') {
+            throw 'Deck credential provision returned an unexpected response.'
+        }
+        Write-Host 'Deck camera credential stored in the operating-system credential manager.' -ForegroundColor Green
+    }
+    finally {
+        $payload = $null
+        $process.Dispose()
+    }
+}
+
+$ipSecret = Read-Host 'Camera IP (kept local)' -AsSecureString
+$usernameSecret = Read-Host 'Camera local username (kept local)' -AsSecureString
+$passwordSecret = Read-Host 'Camera local password (kept local)' -AsSecureString
+
+$cameraIp = $null
+$username = $null
+$password = $null
+$handler = $null
+$client = $null
+
+try {
+    $cameraIp = ConvertTo-TemporaryPlainText $ipSecret
+    $username = ConvertTo-TemporaryPlainText $usernameSecret
+    $password = ConvertTo-TemporaryPlainText $passwordSecret
+
+    $parsedAddress = $null
+    if (-not [Net.IPAddress]::TryParse($cameraIp, [ref]$parsedAddress)) {
+        throw 'Camera IP was not a valid IPv4 or IPv6 address.'
+    }
+    if (-not $parsedAddress.IsIPv4MappedToIPv6 -and $parsedAddress.AddressFamily -ne [Net.Sockets.AddressFamily]::InterNetwork) {
+        throw 'This pilot probe currently accepts a private IPv4 camera address only.'
+    }
+
+    $deviceEndpoint = [Uri]::new("http://${cameraIp}:$OnvifPort/onvif/device_service")
+    $handler = [Net.Http.HttpClientHandler]::new()
+    $handler.Credentials = [Net.NetworkCredential]::new($username, $password)
+    $handler.PreAuthenticate = $false
+    $client = [Net.Http.HttpClient]::new($handler)
+    $client.Timeout = [TimeSpan]::FromSeconds($TimeoutSeconds)
+
+    $capabilities = Invoke-OnvifRequest -Client $client -Endpoint $deviceEndpoint `
+        -Action 'http://www.onvif.org/ver10/device/wsdl/GetCapabilities' `
+        -Username $username -Password $password `
+        -Body '<tds:GetCapabilities><tds:Category>All</tds:Category></tds:GetCapabilities>'
+
+    $mediaAddressNode = $capabilities.SelectSingleNode(
+        "//*[local-name()='Capabilities']/*[local-name()='Media']/*[local-name()='XAddr']"
+    )
+    if ($null -eq $mediaAddressNode) {
+        throw 'ONVIF responded, but did not advertise a Media service.'
+    }
+
+    $mediaEndpoint = [Uri]::new($mediaAddressNode.InnerText)
+    Assert-LocalServiceUri -Uri $mediaEndpoint -ExpectedHost $deviceEndpoint.DnsSafeHost
+
+    $profilesResponse = Invoke-OnvifRequest -Client $client -Endpoint $mediaEndpoint `
+        -Action 'http://www.onvif.org/ver10/media/wsdl/GetProfiles' `
+        -Username $username -Password $password -Body '<trt:GetProfiles />'
+    $profileNodes = @($profilesResponse.SelectNodes("//*[local-name()='GetProfilesResponse']/*[local-name()='Profiles']"))
+    if ($profileNodes.Count -eq 0) {
+        throw 'The ONVIF Media service returned no profiles.'
+    }
+
+    $results = foreach ($profile in $profileNodes) {
+        $token = $profile.Attributes['token'].Value
+        $escapedToken = [Security.SecurityElement]::Escape($token)
+        $streamResponse = Invoke-OnvifRequest -Client $client -Endpoint $mediaEndpoint `
+            -Action 'http://www.onvif.org/ver10/media/wsdl/GetStreamUri' `
+            -Username $username -Password $password `
+            -Body "<trt:GetStreamUri><trt:StreamSetup><tt:Stream>RTP-Unicast</tt:Stream><tt:Transport><tt:Protocol>RTSP</tt:Protocol></tt:Transport></trt:StreamSetup><trt:ProfileToken>$escapedToken</trt:ProfileToken></trt:GetStreamUri>"
+
+        $streamUriNode = $streamResponse.SelectSingleNode("//*[local-name()='MediaUri']/*[local-name()='Uri']")
+        $streamUri = if ($null -ne $streamUriNode) { [Uri]::new($streamUriNode.InnerText) } else { $null }
+        $video = $profile.SelectSingleNode("./*[local-name()='VideoEncoderConfiguration']")
+        $audio = $profile.SelectSingleNode("./*[local-name()='AudioEncoderConfiguration']")
+        $width = if ($null -ne $video) { Get-NodeText -Node $video -LocalName 'Width' } else { $null }
+        $height = if ($null -ne $video) { Get-NodeText -Node $video -LocalName 'Height' } else { $null }
+
+        [pscustomobject]@{
+            Profile          = "profile-$((Get-ShortHash $token).Substring(0, 6))"
+            Encoding         = if ($null -ne $video) { Get-NodeText -Node $video -LocalName 'Encoding' } else { $null }
+            Resolution       = if ($width -and $height) { "${width}x${height}" } else { $null }
+            FrameRateLimit   = if ($null -ne $video) { Get-NodeText -Node $video -LocalName 'FrameRateLimit' } else { $null }
+            BitrateLimitKbps = if ($null -ne $video) { Get-NodeText -Node $video -LocalName 'BitrateLimit' } else { $null }
+            AudioAdvertised  = $null -ne $audio
+            RtspAdvertised   = $null -ne $streamUri -and $streamUri.Scheme -eq 'rtsp'
+            EmbeddedSecret   = $null -ne $streamUri -and -not [string]::IsNullOrEmpty($streamUri.UserInfo)
+            RtspUri           = $streamUri
+        }
+    }
+
+    Write-Host 'ONVIF authenticated successfully. Redacted profile report:' -ForegroundColor Green
+    $results | Format-Table Profile, Encoding, Resolution, FrameRateLimit, BitrateLimitKbps, AudioAdvertised, RtspAdvertised, EmbeddedSecret -AutoSize
+
+    $candidate = $results |
+        Where-Object { $_.RtspAdvertised -and $_.Encoding -eq 'H264' } |
+        Sort-Object @{ Expression = {
+            if ($_.Resolution -match '^(\d+)x(\d+)$') { [int]$Matches[1] * [int]$Matches[2] } else { 0 }
+        }; Descending = $true } |
+        Select-Object -First 1
+
+    if ($null -ne $candidate) {
+        Write-Host "Candidate selected for playback proof: $($candidate.Profile) ($($candidate.Encoding), $($candidate.Resolution))." -ForegroundColor Green
+        if ($RtspProbeExecutable) {
+            Write-Host 'Running two bounded Deck-owned RTSP/TCP frame proofs (initial + reconnect)...' -ForegroundColor Cyan
+            $proofs = 1..2 | ForEach-Object {
+                $proof = Invoke-DeckRtspProbe -Executable $RtspProbeExecutable -Uri $candidate.RtspUri `
+                    -Username $username -Password $password -TimeoutMilliseconds (($TimeoutSeconds + 12) * 1000)
+                [pscustomobject]@{
+                    Attempt = $_
+                    Authenticated = $proof.authenticated
+                    Transport = $proof.transport
+                    Encoding = $proof.encoding
+                    AudioSetUp = $proof.audioSetUp
+                    FirstFrameBytes = $proof.firstFrameBytes
+                    RandomAccessFrame = $proof.randomAccessFrame
+                    RtpPacketLoss = $proof.rtpPacketLossBeforeFrame
+                    TeardownCompleted = $proof.teardownCompleted
+                }
+            }
+            $proofs | Format-Table -AutoSize
+            if ($CredentialProvisionExecutable) {
+                Invoke-DeckCredentialProvision -Executable $CredentialProvisionExecutable `
+                    -Uri $candidate.RtspUri -Username $username -Password $password
+            }
+        }
+        else {
+            Write-Warning 'RTSP frame proof skipped because -RtspProbeExecutable was not supplied.'
+        }
+    }
+    else {
+        Write-Warning 'No H.264 RTSP profile was advertised. Do not guess a stream URL.'
+    }
+}
+catch {
+    Write-Error "Camera probe failed safely: $($_.Exception.Message)"
+    exit 1
+}
+finally {
+    if ($null -ne $client) { $client.Dispose() }
+    if ($null -ne $handler) { $handler.Dispose() }
+    $cameraIp = $null
+    $username = $null
+    $password = $null
+    Remove-Variable ipSecret, usernameSecret, passwordSecret -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
Documents and proves the completed first two front-yard camera slices.\n\n- Adds the bounded operator onboarding/recovery runbook.\n- Adds a redacted local ONVIF/RTSP probe that takes secrets only through secure prompts and passes them over stdin.\n- Records the selected stream, bounded transport/reconnect proof, OS credential-manager provisioning, and manual Deck privacy/restart acceptance in the PRD.\n\nValidation: PowerShell parser validation and diff hygiene; the underlying Deck implementation was separately built and accepted against the real local camera.