### PR TITLE
ci: add concurrency groups to cancel superseded PR runs

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/deploy-functions.yml"
   workflow_dispatch:
 
+concurrency:
+  group: deploy-functions-${{ github.ref }}
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -26,6 +26,9 @@ on:
       - "scripts/verify-deployment-build.mjs"
       - ".github/workflows/deploy-on-merge.yml"
 
+concurrency:
+  group: deploy-on-merge-${{ github.ref }}
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: deploy-${{ github.ref }}
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/deployment-checklist.yml
+++ b/.github/workflows/deployment-checklist.yml
@@ -13,6 +13,10 @@ on:
     # Run daily at 6am UTC to catch infrastructure drift
     - cron: "0 6 * * *"
 
+concurrency:
+  group: deployment-checklist-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -16,6 +16,9 @@ on:
         required: true
         default: ""
 
+concurrency:
+  group: hov-terraform-production-state
+
 permissions:
   contents: write
 

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -7,6 +7,9 @@ on:
         description: "Type DESTROY to confirm"
         required: true
 
+concurrency:
+  group: hov-terraform-production-state
+
 env:
   WORKING_DIR: "./terraform/environments/production"
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -8,6 +8,9 @@ on:
       - "terraform/**"
       - ".github/workflows/terraform-plan.yml"
 
+concurrency:
+  group: terraform-plan-${{ github.event.pull_request.number || github.ref }}
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Superseded runs currently burn to completion instead of cancelling. This repo billed **1,502 Actions minutes ($9.01)** 1–12 Aug 2026.

## Why

Measured in `phoenixvc/mystira-workspace` over the same period:

| Workflow | concurrency | Supersessions | Outcome |
|---|---|---|---|
| `[CI] Validate PR` | none | 72 | ran to completion — **856 wasted wall-minutes**, zero cancelled |
| `[CI] Identity Product` | `cancel-in-progress: true` | 38 | cancelled within ~1 min each — **36 min total** |

Reference implementation: phoenixvc/mystira-workspace#3739.

## The one that matters: `deployment-checklist.yml`

It is the largest consumer here (**488 wall-minutes**) and runs on `push` **and** `pull_request` **and** a daily 06:00 schedule — 100+ runs in the 12-day window. It gets `cancel-in-progress` on `pull_request`.

Despite the name, **it does not deploy**. Verified before gating it:

- `permissions:` is `contents: read` (plus `pull-requests`/`issues: write` for posting the report comment)
- it installs `hashicorp/setup-terraform` but **never invokes `terraform`** — no `init`, `plan`, or `apply` anywhere in the file
- the only `az` mutation-shaped command is `az account set --subscription`, which selects a subscription in the local CLI context
- `config/scripts/deployment-checklist.py` reads Azure state through a **single** `subprocess.run` site; its `fix_command=` strings are remediation text printed into the report and are **never executed**

## Group only, NO `cancel-in-progress`

Everything that can mutate infrastructure serialises instead:

| Workflow | Group | Why |
|---|---|---|
| `deploy.yml`, `deploy-functions.yml`, `deploy-on-merge.yml` | per-`github.ref` | Interrupting a deploy can leave it half-applied |
| `terraform-apply.yml`, `terraform-destroy.yml` | **shared** `hov-terraform-production-state` | Both target `terraform/environments/production`. A shared fixed group also stops an apply and a destroy racing the same state — a hazard that exists today |
| `terraform-plan.yml` | per-PR | See below |

### Why `terraform-plan.yml` serialises rather than cancels

It runs `terraform plan` **without `-lock=false`** against the `azurerm` backend, so it takes a blob lease. Cancelling mid-plan can strand the lock and require a `force-unlock` on production state.

The cost of not cancelling it is measured, not assumed — **11 runs in the 12-day window, ~80–105 s each, ≈16 minutes total (~1% of the repo).** Tightest consecutive pair on a single branch: previous run finished 13:39:48, next started 13:57:45. **Zero supersessions.** Cancelling it would save approximately nothing, so the lock risk buys nothing.

Note the group is per-PR, so plans on *different* PRs can still run concurrently and contend for the lease at the Terraform level — unchanged pre-existing behaviour. If that contention ever bites, the fix is a shared group tied to the state, not `-lock=false`.

## Safety checks

- **No merge queue.** No `merge_group` triggers; the active `Main Protection` ruleset contains only `deletion` and `pull_request` rules — no merge-queue rule. Gating cannot stall a queue.
- **`actionlint` 1.7.12**: identical findings before and after.
- All 7 files re-parsed post-edit to confirm triggers and `jobs` survived intact.

Config-only; no job logic, runner, or step changed.